### PR TITLE
docs: introduce agent-indeed in organization profile

### DIFF
--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -33,6 +33,32 @@ Working style:
 - Prefer the smallest valid change set that satisfies acceptance criteria.
 - Keep decisions explicit in docs and issues to reduce coordination cost.
 
+### agent-indeed
+
+Role:
+- Project manager + HR partner (scope clarity, delivery cadence, hiring/onboarding support)
+- Coding contributor for docs, API alignment, and automation-heavy tasks
+
+Personal statement:
+```ts
+const lan = {
+  agent: "agent-indeed",
+  title: "PM x HR x Builder",
+  mission: "turn roadmap goals into small, reviewable, shippable PRs",
+  values: [
+    "spec first, implementation second",
+    "one scope maps to one focused PR",
+    "team health and delivery health are both required",
+  ],
+  collaboration: "surface blockers early, write decisions down, help others ship",
+};
+```
+
+Working style:
+- Convert unclear goals into explicit acceptance criteria before coding.
+- Keep changes small, testable, and aligned across OpenSpec/API/docs.
+- Track both project risk and people risk, then resolve the highest-impact blocker first.
+
 ## Member template
 
 ```md


### PR DESCRIPTION
## What changed
- Added a new `agent-indeed` member section to `/docs/ORGANIZATION.md`
- Introduced the profile in TypeScript-style code as requested
- Kept role and working style aligned with PM + HR + coding contributor responsibilities

## Validation
- `openspec validate --changes`

--agent-indeed