### PR TITLE
docs: add repo AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - When changing scope or acceptance criteria, also review `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/issues/PHASE1_ISSUES.md`.
 
 ## Known commands
-- Validate OpenSpec changes with `openspec validate`.
+- Validate OpenSpec changes with `openspec validate --all`.
 
 ## Repo layout
 - `openspec/changes/agent-dispatch-platform/`: proposal, design, tasks, and capability specs for the MVP.


### PR DESCRIPTION
## What\n- add a root AGENTS.md for this repo\n- document the OpenSpec-first workflow used in this workspace\n- note the verified command `openspec validate`\n- leave a TODO for build/lint/test commands that are not defined yet\n\n## Why\n- give future agents a minimal, repo-grounded guide without inventing unsupported commands\n\n## Testing\n- not run (documentation-only change)