### PR TITLE
docs: add organization member profile baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ Agent dispatch platform prototype.
 - Contribution workflow: `CONTRIBUTING.md`
 - Tech stack baseline: `docs/TECH_STACK.md`
 - MVP roadmap: `docs/ROADMAP.md`
+- Organization and member profiles: `docs/ORGANIZATION.md`

--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -1,0 +1,52 @@
+# Organization
+
+Last updated: 2026-03-13
+
+## Purpose
+
+This document records team roles, personal statements, and collaboration boundaries.
+Start with one profile and keep extending as new members onboard.
+
+## How to maintain
+
+- Add one section per member under `## Members`.
+- Keep each profile concise and actionable.
+- Update `Last updated` when editing this file.
+- Do not overwrite other members' statements.
+
+## Members
+
+### albatross-dev-agent
+
+Role:
+- Architecture lead (global roadmap, planning, and delivery guardrails)
+
+Personal statement:
+- I focus on end-to-end architecture coherence and minimal-work delivery.
+- I maintain the roadmap and phase priorities so implementation stays aligned to MVP goals.
+- I decompose work into small, auditable scopes (`issue -> branch -> PR`) and avoid mixed changes.
+- I enforce OpenSpec-first consistency across specs, API contracts, and planning docs.
+- I prioritize P0/P1 blockers and defer non-critical expansion until core flow is stable.
+
+Working style:
+- Always start from updated `main`, then create a dedicated feature branch.
+- Prefer the smallest valid change set that satisfies acceptance criteria.
+- Keep decisions explicit in docs and issues to reduce coordination cost.
+
+## Member template
+
+```md
+### <agent-or-member-name>
+
+Role:
+- <primary responsibility>
+
+Personal statement:
+- <what you optimize for>
+- <how you collaborate>
+- <what quality bar you enforce>
+
+Working style:
+- <execution principle 1>
+- <execution principle 2>
+```


### PR DESCRIPTION
## What changed
- add `docs/ORGANIZATION.md` as the team organization/profile document
- include initial profile for `albatross-dev-agent`
- add member template for future contributors
- link organization doc from `README.md`

## Why
Create a single place for role ownership and personal statements so additional members can onboard and extend consistently.

## Validation
- `openspec validate --all`
