### PR TITLE
docs: add PR template and shared issue/PR taxonomy enum

### DIFF
--- a/.github/ISSUE_TEMPLATE/work-item.yml
+++ b/.github/ISSUE_TEMPLATE/work-item.yml
@@ -1,0 +1,76 @@
+name: Work Item
+description: Create a scoped delivery issue with required department and type enums.
+title: "[<phase>] <short scope>"
+labels:
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for planning and delivery work.
+        You must apply exactly one `dept/*` label and one `type/*` label after issue creation.
+  - type: dropdown
+    id: department
+    attributes:
+      label: Department (enum)
+      description: Choose the primary department owner.
+      options:
+        - frontend
+        - backend
+        - qa
+        - planning
+    validations:
+      required: true
+  - type: dropdown
+    id: work_type
+    attributes:
+      label: Type (enum)
+      description: Choose the work type.
+      options:
+        - feature
+        - bugfix
+        - refactor
+        - docs
+        - test
+        - chore
+        - spec
+    validations:
+      required: true
+  - type: input
+    id: related_epic
+    attributes:
+      label: Related Epic/Issue
+      placeholder: "#2"
+    validations:
+      required: true
+  - type: textarea
+    id: why_now
+    attributes:
+      label: Why now
+      description: Explain the blocker or value.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: List concrete in-scope items.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      description: Write testable, externally verifiable criteria.
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: true
+  - type: textarea
+    id: qa_notes
+    attributes:
+      label: QA hints
+      description: If possible, include verification path or reproducible checks.
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,58 @@
+## PR Metadata
+
+- Linked issue(s): <!-- e.g. closes #123 -->
+- Department label (pick one): `dept/frontend` | `dept/backend` | `dept/qa` | `dept/planning`
+- Type label (pick one): `type/feature` | `type/bugfix` | `type/refactor` | `type/docs` | `type/test` | `type/chore` | `type/spec`
+- Scope: <!-- one focused scope only; do not mix unrelated work -->
+
+## What Changed
+
+- <!-- concise bullet list of concrete file/behavior changes -->
+
+## Why
+
+- <!-- explain the problem/risk this PR addresses -->
+
+## Acceptance Criteria Mapping
+
+| Acceptance criterion | How this PR satisfies it | Evidence |
+| --- | --- | --- |
+| <!-- criterion #1 --> | <!-- implementation summary --> | <!-- file path / output --> |
+| <!-- criterion #2 --> | <!-- implementation summary --> | <!-- file path / output --> |
+
+## QA Plan
+
+### Preconditions
+
+- <!-- environment/setup conditions -->
+
+### Steps
+
+1. <!-- step 1 -->
+2. <!-- step 2 -->
+3. <!-- step 3 -->
+
+### Expected Results
+
+- <!-- expected outcome for each key step -->
+
+### Validation Output
+
+- `openspec validate --all`
+- <!-- add other commands if available -->
+
+## Risks and Rollback
+
+- Risk:
+  - <!-- main risk(s) -->
+- Rollback:
+  - <!-- exact rollback approach -->
+
+## Checklist
+
+- [ ] Exactly one department label is set (`dept/*`)
+- [ ] Exactly one type label is set (`type/*`)
+- [ ] OpenSpec/API/contracts/docs are synced if scope requires
+- [ ] Acceptance criteria mapping is complete
+- [ ] QA steps are reproducible and include expected results
+- [ ] PR comments/review replies are signed with `--<agent-name>`

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,75 @@
+name: PR Policy
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  policy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate labels and template sections
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map((l) => l.name);
+            const body = pr.body || "";
+
+            const deptEnum = [
+              "dept/frontend",
+              "dept/backend",
+              "dept/qa",
+              "dept/planning"
+            ];
+
+            const typeEnum = [
+              "type/feature",
+              "type/bugfix",
+              "type/refactor",
+              "type/docs",
+              "type/test",
+              "type/chore",
+              "type/spec"
+            ];
+
+            const deptLabels = labels.filter((l) => deptEnum.includes(l));
+            const typeLabels = labels.filter((l) => typeEnum.includes(l));
+
+            const requiredSections = [
+              "## PR Metadata",
+              "## What Changed",
+              "## Why",
+              "## Acceptance Criteria Mapping",
+              "## QA Plan",
+              "## Risks and Rollback",
+              "## Checklist"
+            ];
+
+            const errors = [];
+
+            if (deptLabels.length !== 1) {
+              errors.push(
+                `PR must have exactly one department label. Found: ${deptLabels.length}. Allowed: ${deptEnum.join(", ")}`
+              );
+            }
+
+            if (typeLabels.length !== 1) {
+              errors.push(
+                `PR must have exactly one type label. Found: ${typeLabels.length}. Allowed: ${typeEnum.join(", ")}`
+              );
+            }
+
+            for (const section of requiredSections) {
+              if (!body.includes(section)) {
+                errors.push(`PR body is missing required section: ${section}`);
+              }
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(errors.map((e) => `- ${e}`).join("\n"));
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,10 +20,24 @@
   4. Re-run required validation commands
   5. Push branch (`git push --force-with-lease` when history was rewritten by rebase)
 
+## PR and issue format policy
+
+- All PRs must use `.github/pull_request_template.md`.
+- Every PR must include:
+  - Exactly one department label: `dept/frontend`, `dept/backend`, `dept/qa`, or `dept/planning`
+  - Exactly one type label: `type/feature`, `type/bugfix`, `type/refactor`, `type/docs`, `type/test`, `type/chore`, or `type/spec`
+- Every issue should use the same enum set for ownership and work classification.
+- Source of truth for enums and examples: `docs/WORK_ITEM_TAXONOMY.md`.
+- PR descriptions must be self-complete for review:
+  - acceptance criteria mapping
+  - reproducible QA steps and expected results
+  - validation output and risk/rollback note
+
 ## Known commands
 
 - Validate OpenSpec changes for active work with `openspec validate --changes`.
 - Run full OpenSpec validation with `openspec validate --all` when needed.
+- Sync required issue/PR labels with `bash scripts/bootstrap_work_item_labels.sh`.
 
 ## Repo layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,9 @@ Thanks for contributing. This repository is currently API/spec-first, so most ch
 6. Run validation:
    - `openspec validate --all`
 7. Open a PR with linked issue(s), scope notes, and verification output.
+8. Use the repository PR template and apply required labels:
+   - exactly one `dept/*` label
+   - exactly one `type/*` label
 
 ## Push Sync Requirement (before every push)
 
@@ -56,6 +59,24 @@ When multiple agents share one machine/worktree pool, isolate git commit identit
 - Avoid mixing unrelated docs/spec/API changes in one PR.
 - Prefer small, reviewable diffs with explicit acceptance criteria.
 
+## Issue + PR Taxonomy Enum
+
+Use one shared enum set across issues and PRs (see `docs/WORK_ITEM_TAXONOMY.md`):
+
+- Department enum (exactly one):
+  - `dept/frontend`
+  - `dept/backend`
+  - `dept/qa`
+  - `dept/planning`
+- Type enum (exactly one):
+  - `type/feature`
+  - `type/bugfix`
+  - `type/refactor`
+  - `type/docs`
+  - `type/test`
+  - `type/chore`
+  - `type/spec`
+
 ## Pull Request Checklist
 
 Before requesting review, ensure:
@@ -66,9 +87,13 @@ Before requesting review, ensure:
 - [ ] Work is on a dedicated `codex/<topic>` branch (not `main`).
 - [ ] `openspec validate --all` passes locally.
 - [ ] Related issue links are added in the PR description.
+- [ ] PR uses `.github/pull_request_template.md` sections fully.
+- [ ] PR has exactly one `dept/*` label and one `type/*` label.
 - [ ] Review-thread replies are explicit and signed with `--<agent-name>`.
 
 ## Current Tooling Notes
 
 - No repo-local build/lint/test command is defined yet.
 - Until runtime modules are added, use OpenSpec validation and contract/doc consistency as the minimum quality gate.
+- To bootstrap label enums in GitHub, run:
+  - `bash scripts/bootstrap_work_item_labels.sh`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Agent dispatch platform prototype.
 ## Project docs
 
 - Contribution workflow: `CONTRIBUTING.md`
+- Issue/PR taxonomy enum: `docs/WORK_ITEM_TAXONOMY.md`
 - Multi-agent git commit identity playbook: `docs/AGENT_IDENTITY.md`
 - Tech stack baseline: `docs/TECH_STACK.md`
 - MVP roadmap: `docs/ROADMAP.md`

--- a/docs/WORK_ITEM_TAXONOMY.md
+++ b/docs/WORK_ITEM_TAXONOMY.md
@@ -1,0 +1,42 @@
+# Work Item Taxonomy (Issue + PR)
+
+Last updated: 2026-03-14
+
+## Purpose
+
+Define one shared enum-based taxonomy for GitHub issues and pull requests so planning, implementation, QA, and reporting use the same labels.
+
+## Department enum (required)
+
+Exactly one department label is required on every issue and PR:
+
+- `dept/frontend`
+- `dept/backend`
+- `dept/qa`
+- `dept/planning`
+
+## Type enum (required)
+
+Exactly one type label is required on every issue and PR:
+
+- `type/feature` (new behavior or endpoint)
+- `type/bugfix` (behavior correction)
+- `type/refactor` (internal structure improvement without behavior change)
+- `type/docs` (documentation-only changes)
+- `type/test` (test coverage or test tooling)
+- `type/chore` (maintenance, automation, dependency/process updates)
+- `type/spec` (OpenSpec or contract-definition change)
+
+## Rules
+
+- Every issue must include exactly one `dept/*` label and one `type/*` label.
+- Every PR must include exactly one `dept/*` label and one `type/*` label.
+- PR body must map changes to acceptance criteria and provide a QA plan.
+- PRs without valid labels should be considered non-ready for review.
+
+## Recommended mapping examples
+
+- API contract update: `dept/backend` + `type/spec`
+- Frontend page implementation: `dept/frontend` + `type/feature`
+- Test matrix expansion: `dept/qa` + `type/test`
+- Roadmap and planning updates: `dept/planning` + `type/docs`

--- a/scripts/bootstrap_work_item_labels.sh
+++ b/scripts/bootstrap_work_item_labels.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create/update the label taxonomy required by docs/WORK_ITEM_TAXONOMY.md.
+# Requires GitHub CLI auth with repo label admin permission.
+
+upsert_label() {
+  local name="$1"
+  local color="$2"
+  local desc="$3"
+
+  if gh label list --limit 200 --json name --jq '.[].name' | grep -Fxq "$name"; then
+    gh label edit "$name" --color "$color" --description "$desc" >/dev/null
+    echo "updated: $name"
+  else
+    gh label create "$name" --color "$color" --description "$desc" >/dev/null
+    echo "created: $name"
+  fi
+}
+
+# Department labels
+upsert_label "dept/frontend" "1f77b4" "Primary owning department: frontend"
+upsert_label "dept/backend" "0052cc" "Primary owning department: backend"
+upsert_label "dept/qa" "0e8a16" "Primary owning department: QA"
+upsert_label "dept/planning" "6f42c1" "Primary owning department: planning"
+
+# Type labels
+upsert_label "type/feature" "a2eeef" "Work type: new feature"
+upsert_label "type/bugfix" "d73a4a" "Work type: bug fix"
+upsert_label "type/refactor" "fbca04" "Work type: refactor"
+upsert_label "type/docs" "0075ca" "Work type: documentation"
+upsert_label "type/test" "0e8a16" "Work type: tests"
+upsert_label "type/chore" "cfd3d7" "Work type: maintenance chore"
+upsert_label "type/spec" "5319e7" "Work type: OpenSpec/API contract"
+
+# Optional helper for freshly created issues.
+upsert_label "needs-triage" "ededed" "Needs maintainer triage and label normalization"
+
+echo "label taxonomy sync complete"


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): n/a (process baseline update)
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Add a complete PR template, shared issue/PR enum taxonomy, and policy checks

## What Changed

- Added `.github/pull_request_template.md` with complete reviewer-facing sections, acceptance mapping, and QA steps.
- Added `docs/WORK_ITEM_TAXONOMY.md` as the source of truth for shared `dept/*` and `type/*` enums.
- Added `.github/ISSUE_TEMPLATE/work-item.yml` so new issues capture the same enum dimensions.
- Added `.github/workflows/pr-policy.yml` to enforce required PR labels and required template sections.
- Added `scripts/bootstrap_work_item_labels.sh` to create/update required labels in the repository.
- Updated `AGENTS.md`, `CONTRIBUTING.md`, and `README.md` to require agents to follow the new format.

## Why

- The repo needed a self-complete PR format so reviewers can evaluate acceptance criteria and QA without extra back-and-forth.
- The team also needed one consistent type enum across issues and PRs for execution tracking and reporting.
- Enforcing labels on PRs avoids missing department ownership during review.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Create a GitHub PR template that is self-complete for reviewers | Added required sections for change summary, criteria mapping, QA steps, expected results, risks, rollback, and checklist | `.github/pull_request_template.md` |
| Ask all agents to follow the format | Added policy language in team workflow docs | `AGENTS.md`, `CONTRIBUTING.md` |
| Require department label on all PRs | Added enum labels and CI policy enforcement for one `dept/*` label | `.github/workflows/pr-policy.yml`, `docs/WORK_ITEM_TAXONOMY.md` |
| Create a type enum used across issues and PRs | Defined `type/*` enum in shared taxonomy and issue/PR process docs/templates | `docs/WORK_ITEM_TAXONOMY.md`, `.github/ISSUE_TEMPLATE/work-item.yml`, `.github/pull_request_template.md` |
| Include QA guidance for reviewers | PR template includes explicit preconditions, steps, expected results, and validation outputs | `.github/pull_request_template.md` |

## QA Plan

### Preconditions

- GitHub Actions enabled in repository.
- Maintainer has `gh` auth for label management.

### Steps

1. Open a new PR and confirm template sections auto-populate.
2. Remove one required section in the PR body and verify `PR Policy` workflow fails.
3. Keep sections but remove `dept/*` or `type/*` label and verify `PR Policy` workflow fails.
4. Add exactly one valid `dept/*` and `type/*` label and verify workflow passes.
5. Create a new issue with `Work Item` form and confirm enum fields are present.
6. Run `bash scripts/bootstrap_work_item_labels.sh` and confirm labels are created/updated.

### Expected Results

- PR template is complete and reusable.
- PR policy check blocks non-compliant PRs.
- Label bootstrap script creates/updates all enum labels.
- Issue form exposes the same enum dimensions used by PR policy.

### Validation Output

- `openspec validate --all`
- `bash -n scripts/bootstrap_work_item_labels.sh`
- `bash scripts/bootstrap_work_item_labels.sh`

## Risks and Rollback

- Risk:
  - Existing in-flight PRs may fail policy checks until labels/body sections are updated.
- Rollback:
  - Revert `.github/workflows/pr-policy.yml` first to remove hard enforcement, then adjust templates/docs incrementally.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
