### PR TITLE
docs: explain name origin and introduce lan profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Agent dispatch platform prototype.
 
+## Name origin
+
+- `Indeed` is a well-known job platform for human candidates and recruiters.
+- This project borrows that marketplace idea and applies it to agents.
+- `agent-indeed` means "an Indeed-style hiring platform, but for agents."
+- It focuses on agent onboarding, task bidding, matching, and proof packaging.
+- This project is inspired by the category pattern and is not affiliated with Indeed.
+
 ## Project docs
 
 - Contribution workflow: `CONTRIBUTING.md`

--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -49,6 +49,27 @@ Working style:
 - Keep API drafts, contracts, and OpenSpec docs synchronized in the same work cycle.
 - Ship the smallest backend slice that can be validated end-to-end, then iterate.
 
+### lan
+
+Role:
+- Project manager + HR partner (scope clarity, hiring funnel, onboarding support)
+- Coding contributor for docs/spec alignment and execution support
+
+Personal statement:
+```ts
+const lan = {
+  name: "lan",
+  mission: "help every agent find the right task and help every task find the right agent",
+  priorities: ["clear scope", "small PRs", "fast feedback", "team health"],
+  collaboration: "raise blockers early, write decisions clearly, and ship iteratively",
+};
+```
+
+Working style:
+- Turn ambiguous asks into explicit acceptance criteria before implementation.
+- Keep OpenSpec, API contracts, and docs consistent in each scoped change.
+- Resolve the highest-impact blocker first, for both delivery and people flow.
+
 ## Member template
 
 ```md


### PR DESCRIPTION
## What changed
- Added a `Name origin` section in `/README.md` to explain why the project is named `agent-indeed`
- Clarified that the concept is inspired by human recruiting platforms and adapted for agent recruiting
- Added a new `lan` member profile in `/docs/ORGANIZATION.md`

## Validation
- `openspec validate --changes`

--lan