### PR TITLE
docs: define frontend MVP surface and API wiring matrix (P0-07)

### DIFF
--- a/docs/FRONTEND_MVP_SURFACE.md
+++ b/docs/FRONTEND_MVP_SURFACE.md
@@ -60,7 +60,7 @@ Define the minimum manager, agent, and operator console surface needed to execut
 
 | Page | API endpoint | Required request fields from UI | Response fields required by UI | Contract status |
 | --- | --- | --- | --- | --- |
-| `/manager/tasks/new` | `POST /v1/tasks` | `task.title`, `task.description`, `task.budget.*`, `task.sla.*`, `task.constraints.*`, `task.risk.*`, `task.powmPolicy.*`, `task.biddingWindow.*` | `taskId`, `status`, `commitDeadline`, `revealDeadline` | Ready, but no idempotency key and no structured validation details |
+| `/manager/tasks/new` | `POST /v1/tasks` | `idempotencyKey`, `task.title`, `task.description`, `task.budget.*`, `task.sla.*`, `task.constraints.*`, `task.risk.*`, `task.powmPolicy.*`, `task.biddingWindow.*` | `taskId`, `status`, `commitDeadline`, `revealDeadline` | Ready for core publish path; FE must include idempotency key and handle structured validation details when contract sync lands |
 | `/manager/tasks/{taskId}/candidates` | `GET /v1/tasks/{taskId}/candidates` (proposed) | `taskId`, `topK`, `includeScoreBreakdown` | `agentId`, `identityTier`, `hardFilterPassed`, `rankingScore`, `scoreBreakdown`, `proofReadiness`, `decisionTraceHash` | Missing in current API |
 | `/manager/tasks/{taskId}/award` | `POST /v1/tasks/{taskId}/award` + `GET /v1/tasks/{taskId}/award` (proposed) | `taskId`, `bidId`, `awardReason`, `idempotencyKey` | `taskId`, `awardedBidId`, `awardedAt`, `proofSummary`, `decisionTraceHash`, `auditEventId` | Missing in current API |
 

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -111,7 +111,7 @@ Acceptance criteria:
 - Each MVP flow stage has an owning backend module.
 - Cross-module contract dependencies and sequencing risks are called out.
 
-### P0-07 Define frontend MVP surface and API wiring matrix
+### P0-07 Define frontend MVP surface and API wiring matrix (`docs/FRONTEND_MVP_SURFACE.md`)
 
 References:
 - `docs/FRONTEND_MVP_SURFACE.md`


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #33
- Department label (pick one): `dept/frontend`
- Type label (pick one): `type/docs`
- Scope: Define frontend MVP surface and API wiring matrix for P0-07 only

## What Changed

- Added `docs/FRONTEND_MVP_SURFACE.md` with persona map for manager, agent, and operator.
- Defined a closed-beta page map and minimal navigation flow for manager/agent/operator consoles.
- Added API-to-UI wiring matrix per page, including request/response fields and contract status.
- Updated wiring matrix to explicitly include `idempotencyKey` for task creation and `bundle.schemaVersion` for onboarding input requirements.
- Narrowed `docs/issues/PHASE1_ISSUES.md` edits to P0-07 scope only (removed unrelated issue-link additions).

## Why

- P0-07 requires a concrete frontend MVP surface before implementation can proceed.
- Backend contracts exist, but frontend consumers and dependency gaps were not explicitly mapped.
- Reviewer feedback requested explicit required request fields and strict one-issue scope in this PR.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Persona map covers manager, agent, and operator roles. | Added explicit persona table with objectives/actions/artifacts for all three roles. | `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/FRONTEND_MVP_SURFACE.md` |
| MVP page map is limited to the closed-beta flow. | Added manager/agent/operator page map scoped only to closed-beta lifecycle pages. | `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/FRONTEND_MVP_SURFACE.md` |
| API-to-UI field matrix exists for each required page. | Added matrix sections for manager, agent, operator pages with endpoint + field mapping + readiness status. | `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/FRONTEND_MVP_SURFACE.md` |
| Integration risks or missing backend fields are listed explicitly. | Added dedicated risk table and follow-up contract actions. | `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/FRONTEND_MVP_SURFACE.md` |
| Output is linked from `docs/issues/PHASE1_ISSUES.md`. | Added P0-07 section and references in Phase 1 issue backlog doc. | `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/issues/PHASE1_ISSUES.md` |

## QA Plan

### Preconditions

- Repository is on branch `codex/p0-07-frontend-mvp-surface-matrix` with this PR changes.

### Steps

1. Open `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/FRONTEND_MVP_SURFACE.md` and verify persona map/page map/API matrix/risk sections exist.
2. Confirm manager task publish matrix row includes `idempotencyKey`.
3. Confirm agent onboarding matrix row includes `bundle.schemaVersion`.
4. Open `/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/issues/PHASE1_ISSUES.md` and verify only P0-07 link/update is part of this PR scope.
5. Run `openspec validate --all`.

### Expected Results

- All P0-07 acceptance criteria have explicit, discoverable documentation evidence.
- Required request fields called out in reviewer comments are explicitly present in matrix.
- No unrelated issue-backlog expansion remains in this PR.
- OpenSpec validation passes with zero failures.

### Validation Output

- Command: `openspec validate --all`
- Output:

```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

## Risks and Rollback

- Risk:
  - Matrix includes proposed endpoints not yet implemented, which can drift if backend naming changes.
- Rollback:
  - Revert commits `e96bcea` and `8a0b973` from this branch.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--lanzhou-fe-agent`
