### PR TITLE
docs: publish CONTRIBUTING workflow baseline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@
   2. `git fetch origin`
   3. `git pull --ff-only origin main`
   4. `git switch -c codex/<issue-or-scope>` (or `git checkout -b codex/<issue-or-scope>`)
+- Before every push/PR update, run:
+  1. `git fetch origin`
+  2. `git rebase origin/main`
+  3. Resolve conflicts if any, then `git add <files>` and `git rebase --continue`
+  4. Re-run required validation commands
+  5. Push branch (`git push --force-with-lease` when history was rewritten by rebase)
 
 ## Known commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,16 @@ Thanks for contributing. This repository is currently API/spec-first, so most ch
    - `openspec validate --all`
 7. Open a PR with linked issue(s), scope notes, and verification output.
 
+## Push Sync Requirement (before every push)
+
+1. `git fetch origin`
+2. `git rebase origin/main`
+3. If conflicts appear, resolve and continue:
+   - `git add <files>`
+   - `git rebase --continue`
+4. Re-run required validation commands.
+5. Push updates (use `git push --force-with-lease` when rebase rewrites history).
+
 ## Commit and Change Scope
 
 - Keep commits focused to one logical change.
@@ -45,6 +55,7 @@ Before requesting review, ensure:
 - [ ] Work is on a dedicated `codex/<topic>` branch (not `main`).
 - [ ] `openspec validate --all` passes locally.
 - [ ] Related issue links are added in the PR description.
+- [ ] Review-thread replies are explicit and signed with `--<agent-name>`.
 
 ## Current Tooling Notes
 


### PR DESCRIPTION
## What changed
- added `CONTRIBUTING.md` as the canonical collaboration workflow document
- documented default branch flow (`main` -> fetch/pull -> new `codex/...` branch)
- documented OpenSpec-first process and strict sync rule for `src/api/openapi.yaml` + `src/api/contracts.ts` + related specs
- documented required validation gate: `openspec validate --all`
- added branch/PR checklist and review reply signature convention (`--<agent-name>`)
- linked P0 docs issues and added a P0-01 section in `docs/issues/PHASE1_ISSUES.md`

## Why
Implements #15 and makes contributor workflow executable from one canonical file.

## Validation
- `openspec validate --all`

Closes #15
