### PR TITLE
[P1-01] Align AgentBundle schema version contract

### DIFF
--- a/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md
@@ -5,16 +5,24 @@
 平台 MUST 支持上传标准化 `AgentBundle`，并在入库前完成完整性与身份可验证检查。
 
 #### Scenario: Valid signed bundle is accepted
-- **WHEN** agent owner 提交包含 `manifest`, `identity`, `skills`, `memoryRef` 的 bundle，且签名有效
+- **WHEN** agent owner 提交包含 `schemaVersion`, `manifest`, `identity`, `skills`, `memoryRef` 的 bundle，且签名有效
 - **THEN** 平台接受上传并返回 `agent_id` 与 `version`
 
 #### Scenario: Invalid signature is rejected
 - **WHEN** 上传包签名校验失败
-- **THEN** 平台拒绝入库并返回可审计错误码（`AGENT_BUNDLE_SIGNATURE_INVALID` 或同类签名错误码）
+- **THEN** 平台拒绝入库并返回可审计错误码 `AGENT_BUNDLE_SIGNATURE_INVALID`
+
+#### Scenario: Signature signer does not match declared identity
+- **WHEN** `signature.signerDid` 与 `identity.did` 不一致
+- **THEN** 平台拒绝入库并返回稳定错误码 `AGENT_BUNDLE_SIGNATURE_SIGNER_MISMATCH`
 
 #### Scenario: Invalid schema is rejected
-- **WHEN** 上传包缺少必填字段、字段格式不合法，或 schema 版本不受支持
-- **THEN** 平台拒绝入库并返回稳定 schema 错误码（`AGENT_BUNDLE_SCHEMA_INVALID` / `AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION`）与字段路径
+- **WHEN** 上传包缺少必填字段或字段格式不合法
+- **THEN** 平台拒绝入库并返回稳定 schema 错误码 `AGENT_BUNDLE_SCHEMA_INVALID` 与字段路径
+
+#### Scenario: Unsupported bundle schema version is rejected
+- **WHEN** `schemaVersion` 不在平台支持列表内
+- **THEN** 平台拒绝入库并返回稳定错误码 `AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION` 与字段路径 `bundle.schemaVersion`
 
 ### Requirement: Bundle Version Conflict Must Follow Deterministic Strategy
 
@@ -23,10 +31,11 @@
 #### Scenario: Replayed upload with identical payload hash
 - **WHEN** 同一 `agent_id` 与 `manifest.version` 已存在，且 `payload_hash` 一致
 - **THEN** 平台返回已存在版本信息，并标记冲突策略 `RETURN_EXISTING_ON_HASH_MATCH`
+- **AND** 响应中回显已有版本的 `agent_id`, `version`, `existing_payload_hash`, `incoming_payload_hash`
 
 #### Scenario: Duplicate version with different payload hash
 - **WHEN** 同一 `agent_id` 与 `manifest.version` 已存在，但 `payload_hash` 不一致
-- **THEN** 平台拒绝上传并返回 `AGENT_BUNDLE_VERSION_CONFLICT` 与策略 `REJECT_ON_HASH_MISMATCH`
+- **THEN** 平台拒绝上传并返回版本冲突错误码 `AGENT_BUNDLE_VERSION_CONFLICT` 与策略 `REJECT_ON_HASH_MISMATCH`
 
 #### Scenario: Upload replay with identical idempotency key is deterministic
 - **WHEN** 客户端因网络抖动重试同一个 `idempotencyKey` 且 payload hash 不变

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -1,5 +1,6 @@
 export type IdentityTier = "T0" | "T1" | "T2";
 
+export type AgentBundleSchemaVersion = "1.0";
 export type AgentRuntime = "OPENCLAW" | "CUSTOM_CONTAINER" | "WASM";
 export type AgentMemoryMode = "INDEX_ONLY" | "ENCRYPTED_REF" | "FULL";
 export type AgentMemoryScope = "DISCOVERY_ONLY" | "MATCHING_ONLY" | "TASK_RUNTIME";
@@ -78,6 +79,7 @@ export interface AgentBundleSignature {
 }
 
 export interface AgentBundle {
+  schemaVersion: AgentBundleSchemaVersion;
   manifest: AgentManifest;
   identity: AgentIdentity;
   skills: AgentSkillMetadata[];

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -37,6 +37,7 @@ paths:
                 value:
                   idempotencyKey: idem_agentbundle_001
                   bundle:
+                    schemaVersion: '1.0'
                     manifest:
                       name: support_triage_agent
                       version: 1.2.0
@@ -169,12 +170,40 @@ paths:
                       rule: signer_matches_identity
                       expected: did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8Kestrel
                       actual: did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8WrongSigner
+                unsupportedSchemaVersion:
+                  summary: Unsupported bundle schema version
+                  value:
+                    code: AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION
+                    category: SCHEMA
+                    message: bundle.schemaVersion 2.0 is not supported
+                    auditId: audit_bundle_upload_unsupported_schema
+                    retryable: false
+                    details:
+                      fieldPath: bundle.schemaVersion
+                      rule: supported_schema_version
+                      expected: '1.0'
+                      actual: '2.0'
         '409':
           description: Duplicate bundle version
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UploadAgentBundleVersionConflictResponse'
+              examples:
+                hashMismatchConflict:
+                  summary: Same agent and version but different payload
+                  value:
+                    code: AGENT_BUNDLE_VERSION_CONFLICT
+                    category: VERSION
+                    message: agent_supporttriage001@1.2.0 already exists with a different payload hash
+                    auditId: audit_bundle_upload_version_conflict
+                    retryable: false
+                    conflict:
+                      strategy: REJECT_ON_HASH_MISMATCH
+                      existingAgentId: agent_supporttriage001
+                      existingVersion: 1.2.0
+                      existingPayloadHash: sha256:3333333333333333333333333333333333333333333333333333333333333333
+                      incomingPayloadHash: sha256:4444444444444444444444444444444444444444444444444444444444444444
 
   /v1/tasks:
     post:
@@ -632,8 +661,12 @@ components:
     AgentBundle:
       type: object
       additionalProperties: false
-      required: [manifest, identity, skills, memoryRef, signature]
+      required: [schemaVersion, manifest, identity, skills, memoryRef, signature]
       properties:
+        schemaVersion:
+          type: string
+          enum: ['1.0']
+          description: Contract version used to route schema compatibility checks.
         manifest:
           type: object
           additionalProperties: false


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): Closes #3
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/spec`
- Scope: Align AgentBundle schema-version and upload response contracts across OpenSpec + OpenAPI + TypeScript contracts.

## What Changed

- Added required `bundle.schemaVersion` (`"1.0"`) to the `AgentBundle` contract in `/src/api/openapi.yaml` and `/src/api/contracts.ts`.
- Split upload success responses into explicit created/replay shapes and kept deterministic replay/conflict payloads with concrete examples.
- Synced OpenSpec onboarding requirement scenarios for signature/schema/version conflict error-code behavior in `/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md`.
- Added explicit schema descriptions for `UploadAgentBundleReplayResponse`, `UploadAgentBundleValidationErrorResponse`, and `UploadAgentBundleVersionConflictResponse` to address review comments and keep response references unambiguous.

## Why

- The upload API already surfaced `AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION`, but `AgentBundle` lacked a first-class schema-version field, creating a contract gap.
- This PR makes schema-version validation auditable, keeps replay/conflict semantics deterministic, and aligns OpenSpec requirements with the API/contract artifacts used for implementation.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Bundle upload contract includes explicit schema version for compatibility validation. | Adds required `schemaVersion` on `AgentBundle` and constrains it to supported value `1.0`. | `/src/api/openapi.yaml` `AgentBundle.schemaVersion`; `/src/api/contracts.ts` `AgentBundle.schemaVersion` |
| Schema/signature failures expose stable and auditable error semantics. | Defines stable error-code scenarios and response payload fields for validation failures. | `/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md`; `/src/api/openapi.yaml` upload `400` response + schema |
| Version conflict/replay behavior is deterministic and inspectable. | Keeps explicit replay/conflict response schemas with strategy + hash fields and examples. | `/src/api/openapi.yaml` `UploadAgentBundleReplayResponse` / `UploadAgentBundleVersionConflictResponse` |

## QA Plan

### Preconditions

- Checked out PR branch `codex/p1-01-agentbundle-contract-kestrel-issue-3-run2`.
- OpenSpec CLI and Node/npm available in local environment.

### Steps

1. Run `openspec validate --changes`.
2. Run `openspec validate --all`.
3. Run `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`.
4. Run `bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent`.

### Expected Results

- OpenSpec change and full repo spec validation pass with zero failures.
- OpenAPI document validates with no missing `$ref` components.
- Pre-push guard passes on branch policy + identity checks.

### Validation Output

```text
$ openspec validate --changes
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml
src/api/openapi.yaml is valid

$ bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent
[ok] Branch 'codex/p1-01-agentbundle-contract-kestrel-issue-3-run2' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (kestrel-dev-agent).
[ok] git user.email matches expected account (kestrel-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - Consumers that still assume old response naming (`UploadAgentBundleResponse`) may need to adapt to the explicit created/replay schema naming.
  - Example payload expectations can drift if future contract fields change without synchronized edits.
- Rollback:
  - Revert the PR commits from this branch (`00fad6d` and `92bb4f5`) and force-push the branch.
  - Re-run OpenSpec/OpenAPI validation to confirm baseline behavior is restored.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
