### PR TITLE
docs: establish P0 contribution and tech stack baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to agent-indeed
+
+Thanks for contributing. This repository is currently API/spec-first, so most changes should start from specification and contract alignment before runtime implementation.
+
+## Ground Rules
+
+- Follow OpenSpec-first workflow for product changes.
+- Keep API draft in sync across:
+  - `src/api/openapi.yaml`
+  - `src/api/contracts.ts`
+  - `openspec/changes/agent-dispatch-platform/`
+- If scope or acceptance criteria changes, also review:
+  - `docs/PHASE1_GOALS.md`
+  - `docs/ROADMAP.md`
+  - `docs/issues/PHASE1_ISSUES.md`
+
+## Branch and PR Flow
+
+1. Create a branch using `codex/<topic>` prefix.
+2. Update OpenSpec artifacts first (or in the same PR as implementation).
+3. Update API contracts and docs in the same change set.
+4. Run validation:
+   - `openspec validate --all`
+5. Open a PR with linked issue(s), scope notes, and verification output.
+
+## Commit and Change Scope
+
+- Keep commits focused to one logical change.
+- Avoid mixing unrelated docs/spec/API changes in one PR.
+- Prefer small, reviewable diffs with explicit acceptance criteria.
+
+## Pull Request Checklist
+
+Before requesting review, ensure:
+
+- [ ] OpenSpec artifacts are updated for behavior/scope changes.
+- [ ] `openapi.yaml` and `contracts.ts` remain aligned.
+- [ ] Roadmap/goals/issues docs are updated when planning scope changes.
+- [ ] `openspec validate --all` passes locally.
+- [ ] Related issue links are added in the PR description.
+
+## Current Tooling Notes
+
+- No repo-local build/lint/test command is defined yet.
+- Until runtime modules are added, use OpenSpec validation and contract/doc consistency as the minimum quality gate.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # agent-indeed
 
 Agent dispatch platform prototype.
+
+## Project docs
+
+- Contribution workflow: `CONTRIBUTING.md`
+- Tech stack baseline: `docs/TECH_STACK.md`
+- MVP roadmap: `docs/ROADMAP.md`

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -2,6 +2,8 @@
 
 Timebox: 2026-03-13 to 2026-04-30
 
+Prerequisite: P0 repository-readiness items (contribution workflow + tech stack baseline documentation) are tracked and actively prioritized.
+
 ## Objective
 
 Ship the first usable agent dispatch loop for closed beta:
@@ -61,3 +63,4 @@ Ship the first usable agent dispatch loop for closed beta:
 - API draft and TypeScript contracts are consistent for `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`.
 - End-to-end happy path + key negative paths are covered by automated tests.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
+- P0 baseline issues that block collaboration quality are closed or explicitly waived.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,8 +12,23 @@ Build a trustworthy agent dispatch network where managers can publish tasks, age
 - Keep policy configurable by identity tier (T0/T1/T2), not hard-coded by one model.
 - Prefer auditability and abuse resistance over feature breadth in early stages.
 - Keep API-first implementation aligned with OpenSpec artifacts.
+- Resolve repository readiness blockers (P0) before broad Phase 1 implementation.
 
 ## Phase Plan
+
+### Phase 0: Engineering Readiness (Target: 2026-03)
+
+Goal: remove process and baseline documentation blockers before scaling implementation work.
+
+Scope:
+- Contribution workflow baseline (`CONTRIBUTING.md`) aligned with OpenSpec-first practice.
+- Tech stack baseline inventory (`docs/TECH_STACK.md`) with known gaps and decision boundaries.
+- P0 issue tracking wired to planning docs for execution visibility.
+
+Exit criteria:
+- Contribution guidelines are published and reviewable.
+- Tech stack baseline is documented and linked by backlog issue(s).
+- P0 issues are tracked and prioritized ahead of new Phase 1 coding tasks.
 
 ### Phase 1: Marketplace Foundation (Target: 2026-03 to 2026-04)
 
@@ -53,6 +68,7 @@ Scope:
 
 ## Milestones (Phase 1)
 
+- M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M1 (Week 1): finalize contracts + upload pipeline design.
 - M2 (Week 2): task/matching + bidding API baseline.
 - M3 (Week 3): PoMW policy + verifier baseline.

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -1,0 +1,39 @@
+# Agent Indeed Tech Stack Baseline
+
+Last updated: 2026-03-13
+
+## Repository Maturity Snapshot
+
+Current repository focus is specification and API contract design. Runtime service modules, build pipelines, and automated test suites are not introduced yet.
+
+## Stack Inventory
+
+| Layer | Current Choice | Where It Lives | Notes |
+| --- | --- | --- | --- |
+| Product/API specification | OpenSpec + Markdown | `openspec/changes/agent-dispatch-platform/`, `docs/` | Canonical source for MVP scope and acceptance criteria. |
+| HTTP API contract | OpenAPI 3.1 (YAML) | `src/api/openapi.yaml` | Defines onboarding, task publish/match, bidding, and PoMW verification APIs. |
+| Typed domain contract | TypeScript interfaces | `src/api/contracts.ts` | Mirrors OpenAPI key objects: `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`. |
+| Collaboration workflow | Git + GitHub Issues + AGENTS guidance | `AGENTS.md`, `docs/issues/PHASE1_ISSUES.md` | Issue-driven planning with OpenSpec-first development expectation. |
+| Quality gate (current) | OpenSpec CLI validation | `openspec validate --all` | Only verified command currently documented in repo. |
+
+## API/Domain Model Stack (Current)
+
+- Identity model: `T0` / `T1` / `T2`
+- Core entities: `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`
+- Protocol patterns:
+  - Task lifecycle with auditable state transitions
+  - Commit-reveal bidding
+  - Policy-driven PoMW verification
+
+## Gaps To Fill In Next Iterations
+
+1. Runtime service framework and language/toolchain are not finalized.
+2. Storage/index technology choices (task/bid/audit/proof) are not finalized.
+3. CI quality gates (lint/unit/e2e/security) are not configured.
+4. Local developer commands (build/test/lint) are not standardized.
+
+## Decision Policy (Until Runtime Stack Is Introduced)
+
+- Any new runtime technology proposal should be linked to OpenSpec acceptance criteria.
+- Contract changes should land in `openapi.yaml` and `contracts.ts` together.
+- Planning docs (`PHASE1_GOALS`, `ROADMAP`, `PHASE1_ISSUES`) should be updated in the same PR when scope changes.

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -1,7 +1,10 @@
-# Phase 1 Issue Backlog
+# MVP Issue Backlog (P0 + P1)
 
 ## GitHub Tracking (created)
 
+- P0-00 #14 (closed): https://github.com/jckhang/agent-indeed/issues/14
+- P0-01 #15: https://github.com/jckhang/agent-indeed/issues/15
+- P0-02 #16: https://github.com/jckhang/agent-indeed/issues/16
 - Epic #2: https://github.com/jckhang/agent-indeed/issues/2
 - P1-01 #3: https://github.com/jckhang/agent-indeed/issues/3
 - P1-02 #4: https://github.com/jckhang/agent-indeed/issues/4
@@ -13,7 +16,46 @@
 - P1-08 #10: https://github.com/jckhang/agent-indeed/issues/10
 - P1-09 #11: https://github.com/jckhang/agent-indeed/issues/11
 
-## Epic
+## P0 Readiness
+
+### P0-00 Repository baseline unblockers
+
+Description:
+- Fix high-priority process/documentation gaps that can cause invalid changes to slip through review.
+- Establish a repeatable contribution workflow and stack baseline before scaling feature implementation.
+
+Acceptance criteria:
+- Repository guidance commands are executable and verified.
+- Contribution process documentation exists and is linked from issue tracking.
+- Tech stack baseline and current gaps are documented and linked from issue tracking.
+
+## P0 Delivery Issues
+
+### P0-01 Publish contribution workflow baseline (`CONTRIBUTING.md`)
+
+References:
+- `CONTRIBUTING.md`
+- `AGENTS.md`
+- `docs/ROADMAP.md`
+
+Acceptance criteria:
+- Branching, OpenSpec-first flow, validation command, and PR checklist are documented.
+- Guidelines explicitly require contract sync for `openapi.yaml` and `contracts.ts`.
+- Document is linked by a tracked GitHub issue.
+
+### P0-02 Publish repository tech stack baseline (`docs/TECH_STACK.md`)
+
+References:
+- `docs/TECH_STACK.md`
+- `src/api/openapi.yaml`
+- `src/api/contracts.ts`
+
+Acceptance criteria:
+- Current stack choices are enumerated by layer and mapped to repository paths.
+- Unresolved technology decisions and quality-gate gaps are explicitly listed.
+- Document is linked by a tracked GitHub issue.
+
+## P1 Epic
 
 ### P1-00 MVP: Agent Dispatch Foundation
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -1,3 +1,8 @@
+## 0. P0 协作与工程基线
+
+- [x] 0.1 发布 `CONTRIBUTING.md`，明确 OpenSpec-first 协作流程与 PR 检查清单。
+- [x] 0.2 输出 `docs/TECH_STACK.md`，沉淀当前技术栈盘点与缺口清单，并关联 issue 跟踪。
+
 ## 1. OpenSpec 基础落地
 
 - [ ] 1.1 完成 proposal/design/specs/tasks 四类工件并通过 `openspec validate`。


### PR DESCRIPTION
## What changed
- add `CONTRIBUTING.md` as the canonical OpenSpec-first contribution workflow
- add `docs/TECH_STACK.md` to document current stack inventory and unresolved decisions
- update roadmap/goals/backlog docs to introduce explicit P0 readiness tracking
- update OpenSpec change tasks with P0 collaboration baseline items
- link README to the new contribution and tech stack docs

## Why
This addresses repository readiness blockers before scaling Phase 1 implementation, and makes process/tooling expectations explicit for contributors.

## Issue tracking
- closes #15
- closes #16
- references #14 (already closed)

## Validation
- `openspec validate --all`
