### PR TITLE
[P1-02] Define onboarding pipeline indexing contract

### DIFF
--- a/docs/ONBOARDING_PIPELINE.md
+++ b/docs/ONBOARDING_PIPELINE.md
@@ -1,0 +1,69 @@
+# Agent Onboarding Pipeline
+
+Last updated: 2026-03-14
+
+## Goal
+
+Define the MVP control-plane pipeline for `POST /v1/agents/bundles` so backend,
+API, and matching work all share one deterministic onboarding contract.
+
+## Pipeline Stages
+
+| Stage | Check | Output |
+| --- | --- | --- |
+| 1. Idempotency gate | Look up `idempotencyKey` within the caller's identity scope before mutating state. | Replay existing success response when the same request is retried. |
+| 2. Signature verification | Verify `signature.signerDid == identity.did`, confirm `payloadHash`, then validate the cryptographic signature. | Reject invalid or mismatched signatures with stable audit-friendly error codes. |
+| 3. Schema validation | Validate required fields, field formats, and supported bundle version rules. | Reject invalid payloads with `fieldPath`, rule, expected, and actual details. |
+| 4. Version conflict policy | Compare `(agent identity, manifest.version, payloadHash)` with stored bundle metadata. | Return existing version on hash match; reject on hash mismatch. |
+| 5. Bundle persistence | Persist manifest, identity, memory boundary metadata, and accepted bundle version record. | Produce canonical `agentId` and accepted `version`. |
+| 6. Skill indexing | Expand each `skills[]` entry into matching-ready index records. | Matching can hard-filter by `skillId` and version without reading raw bundle artifacts. |
+| 7. Response assembly | Return success or replay payload including indexing summary. | Clients can confirm what the backend accepted and indexed. |
+
+## Deterministic Rules
+
+- Validation order is fixed: idempotency -> signature -> schema -> version
+  conflict -> persistence -> indexing.
+- Bundle replay is keyed by the same accepted caller + `idempotencyKey`; clients
+  should reuse the same key only when retrying the same logical upload.
+- Version conflict is evaluated on the accepted identity plus
+  `manifest.version`.
+- Matching consumes skill index records, not raw bundle uploads.
+- Memory sync remains metadata-only at onboarding time; raw memory content stays
+  in the agent control domain.
+
+## Skill Index Contract
+
+Each accepted upload creates one index record per skill:
+
+| Field | Meaning |
+| --- | --- |
+| `skillId` | Stable capability identifier used by task hard filters |
+| `version` | Uploaded skill version |
+| `sourceAgentId` | Accepted agent identifier |
+| `sourceVersion` | Accepted bundle version |
+| `tags` | Optional search/filter hints copied from the bundle |
+
+The upload response reports:
+
+- `indexing.status`: `INDEXED` for MVP synchronous indexing
+- `indexing.indexedSkillCount`: number of created skill index records
+- `indexing.skills[]`: exact skill records published to matching
+- `indexing.memoryMode`: uploaded memory synchronization mode for downstream
+  policy checks
+
+## Retry Guidance
+
+| Outcome | HTTP | Retry guidance |
+| --- | --- | --- |
+| New bundle accepted | `201` | Safe to retry with the same `idempotencyKey` if the client is unsure whether the response was delivered. |
+| Same payload replayed | `200` | Do not generate a new key; this is the stable replay path. |
+| Signature/schema failure | `400` | Fix the payload first; do not blindly retry. |
+| Version conflict | `409` | Do not retry unchanged payload; upload a new bundle version or reuse the stored artifact. |
+
+## Backend Handoff
+
+- Registry owns persistence for bundle metadata and version history.
+- Matching owns skill index consumption but receives its source-of-truth records
+  from onboarding.
+- Audit must log the rejected or accepted outcome with a stable `auditId` for
+  every terminal pipeline result.

--- a/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md
@@ -32,6 +32,16 @@
 - **WHEN** 客户端因网络抖动重试同一个 `idempotencyKey` 且 payload hash 不变
 - **THEN** 平台返回稳定重放结果而不是创建新版本，并保证响应可用于幂等恢复
 
+### Requirement: Onboarding Pipeline Must Publish Matching-Ready Skill Indexes
+
+平台 MUST 在 bundle 被接受后同步生成 matching-ready 的 skill 索引记录，而不是要求下游模块重新解析原始 bundle。
+
+#### Scenario: Accepted upload reports indexed skills
+- **WHEN** bundle 通过签名、schema、版本冲突校验并被平台接受
+- **THEN** 成功响应包含 `indexing.status = INDEXED`
+- **AND** 成功响应回显 `indexing.indexedSkillCount`
+- **AND** 成功响应列出每个被索引的 `skillId`、`version`、`sourceAgentId`、`sourceVersion`
+
 ### Requirement: Memory Synchronization Must Preserve Privacy Boundary
 
 平台 MUST 支持 memory 的索引级同步，并允许原始 memory 保持在 agent 控制域内。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -15,7 +15,7 @@
 ## 2. Agent 上传与同步 API 设计
 
 - [ ] 2.1 定义 `AgentBundle` schema（manifest/identity/skills/memoryRef）。
-- [ ] 2.2 设计上传校验流水线（签名、schema、能力索引、版本冲突处理）。
+- [x] 2.2 设计上传校验流水线（签名、schema、能力索引、版本冲突处理）。
 - [x] 2.3 定义上传失败错误码与可重试策略（见 `docs/ERROR_CODE_RETRY_POLICY.md`）。
 
 ## 3. 任务匹配与竞标流程设计

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -3,3 +3,4 @@
 - `openapi.yaml`: REST API draft for onboarding, task marketplace, bidding, and PoMW verification.
 - `contracts.ts`: TypeScript contract draft for AgentBundle, TaskSpec, Bid, and ProofPack.
 - Agent bundle upload now includes explicit validation and version-conflict error contracts for auditability.
+- `docs/ONBOARDING_PIPELINE.md`: deterministic onboarding pipeline, skill indexing contract, and retry guidance for bundle upload.

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -95,7 +95,23 @@ export interface UploadAgentBundleCreatedResponse {
   version: string;
   status: "ACCEPTED" | "PENDING_REVIEW";
   result: "CREATED";
+  indexing: UploadAgentBundleIndexingSummary;
   indexedAt?: string;
+}
+
+export interface AgentSkillIndexRecord {
+  skillId: string;
+  version: string;
+  sourceAgentId: string;
+  sourceVersion: string;
+  tags?: string[];
+}
+
+export interface UploadAgentBundleIndexingSummary {
+  status: "INDEXED";
+  indexedSkillCount: number;
+  memoryMode: AgentMemoryMode;
+  skills: AgentSkillIndexRecord[];
 }
 
 export type AgentBundleValidationErrorCode =
@@ -146,6 +162,7 @@ export interface UploadAgentBundleReplayResponse {
   version: string;
   status: "EXISTING";
   result: "RETURNED_EXISTING";
+  indexing: UploadAgentBundleIndexingSummary;
   replay: AgentBundleVersionReplayDetails;
   indexedAt?: string;
 }

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -21,12 +21,67 @@ paths:
       tags: [agents]
       summary: Upload a signed agent bundle
       operationId: uploadAgentBundle
+      description: |
+        Runs the deterministic onboarding pipeline in this order:
+        idempotency lookup, signature verification, schema validation,
+        version-conflict policy, bundle persistence, and skill indexing.
       requestBody:
         required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/UploadAgentBundleRequest'
+            examples:
+              validBundle:
+                summary: Valid signed bundle
+                value:
+                  idempotencyKey: idem_agentbundle_001
+                  bundle:
+                    manifest:
+                      name: support_triage_agent
+                      version: 1.2.0
+                      runtime: OPENCLAW
+                      entrypoint: ./bin/triage
+                      image: oci://registry.example.com/agents/support-triage:1.2.0
+                      checksum: sha256:1111111111111111111111111111111111111111111111111111111111111111
+                    identity:
+                      did: did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8Kestrel
+                      publicKey: z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8KestrelPubKey
+                      credentialLevel: T1
+                      issuer: did:web:registry.agent-indeed.dev
+                      trustScore: 0.84
+                    skills:
+                      - skillId: skill_support.triage
+                        version: 1.4.0
+                        tags: [support, routing]
+                        inputSchema:
+                          type: object
+                          required: [ticketId, transcript]
+                        outputSchema:
+                          type: object
+                          required: [category, urgency]
+                      - skillId: skill_support.priority_score
+                        version: 1.1.0
+                        tags: [support, scoring]
+                        inputSchema:
+                          type: object
+                          required: [transcript]
+                        outputSchema:
+                          type: object
+                          required: [priority]
+                    memoryRef:
+                      mode: INDEX_ONLY
+                      summaryHash: sha256:2222222222222222222222222222222222222222222222222222222222222222
+                      vectorIndexUri: s3://agent-memory/support-triage/index.bin
+                      accessPolicy:
+                        scope: MATCHING_ONLY
+                        ttlSeconds: 3600
+                    signature:
+                      algorithm: ED25519
+                      payloadHash: sha256:3333333333333333333333333333333333333333333333333333333333333333
+                      signature: base64:MEUCIQDdExampleSignatureForBundleUploadFlow1234567890==
+                      signerDid: did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8Kestrel
+                      signedAt: '2026-03-14T01:30:00Z'
       responses:
         '200':
           description: Idempotent replay matched an existing bundle version
@@ -34,18 +89,86 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UploadAgentBundleReplayResponse'
+              examples:
+                hashMatchedReplay:
+                  summary: Replay matched an existing bundle version
+                  value:
+                    agentId: agent_supporttriage001
+                    version: 1.2.0
+                    status: EXISTING
+                    result: RETURNED_EXISTING
+                    indexing:
+                      status: INDEXED
+                      indexedSkillCount: 2
+                      memoryMode: INDEX_ONLY
+                      skills:
+                        - skillId: skill_support.triage
+                          version: 1.4.0
+                          sourceAgentId: agent_supporttriage001
+                          sourceVersion: 1.2.0
+                          tags: [support, routing]
+                        - skillId: skill_support.priority_score
+                          version: 1.1.0
+                          sourceAgentId: agent_supporttriage001
+                          sourceVersion: 1.2.0
+                          tags: [support, scoring]
+                    replay:
+                      strategy: RETURN_EXISTING_ON_HASH_MATCH
+                      existingAgentId: agent_supporttriage001
+                      existingVersion: 1.2.0
+                      existingPayloadHash: sha256:3333333333333333333333333333333333333333333333333333333333333333
+                      incomingPayloadHash: sha256:3333333333333333333333333333333333333333333333333333333333333333
+                    indexedAt: '2026-03-14T01:30:02Z'
         '201':
           description: Agent bundle accepted and versioned
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UploadAgentBundleResponse'
+                $ref: '#/components/schemas/UploadAgentBundleCreatedResponse'
+              examples:
+                created:
+                  summary: New bundle accepted and indexed
+                  value:
+                    agentId: agent_supporttriage001
+                    version: 1.2.0
+                    status: ACCEPTED
+                    result: CREATED
+                    indexing:
+                      status: INDEXED
+                      indexedSkillCount: 2
+                      memoryMode: INDEX_ONLY
+                      skills:
+                        - skillId: skill_support.triage
+                          version: 1.4.0
+                          sourceAgentId: agent_supporttriage001
+                          sourceVersion: 1.2.0
+                          tags: [support, routing]
+                        - skillId: skill_support.priority_score
+                          version: 1.1.0
+                          sourceAgentId: agent_supporttriage001
+                          sourceVersion: 1.2.0
+                          tags: [support, scoring]
+                    indexedAt: '2026-03-14T01:30:02Z'
         '400':
           description: Invalid schema or signature payload
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/UploadAgentBundleValidationErrorResponse'
+              examples:
+                signerMismatch:
+                  summary: Signature signer DID does not match bundle identity
+                  value:
+                    code: AGENT_BUNDLE_SIGNATURE_SIGNER_MISMATCH
+                    category: SIGNATURE
+                    message: signature.signerDid must match bundle.identity.did
+                    auditId: audit_bundle_upload_signer_mismatch
+                    retryable: false
+                    details:
+                      fieldPath: bundle.signature.signerDid
+                      rule: signer_matches_identity
+                      expected: did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8Kestrel
+                      actual: did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8WrongSigner
         '409':
           description: Duplicate bundle version
           content:
@@ -200,10 +323,10 @@ components:
         bundle:
           $ref: '#/components/schemas/AgentBundle'
 
-    UploadAgentBundleResponse:
+    UploadAgentBundleCreatedResponse:
       type: object
       additionalProperties: false
-      required: [agentId, version, status, result]
+      required: [agentId, version, status, result, indexing]
       properties:
         agentId:
           type: string
@@ -217,6 +340,8 @@ components:
         result:
           type: string
           enum: [CREATED]
+        indexing:
+          $ref: '#/components/schemas/UploadAgentBundleIndexingSummary'
         indexedAt:
           type: string
           format: date-time
@@ -224,7 +349,7 @@ components:
     UploadAgentBundleReplayResponse:
       type: object
       additionalProperties: false
-      required: [agentId, version, status, result, replay]
+      required: [agentId, version, status, result, indexing, replay]
       properties:
         agentId:
           type: string
@@ -238,11 +363,53 @@ components:
         result:
           type: string
           enum: [RETURNED_EXISTING]
+        indexing:
+          $ref: '#/components/schemas/UploadAgentBundleIndexingSummary'
         replay:
           $ref: '#/components/schemas/AgentBundleVersionReplay'
         indexedAt:
           type: string
           format: date-time
+
+    UploadAgentBundleIndexingSummary:
+      type: object
+      additionalProperties: false
+      required: [status, indexedSkillCount, memoryMode, skills]
+      properties:
+        status:
+          type: string
+          enum: [INDEXED]
+        indexedSkillCount:
+          type: integer
+          minimum: 0
+        memoryMode:
+          type: string
+          enum: [INDEX_ONLY, ENCRYPTED_REF, FULL]
+        skills:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentSkillIndexRecord'
+
+    AgentSkillIndexRecord:
+      type: object
+      additionalProperties: false
+      required: [skillId, version, sourceAgentId, sourceVersion]
+      properties:
+        skillId:
+          type: string
+        version:
+          type: string
+          pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        sourceAgentId:
+          type: string
+          pattern: '^agent_[a-zA-Z0-9_-]{8,64}$'
+        sourceVersion:
+          type: string
+          pattern: '^[0-9]+\.[0-9]+\.[0-9]+$'
+        tags:
+          type: array
+          items:
+            type: string
 
     UploadAgentBundleValidationErrorResponse:
       type: object


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #4
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/spec`
- Scope: P1-02 onboarding pipeline contract, indexing summary, and retry guidance

## What Changed

- Added `docs/ONBOARDING_PIPELINE.md` to define the deterministic onboarding pipeline order, skill-index contract, backend handoff, and upload retry guidance.
- Extended `src/api/openapi.yaml` with onboarding pipeline descriptions, concrete request/response examples, signer-mismatch example, and indexing summary schemas.
- Extended `src/api/contracts.ts` with `UploadAgentBundleIndexingSummary` and `AgentSkillIndexRecord`, and included indexing summaries in created/replay responses.
- Updated `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md` to require matching-ready skill indexes in successful upload responses.
- Marked OpenSpec tasks `2.2` and `2.3` complete in `openspec/changes/agent-dispatch-platform/tasks.md`.

## Why

- `#4` is the next kestrel-owned backend dependency after the AgentBundle contract baseline and blocks matching/bidding work from relying on a stable onboarding ingestion contract.
- The repo had bundle validation and conflict errors, but it did not yet define the full stage ordering, matching-ready index output, or explicit retry behavior for upload clients.
- This PR turns the onboarding pipeline into a reviewable, testable contract shared across OpenSpec, OpenAPI, and TypeScript.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Valid signed bundle returns `agent_id` and `version`. | `201` success response remains the accepted path and now includes deterministic indexing details for the accepted bundle. | `src/api/openapi.yaml`, `src/api/contracts.ts`, `docs/ONBOARDING_PIPELINE.md` |
| Invalid signature is rejected with audit-friendly error code. | Added explicit signer-mismatch example and documented signature validation as a fixed early pipeline stage. | `src/api/openapi.yaml`, `docs/ONBOARDING_PIPELINE.md`, `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md` |
| Skills metadata is indexed for matching. | Added a matching-ready skill index response contract and a dedicated onboarding pipeline doc that defines the index records produced per accepted upload. | `src/api/contracts.ts`, `src/api/openapi.yaml`, `docs/ONBOARDING_PIPELINE.md`, `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md` |

## QA Plan

### Preconditions

- OpenSpec CLI is installed.
- Node/npm is available to run `swagger-cli` via `npx`.

### Steps

1. Run `openspec validate --all`.
2. Run `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`.
3. Inspect `docs/ONBOARDING_PIPELINE.md`, `src/api/openapi.yaml`, and `src/api/contracts.ts` together to confirm the indexing summary fields match.

### Expected Results

- OpenSpec validation passes for `agent-dispatch-platform`.
- OpenAPI validation passes with the new onboarding schemas/examples.
- The onboarding pipeline stage order, retry guidance, and indexing response shapes are consistent across docs/spec/contracts.

### Validation Output

- `openspec validate --all`
  - `✓ change/agent-dispatch-platform`
- `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`
  - `src/api/openapi.yaml is valid`

## Risks and Rollback

- Risk:
  - Adds richer success payloads to the onboarding draft, so any future implementation must keep the indexing summary synchronized with matching ingestion.
- Rollback:
  - Revert this PR to restore the prior minimal upload response contract and remove the pipeline doc/task updates.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
