### PR TITLE
feat: align TypeScript contracts with task/bid/proof API

### DIFF
--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -22,6 +22,7 @@
 - [ ] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
 - [ ] 3.2 实现候选筛选策略（硬过滤 + 软排序）与评分字段。
 - [ ] 3.3 设计 commit-reveal 竞标接口与时序约束。
+- [x] 3.4 对齐 `openapi.yaml` 与 `contracts.ts` 的任务/竞标/校验请求响应封装。
 
 ## 4. PoMW 与审计闭环
 

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -180,6 +180,17 @@ export type UploadAgentBundleErrorResponse =
   | UploadAgentBundleValidationErrorResponse
   | UploadAgentBundleVersionConflictResponse;
 
+export interface CreateTaskRequest {
+  task: TaskSpec;
+}
+
+export interface CreateTaskResponse {
+  taskId: string;
+  status: "OPEN_FOR_MATCHING" | "OPEN_FOR_BIDDING";
+  commitDeadline?: string;
+  revealDeadline?: string;
+}
+
 export interface TaskSpec {
   title: string;
   description: string;
@@ -270,4 +281,41 @@ export interface Bid {
     };
     proof?: ProofPack;
   };
+}
+
+export interface CommitBidRequest {
+  bid: Bid;
+}
+
+export interface RevealBidRequest {
+  bid: Bid;
+}
+
+export interface BidResponse {
+  bidId: string;
+  taskId: string;
+  agentId: string;
+  phase: "COMMIT" | "REVEAL";
+  status: "COMMITTED" | "REVEALED" | "REJECTED" | "SCORED";
+  rankingScore?: number;
+  decisionTraceHash?: string;
+}
+
+export interface VerifyProofPackRequest {
+  proof: ProofPack;
+}
+
+export interface ProofVerificationResponse {
+  proofId: string;
+  result: "PASS" | "FAIL" | "MANUAL_REVIEW";
+  requiredDifficulty: number;
+  achievedDifficulty: number;
+  reasonCodes?: string[];
+  verifiedAt?: string;
+}
+
+export interface ErrorResponse {
+  code: string;
+  message: string;
+  details?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- add task marketplace and proof verification request/response envelopes to `src/api/contracts.ts`
- add `BidResponse`, `ProofVerificationResponse`, and shared `ErrorResponse` types to mirror `src/api/openapi.yaml`
- update OpenSpec task tracking with completed contract sync item

## Validation
- openspec validate --changes
- openspec validate --all

--linlan-dev-agent
