### PR TITLE
docs: baseline architecture gaps, FE/BE tracks, and hiring plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,6 @@ Agent dispatch platform prototype.
 - Tech stack baseline: `docs/TECH_STACK.md`
 - MVP roadmap: `docs/ROADMAP.md`
 - Organization and member profiles: `docs/ORGANIZATION.md`
+- Architecture gap assessment: `docs/ARCHITECTURE_GAPS.md`
+- Frontend/backend delivery tracks: `docs/ENGINEERING_TRACKS_FE_BE.md`
+- HR hiring plan: `docs/HR_HIRING_PLAN.md`

--- a/docs/ARCHITECTURE_GAPS.md
+++ b/docs/ARCHITECTURE_GAPS.md
@@ -1,0 +1,46 @@
+# Architecture Gap Assessment
+
+Last updated: 2026-03-13
+
+## Goal
+
+Identify the smallest set of missing decisions that block delivery of the Phase 1 MVP loop:
+`upload -> match -> bid -> verify -> award`.
+
+## Current State Snapshot
+
+- Product and capability boundaries are defined in OpenSpec.
+- API object draft exists in `src/api/openapi.yaml` and `src/api/contracts.ts`.
+- Implementation architecture (frontend, backend, data, operations) is not yet baseline-documented.
+
+## Critical Gaps (P0/P1)
+
+| Priority | Gap | Why it blocks delivery | Minimal output needed |
+| --- | --- | --- | --- |
+| P0 | Backend service boundaries are undefined | Teams cannot split execution ownership safely | Service map + ownership for onboarding, matching, bidding, proof, audit modules |
+| P0 | Frontend MVP scope is undefined | No visible closed-beta flow for manager/agent roles | Page map + role journeys + endpoint wiring matrix |
+| P0 | Data and state transition model is incomplete | Commit-reveal and PoMW decisions can become inconsistent | Task/bid/proof/audit state machine + write model |
+| P1 | Error-code catalog and retry policy are incomplete | Integrations cannot handle failures deterministically | Stable error-code table + idempotency and retry rules |
+| P1 | Observability baseline is missing | Incidents cannot be diagnosed quickly in beta | Event schema + trace/log/metric baseline per flow stage |
+| P1 | Security and compliance baseline is missing | High-risk tasks lack policy guardrails | AuthN/AuthZ model + sensitive data handling checklist |
+
+## Frontend-Specific Gaps
+
+- No manager-side experience definition for task authoring and award visibility.
+- No agent-side workflow definition for bid commit/reveal and proof status feedback.
+- No contract for sync/async updates (polling, event stream, or both).
+- No UX-level error taxonomy for invalid commit/reveal/proof failure branches.
+
+## Backend-Specific Gaps
+
+- Missing module boundaries and data ownership (registry, marketplace, verifier, audit).
+- Missing write sequencing rules for commit/reveal windows and anti-race protections.
+- Missing formal definition of PoMW policy evaluation inputs and outputs.
+- Missing audit query model and storage retention baseline.
+
+## 2-Week Stabilization Targets
+
+1. Publish frontend and backend delivery tracks with milestone-level ownership.
+2. Freeze minimal data/state model required for P1-01 to P1-09 implementation.
+3. Produce staffing plan tied to the roadmap critical path.
+4. Track all outputs through dedicated issues linked from `docs/issues/PHASE1_ISSUES.md`.

--- a/docs/ENGINEERING_TRACKS_FE_BE.md
+++ b/docs/ENGINEERING_TRACKS_FE_BE.md
@@ -1,0 +1,104 @@
+# Frontend/Backend Delivery Tracks (MVP)
+
+Last updated: 2026-03-13
+
+## Objective
+
+Deliver a closed-beta usable MVP with the least coordination overhead:
+- one shared contract layer (`OpenSpec` + `OpenAPI` + `contracts.ts`)
+- two execution tracks (backend first, frontend close-follow)
+- explicit integration checkpoints each week
+
+## Execution Strategy
+
+- Backend defines reliable state and policy behavior first.
+- Frontend implements only the pages needed to prove end-to-end business value.
+- Integration happens at milestone boundaries, not after full feature completion.
+
+## Backend Track
+
+### B0. Contract Freeze (Week 0)
+
+Deliverables:
+- Finalize `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack` required fields for MVP.
+- Define error-code baseline for onboarding, commit, reveal, verify.
+- Define idempotency and retry rules.
+
+Exit criteria:
+- OpenAPI and TypeScript contracts are fully aligned.
+- Backend issue owners accept state transitions and payload contracts.
+
+### B1. Core Control-Plane APIs (Week 1-2)
+
+Deliverables:
+- Onboarding pipeline (signature/schema/indexing/version conflict).
+- Task create + candidate retrieval baseline.
+- Bid commit/reveal API behavior with window checks.
+
+Exit criteria:
+- API-level happy path works end-to-end without UI.
+- Negative paths return deterministic error codes.
+
+### B2. Trust and Audit Layer (Week 3-4)
+
+Deliverables:
+- PoMW policy engine (T0/T1/T2 baseline).
+- Proof verification result codes and reason mapping.
+- Audit events and award decision trace queryability.
+
+Exit criteria:
+- `publish -> commit -> reveal -> verify -> award` is auditable by task/bid id.
+
+## Frontend Track
+
+### F0. MVP Product Surface Definition (Week 0)
+
+Deliverables:
+- Persona map: manager, agent, operator.
+- Page map and navigation for MVP only.
+- API-to-UI field matrix.
+
+Exit criteria:
+- Every required API for MVP has at least one UI consumer.
+
+### F1. Manager Console Baseline (Week 1-2)
+
+Deliverables:
+- Task creation form (`TaskSpec`) with validation hints.
+- Candidate/ranking view with score breakdown.
+- Award decision summary panel.
+
+Exit criteria:
+- Manager can complete task publish and award flow from UI.
+
+### F2. Agent Bidding Console Baseline (Week 2-3)
+
+Deliverables:
+- Bid commit form and deadline feedback.
+- Reveal form with proof pack upload/entry.
+- Verification and bid status timeline.
+
+Exit criteria:
+- Agent can complete commit/reveal and view verification outcome.
+
+### F3. Audit Visibility Baseline (Week 4)
+
+Deliverables:
+- Task/bid audit event timeline view.
+- Failure reason rendering for proof/commit/reveal rejection.
+
+Exit criteria:
+- Non-engineering stakeholders can inspect award decisions without raw logs.
+
+## Integration Checkpoints
+
+- Checkpoint A (end of Week 1): B0 + F0 completed, contract review signed off.
+- Checkpoint B (end of Week 2): B1 + F1 integrated in staging.
+- Checkpoint C (end of Week 3): F2 integrated with B2 verify path.
+- Checkpoint D (end of Week 4): F3 + audit trace + E2E validation completed.
+
+## Out-of-Scope for This MVP
+
+- Rich design-system expansion.
+- Multi-tenant UI configuration.
+- Settlement and payment workflows.

--- a/docs/HR_HIRING_PLAN.md
+++ b/docs/HR_HIRING_PLAN.md
@@ -1,0 +1,92 @@
+# Hiring Plan for MVP Delivery
+
+Last updated: 2026-03-13
+
+## Hiring Objective
+
+Close delivery-critical role gaps so Phase 1 MVP can ship on schedule with minimal team friction.
+
+## Baseline Team Assumption
+
+- Current active role: architecture lead/coordinator
+- Missing execution capacity in frontend, backend integration, and quality operations
+
+## Role Gap Matrix
+
+| Priority | Role | Headcount | Why now | Hiring target |
+| --- | --- | --- | --- | --- |
+| P0 | Backend Engineer (API + Workflow) | 1 | Critical path for commit/reveal, PoMW, audit | Offer accepted within 2 weeks |
+| P0 | Frontend Engineer (MVP Console) | 1 | Required for manager/agent closed-beta usability | Offer accepted within 2 weeks |
+| P1 | QA/Automation Engineer | 1 | Needed for E2E reliability and release confidence | Start by Week 3 |
+| P1 | DevOps/SRE (part-time or shared) | 0.5-1 | Needed for observability/release baseline | Assign by Week 3 |
+
+## Role Profiles for HR
+
+### Backend Engineer (P0)
+
+Mission:
+- Own control-plane APIs and state transitions for onboarding, bidding, proof, and audit.
+
+Must-have:
+- API design and implementation experience (OpenAPI-first preferred).
+- Strong data modeling and idempotency/error-handling skills.
+- Experience with event/audit-oriented backend flows.
+
+30/60/90 expectations:
+- 30d: onboard and deliver one core API slice with tests.
+- 60d: own commit/reveal + proof verify integration path.
+- 90d: stabilize auditability and production-readiness checklist.
+
+### Frontend Engineer (P0)
+
+Mission:
+- Build manager/agent MVP consoles that map directly to backend contracts.
+
+Must-have:
+- Strong TypeScript frontend engineering.
+- Form/state management and API integration rigor.
+- Ability to implement validation/error UX for complex workflows.
+
+30/60/90 expectations:
+- 30d: task publish and candidate view baseline.
+- 60d: bid commit/reveal and proof status flow.
+- 90d: audit timeline and release hardening.
+
+### QA/Automation Engineer (P1)
+
+Mission:
+- Build and maintain E2E coverage for the full MVP lifecycle and key abuse paths.
+
+Must-have:
+- API and UI test automation experience.
+- Ability to design deterministic negative-path test suites.
+
+### DevOps/SRE (P1)
+
+Mission:
+- Establish baseline CI/CD, observability, and release safety gates.
+
+Must-have:
+- CI pipelines, logs/metrics/tracing setup, and incident response fundamentals.
+
+## Interview Loop Suggestion
+
+1. Recruiter screen (role fit + delivery pace expectations).
+2. Technical interview (API/state modeling for backend; workflow UI for frontend).
+3. Practical case (small scoped implementation or architecture exercise).
+4. Architecture lead interview (cross-team collaboration and MVP prioritization).
+5. Final culture and ownership alignment.
+
+## Candidate Evaluation Rubric (1-5)
+
+- Delivery ownership and speed
+- Architecture quality under MVP constraints
+- Contract-first collaboration ability
+- Debugging and production reliability mindset
+- Written communication and documentation clarity
+
+## Recruiting Artifacts for HR
+
+- Use this file as the source for JD drafts.
+- Convert each role profile into one public job post and one internal scorecard.
+- Link open role issues from `docs/issues/PHASE1_ISSUES.md` for status tracking.

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -2,7 +2,7 @@
 
 Timebox: 2026-03-13 to 2026-04-30
 
-Prerequisite: P0 repository-readiness items (contribution workflow + tech stack baseline documentation) are tracked and actively prioritized.
+Prerequisite: P0 repository-readiness items (contribution workflow, tech stack baseline, architecture gap assessment, FE/BE track plan, and staffing plan) are tracked and actively prioritized.
 
 ## Objective
 
@@ -64,3 +64,4 @@ Ship the first usable agent dispatch loop for closed beta:
 - End-to-end happy path + key negative paths are covered by automated tests.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - P0 baseline issues that block collaboration quality are closed or explicitly waived.
+- FE/BE execution ownership and MVP hiring-critical roles are assigned or explicitly risk-accepted.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,11 +24,14 @@ Scope:
 - Contribution workflow baseline (`CONTRIBUTING.md`) aligned with OpenSpec-first practice.
 - Tech stack baseline inventory (`docs/TECH_STACK.md`) with known gaps and decision boundaries.
 - P0 issue tracking wired to planning docs for execution visibility.
+- Architecture gap assessment and FE/BE delivery track baselines.
+- Hiring plan for MVP-critical execution roles.
 
 Exit criteria:
 - Contribution guidelines are published and reviewable.
 - Tech stack baseline is documented and linked by backlog issue(s).
 - P0 issues are tracked and prioritized ahead of new Phase 1 coding tasks.
+- FE/BE track milestones and staffing assumptions are documented and traceable in issues.
 
 ### Phase 1: Marketplace Foundation (Target: 2026-03 to 2026-04)
 
@@ -69,6 +72,7 @@ Scope:
 ## Milestones (Phase 1)
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
+- M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
 - M1 (Week 1): finalize contracts + upload pipeline design.
 - M2 (Week 2): task/matching + bidding API baseline.
 - M3 (Week 3): PoMW policy + verifier baseline.

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -5,6 +5,9 @@
 - P0-00 #14 (closed): https://github.com/jckhang/agent-indeed/issues/14
 - P0-01 #15: https://github.com/jckhang/agent-indeed/issues/15
 - P0-02 #16: https://github.com/jckhang/agent-indeed/issues/16
+- P0-03 #21: https://github.com/jckhang/agent-indeed/issues/21
+- P0-04 #22: https://github.com/jckhang/agent-indeed/issues/22
+- P0-05 #23: https://github.com/jckhang/agent-indeed/issues/23
 - Epic #2: https://github.com/jckhang/agent-indeed/issues/2
 - P1-01 #3: https://github.com/jckhang/agent-indeed/issues/3
 - P1-02 #4: https://github.com/jckhang/agent-indeed/issues/4
@@ -54,6 +57,41 @@ Acceptance criteria:
 - Current stack choices are enumerated by layer and mapped to repository paths.
 - Unresolved technology decisions and quality-gate gaps are explicitly listed.
 - Document is linked by a tracked GitHub issue.
+
+### P0-03 Publish architecture gap assessment (`docs/ARCHITECTURE_GAPS.md`)
+
+References:
+- `docs/ARCHITECTURE_GAPS.md`
+- `docs/TECH_STACK.md`
+- `docs/ROADMAP.md`
+
+Acceptance criteria:
+- Current delivery blockers are categorized by priority with concrete impact.
+- Frontend and backend gaps are explicitly separated.
+- Gap outputs map to next actionable issue scopes.
+
+### P0-04 Publish FE/BE execution tracks (`docs/ENGINEERING_TRACKS_FE_BE.md`)
+
+References:
+- `docs/ENGINEERING_TRACKS_FE_BE.md`
+- `docs/PHASE1_GOALS.md`
+- `src/api/openapi.yaml`
+
+Acceptance criteria:
+- Backend and frontend tracks each define milestones and exit criteria.
+- Integration checkpoints are explicit for weekly execution.
+- Scope remains MVP-focused and excludes non-critical expansion.
+
+### P0-05 Publish staffing and recruiting plan (`docs/HR_HIRING_PLAN.md`)
+
+References:
+- `docs/HR_HIRING_PLAN.md`
+- `docs/ROADMAP.md`
+
+Acceptance criteria:
+- Role gaps, priority, and target hiring window are defined.
+- Each core role includes mission, must-have skills, and 30/60/90 expectations.
+- Interview loop and evaluation rubric are documented for HR execution.
 
 ## P1 Epic
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -2,6 +2,9 @@
 
 - [x] 0.1 发布 `CONTRIBUTING.md`，明确 OpenSpec-first 协作流程与 PR 检查清单。
 - [x] 0.2 输出 `docs/TECH_STACK.md`，沉淀当前技术栈盘点与缺口清单，并关联 issue 跟踪。
+- [x] 0.3 输出 `docs/ARCHITECTURE_GAPS.md`，明确当前前后端与系统实现缺口。
+- [x] 0.4 输出 `docs/ENGINEERING_TRACKS_FE_BE.md`，定义前后端最小可交付路线。
+- [x] 0.5 输出 `docs/HR_HIRING_PLAN.md`，形成 MVP 人员缺口与招聘执行方案。
 
 ## 1. OpenSpec 基础落地
 


### PR DESCRIPTION
## What changed
- add architecture gap baseline in `docs/ARCHITECTURE_GAPS.md`
- add frontend/backend execution tracks in `docs/ENGINEERING_TRACKS_FE_BE.md`
- add HR recruiting baseline in `docs/HR_HIRING_PLAN.md`
- align roadmap/goals/OpenSpec tasks and issue backlog with these P0 outputs
- link new docs from `README.md`

## Why
This establishes architecture-level coordination and staffing readiness so Phase 1 delivery can proceed with minimal rework.

## Issue tracking
- closes #21
- closes #22
- closes #23

## Validation
- `openspec validate --all`
