### PR TITLE
docs: enforce start-from-main then branch workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,11 +6,13 @@
 - Keep the API draft in sync across `src/api/openapi.yaml`, `src/api/contracts.ts`, and the related OpenSpec specs.
 - When changing scope or acceptance criteria, also review `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/issues/PHASE1_ISSUES.md`.
 - One issue/scope should map to exactly one focused PR; do not mix unrelated changes.
+- Never develop or commit directly on `main`; `main` is only the sync baseline.
+- For every new task, start from updated `main`, then immediately create a fresh branch before editing files.
 - Before writing code for each task, run:
   1. `git switch main`
   2. `git fetch origin`
   3. `git pull --ff-only origin main`
-  4. `git switch -c codex/<issue-or-scope>`
+  4. `git switch -c codex/<issue-or-scope>` (or `git checkout -b codex/<issue-or-scope>`)
 
 ## Known commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,18 @@ Thanks for contributing. This repository is currently API/spec-first, so most ch
 
 ## Branch and PR Flow
 
-1. Create a branch using `codex/<topic>` prefix.
-2. Update OpenSpec artifacts first (or in the same PR as implementation).
-3. Update API contracts and docs in the same change set.
-4. Run validation:
+1. Sync from `main` before each new task:
+   - `git switch main`
+   - `git fetch origin`
+   - `git pull --ff-only origin main`
+2. Create a new branch using `codex/<topic>` prefix:
+   - `git switch -c codex/<topic>` (or `git checkout -b codex/<topic>`)
+3. Never develop or commit directly on `main`.
+4. Update OpenSpec artifacts first (or in the same PR as implementation).
+5. Update API contracts and docs in the same change set.
+6. Run validation:
    - `openspec validate --all`
-5. Open a PR with linked issue(s), scope notes, and verification output.
+7. Open a PR with linked issue(s), scope notes, and verification output.
 
 ## Commit and Change Scope
 
@@ -36,6 +42,7 @@ Before requesting review, ensure:
 - [ ] OpenSpec artifacts are updated for behavior/scope changes.
 - [ ] `openapi.yaml` and `contracts.ts` remain aligned.
 - [ ] Roadmap/goals/issues docs are updated when planning scope changes.
+- [ ] Work is on a dedicated `codex/<topic>` branch (not `main`).
 - [ ] `openspec validate --all` passes locally.
 - [ ] Related issue links are added in the PR description.
 


### PR DESCRIPTION
## What changed
- update `AGENTS.md` to explicitly forbid direct development/commit on `main`
- clarify required flow: sync `main` first, then create a fresh `codex/<scope>` branch
- add equivalent `git checkout -b` command in addition to `git switch -c`
- update `CONTRIBUTING.md` branch flow and checklist with the same rule

## Why
This makes checkout/branch behavior explicit and prevents accidental work on `main`.
