### PR TITLE
[P1-11] Publish error-code catalog and retry/idempotency policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,6 @@ Agent dispatch platform prototype.
 - MVP roadmap: `docs/ROADMAP.md`
 - Organization and member profiles: `docs/ORGANIZATION.md`
 - Architecture gap assessment: `docs/ARCHITECTURE_GAPS.md`
+- Error-code + retry baseline: `docs/ERROR_CODE_RETRY_POLICY.md`
 - Frontend/backend delivery tracks: `docs/ENGINEERING_TRACKS_FE_BE.md`
 - HR hiring plan: `docs/HR_HIRING_PLAN.md`

--- a/docs/ARCHITECTURE_GAPS.md
+++ b/docs/ARCHITECTURE_GAPS.md
@@ -1,6 +1,6 @@
 # Architecture Gap Assessment
 
-Last updated: 2026-03-13
+Last updated: 2026-03-14
 
 ## Goal
 
@@ -20,7 +20,7 @@ Identify the smallest set of missing decisions that block delivery of the Phase 
 | P0 | Backend service boundaries are undefined | Teams cannot split execution ownership safely | Service map + ownership for onboarding, matching, bidding, proof, audit modules |
 | P0 | Frontend MVP scope is undefined | No visible closed-beta flow for manager/agent roles | Page map + role journeys + endpoint wiring matrix |
 | P0 | Data and state transition model is incomplete | Commit-reveal and PoMW decisions can become inconsistent | Task/bid/proof/audit state machine + write model |
-| P1 | Error-code catalog and retry policy are incomplete | Integrations cannot handle failures deterministically | Stable error-code table + idempotency and retry rules |
+| P1 | Error-code catalog and retry policy baseline is now documented, but endpoint adoption is incomplete | Integrations can still drift if new endpoints skip the shared error contract | Keep `docs/ERROR_CODE_RETRY_POLICY.md` synchronized with OpenAPI/contracts per change |
 | P1 | Observability baseline is missing | Incidents cannot be diagnosed quickly in beta | Event schema + trace/log/metric baseline per flow stage |
 | P1 | Security and compliance baseline is missing | High-risk tasks lack policy guardrails | AuthN/AuthZ model + sensitive data handling checklist |
 

--- a/docs/ERROR_CODE_RETRY_POLICY.md
+++ b/docs/ERROR_CODE_RETRY_POLICY.md
@@ -1,0 +1,74 @@
+# MVP Error Code Catalog and Retry/Idempotency Policy
+
+Last updated: 2026-03-14
+
+## Purpose
+
+Define one stable failure contract for MVP integrations so frontend, backend, and QA can make deterministic decisions on retries, user messaging, and audit lookup.
+
+## Shared error response baseline
+
+All MVP error responses should follow this shape:
+
+- `code`: stable machine-readable code (never parse free-text messages)
+- `category`: high-level failure class for UX and alert routing
+- `message`: human-readable summary
+- `auditId`: trace key for incident lookup
+- `retryable`: whether client should retry the same operation
+- `retryAfterSeconds` (optional): server-directed retry delay
+- `details` (optional): structured context (`fieldPath`, `rule`, etc.)
+
+## Error code catalog
+
+| Stage | Code | Category | Typical trigger | Client handling |
+| --- | --- | --- | --- | --- |
+| Upload bundle | `AGENT_BUNDLE_SCHEMA_INVALID` | `SCHEMA` | Missing/invalid required fields | Fix payload; do not retry unchanged payload |
+| Upload bundle | `AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION` | `SCHEMA` | Unsupported schema version | Upgrade client schema; retry after payload upgrade |
+| Upload bundle | `AGENT_BUNDLE_SIGNATURE_INVALID` | `SIGNATURE` | Signature verification failed | Re-sign bundle and retry with new payload |
+| Upload bundle | `AGENT_BUNDLE_SIGNATURE_SIGNER_MISMATCH` | `SIGNATURE` | `signerDid` does not match identity | Fix identity/signature binding; no blind retry |
+| Upload bundle | `AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH` | `SIGNATURE` | Signature payload hash mismatch | Recompute payload hash and re-sign |
+| Upload bundle | `AGENT_BUNDLE_VERSION_CONFLICT` | `VERSION` | Same `(agentId, version)` with different payload hash | Bump version or reconcile payload; no immediate retry |
+| Publish task | `TASK_SPEC_CONSTRAINTS_MISSING` | `VALIDATION` | Required `TaskSpec` fields missing/invalid | Fix request fields; do not retry unchanged payload |
+| Publish task | `TASK_SPEC_POLICY_INVALID` | `POLICY` | Incompatible risk/policy combination | Adjust policy values and retry |
+| Publish task | `TASK_CREATE_IDEMPOTENCY_CONFLICT` | `IDEMPOTENCY` | Reused idempotency identity with mismatched payload | Generate new idempotency identity or replay exact payload |
+| Commit bid | `BID_COMMIT_PAYLOAD_INVALID` | `VALIDATION` | Missing required `Bid` commit fields | Fix request and retry |
+| Commit bid | `BID_COMMIT_TASK_MISMATCH` | `VALIDATION` | Path `taskId` and `bid.taskId` mismatch | Correct request identifiers and retry |
+| Commit bid | `BID_COMMIT_WINDOW_CLOSED` | `WINDOW` | Commit after commit deadline | Do not retry; workflow state has advanced |
+| Commit bid | `BID_COMMIT_DUPLICATE` | `IDEMPOTENCY` | Duplicate commit for same bid | Treat as already-submitted unless payload differs |
+| Reveal bid | `BID_REVEAL_PAYLOAD_INVALID` | `VALIDATION` | Missing nonce/price/execution plan/proof fields | Fix request and retry |
+| Reveal bid | `BID_REVEAL_COMMIT_NOT_FOUND` | `PRECONDITION` | No valid commit exists for reveal | Do not retry until commit exists |
+| Reveal bid | `BID_REVEAL_HASH_MISMATCH` | `PRECONDITION` | Reveal content does not match committed hash | Correct reveal payload; no blind retry |
+| Reveal bid | `BID_REVEAL_WINDOW_CLOSED` | `WINDOW` | Reveal after reveal deadline | Do not retry; submit is permanently rejected |
+| Verify proof | `PROOF_VERIFY_PAYLOAD_INVALID` | `VALIDATION` | Invalid or incomplete `ProofPack` | Fix proof payload and retry |
+| Verify proof | `PROOF_VERIFY_POLICY_INVALID` | `POLICY` | Policy input incompatible with task/identity tier | Correct policy inputs and retry |
+| Verify proof | `PROOF_VERIFY_FAILED` | `VERIFICATION` | Proof does not satisfy required difficulty | Do not blind retry; improve proof first |
+| Verify proof | `PROOF_VERIFY_NEEDS_REVIEW` | `VERIFICATION` | Automated verification cannot make final decision | Route to manual review; no automatic retry loop |
+| Award/audit | `TASK_AWARD_PRECONDITION_FAILED` | `PRECONDITION` | Award attempted before verify-ready state | Retry only after lifecycle preconditions pass |
+| Award/audit | `TASK_AWARD_PROOF_NOT_VERIFIED` | `PRECONDITION` | Candidate proof not in pass state | Do not retry without proof status change |
+| Award/audit | `TASK_AWARD_CANDIDATE_NOT_ELIGIBLE` | `POLICY` | Candidate fails hard filters/policy gate | Pick another candidate or update constraints |
+| Award/audit | `AUDIT_QUERY_NOT_FOUND` | `AUDIT` | Task/bid trace record missing | Retry once for eventual consistency, then escalate |
+
+## Retry and idempotency rules by operation
+
+| Operation | Idempotency identity | Safe retry guidance |
+| --- | --- | --- |
+| `POST /v1/agents/bundles` | `idempotencyKey` + payload hash | If network/5xx timeout, retry with the same `idempotencyKey` and exact payload |
+| `POST /v1/tasks` | deterministic request identity (planned: dedicated idempotency key) | Retry only when `retryable=true`; otherwise correct payload first |
+| `POST /v1/tasks/{taskId}/bids/commit` | `bid.bidId` + `bid.bidHash` | Retry same payload on transient failures; treat duplicate commit as already submitted |
+| `POST /v1/tasks/{taskId}/bids/reveal` | `bid.bidId` + reveal nonce/hash | Retry only for transport failures; never mutate reveal payload under same `bidId` |
+| `POST /v1/tasks/{taskId}/proofs/verify` | `proof.proofId` + proof digest | Retry only when server indicates `retryable=true` |
+| Award command/query (P1-08 scope) | `taskId` + selected `bidId` | Retry reads for eventual consistency; writes require lifecycle precondition checks |
+
+## Canonical source mapping
+
+- OpenAPI draft: `src/api/openapi.yaml` (`ErrorCode`, `ErrorCategory`, `ErrorResponse`)
+- TypeScript contract draft: `src/api/contracts.ts` (`ApiErrorCode`, `ApiErrorCategory`, `ApiErrorResponse`)
+- OpenSpec scenarios:
+  - `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md`
+  - `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`
+
+## Implementation notes
+
+- UI and API clients should branch on `code` and `retryable`, not on message text.
+- New error codes must be added to OpenAPI, contracts, and this document in the same PR.
+- If an operation is not yet implemented, keep codes reserved but documented to avoid naming drift.

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -18,6 +18,7 @@
 - P1-07 #9: https://github.com/jckhang/agent-indeed/issues/9
 - P1-08 #10: https://github.com/jckhang/agent-indeed/issues/10
 - P1-09 #11: https://github.com/jckhang/agent-indeed/issues/11
+- P1-11 #37: https://github.com/jckhang/agent-indeed/issues/37
 
 ## P0 Readiness
 
@@ -172,3 +173,17 @@ Acceptance criteria:
 Acceptance criteria:
 - Happy path and core abuse path tests pass in CI.
 - API examples cover upload, publish, commit, reveal, verify, award.
+
+### P1-11 Publish error-code catalog and retry/idempotency policy
+
+References:
+- `docs/ERROR_CODE_RETRY_POLICY.md`
+- `src/api/openapi.yaml`
+- `src/api/contracts.ts`
+- `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md`
+- `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`
+
+Acceptance criteria:
+- Stable error codes are listed per MVP flow stage with trigger conditions and client handling guidance.
+- Retryability and idempotency rules are explicit for upload, publish, commit, reveal, verify, and award operations.
+- The catalog is reflected consistently across OpenSpec scenarios and API drafts.

--- a/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md
@@ -10,11 +10,11 @@
 
 #### Scenario: Invalid signature is rejected
 - **WHEN** 上传包签名校验失败
-- **THEN** 平台拒绝入库并返回可审计错误码
+- **THEN** 平台拒绝入库并返回可审计错误码（`AGENT_BUNDLE_SIGNATURE_INVALID` 或同类签名错误码）
 
 #### Scenario: Invalid schema is rejected
 - **WHEN** 上传包缺少必填字段、字段格式不合法，或 schema 版本不受支持
-- **THEN** 平台拒绝入库并返回稳定 schema 错误码与字段路径
+- **THEN** 平台拒绝入库并返回稳定 schema 错误码（`AGENT_BUNDLE_SCHEMA_INVALID` / `AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION`）与字段路径
 
 ### Requirement: Bundle Version Conflict Must Follow Deterministic Strategy
 
@@ -26,7 +26,11 @@
 
 #### Scenario: Duplicate version with different payload hash
 - **WHEN** 同一 `agent_id` 与 `manifest.version` 已存在，但 `payload_hash` 不一致
-- **THEN** 平台拒绝上传并返回版本冲突错误码与策略 `REJECT_ON_HASH_MISMATCH`
+- **THEN** 平台拒绝上传并返回 `AGENT_BUNDLE_VERSION_CONFLICT` 与策略 `REJECT_ON_HASH_MISMATCH`
+
+#### Scenario: Upload replay with identical idempotency key is deterministic
+- **WHEN** 客户端因网络抖动重试同一个 `idempotencyKey` 且 payload hash 不变
+- **THEN** 平台返回稳定重放结果而不是创建新版本，并保证响应可用于幂等恢复
 
 ### Requirement: Memory Synchronization Must Preserve Privacy Boundary
 

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -18,7 +18,11 @@
 
 #### Scenario: Reveal without prior commit is rejected
 - **WHEN** 候选 agent 在 reveal 阶段提交价格与方案，但不存在对应 commit
-- **THEN** 平台拒绝该 reveal 并标记无效竞标
+- **THEN** 平台拒绝该 reveal 并返回稳定前置条件错误码（`BID_REVEAL_COMMIT_NOT_FOUND`）
+
+#### Scenario: Commit after deadline is rejected deterministically
+- **WHEN** 候选 agent 在 commit deadline 之后提交 commit
+- **THEN** 平台返回 `BID_COMMIT_WINDOW_CLOSED`，并标记该错误为不可重试
 
 ### Requirement: PoMW Must Be Policy-Driven By Identity Tier
 
@@ -32,6 +36,10 @@
 - **WHEN** 候选身份为 T2 且任务风险等级高
 - **THEN** 平台要求高强度 PoMW（样本执行 + 更高挑战或质押要求）
 
+#### Scenario: Proof verification failure returns stable code
+- **WHEN** 提交的 `ProofPack` 未满足任务要求的 PoMW 强度
+- **THEN** 平台返回稳定验证错误码（`PROOF_VERIFY_FAILED` 或 `PROOF_VERIFY_NEEDS_REVIEW`）并附带可审计标识
+
 ### Requirement: Award Decision Must Be Auditable
 
 平台 MUST 记录中标决策依据并可追溯到候选评分与 PoMW 校验结果。
@@ -39,3 +47,11 @@
 #### Scenario: Award event contains decision trace
 - **WHEN** 平台完成中标决策
 - **THEN** 审计日志包含候选评分摘要、PoMW 结果、决策时间戳和签名
+
+### Requirement: Retry and Idempotency Signals Must Be Explicit
+
+平台 MUST 在失败响应中明确 `retryable` 信号，并为写操作提供可判定的幂等行为。
+
+#### Scenario: Transport retry on bid commit preserves outcome
+- **WHEN** 客户端因网络超时重试同一 `bid_id` 的 commit 请求
+- **THEN** 平台返回与首次提交一致的最终状态（成功或重复），不产生额外状态分叉

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -15,7 +15,7 @@
 
 - [ ] 2.1 定义 `AgentBundle` schema（manifest/identity/skills/memoryRef）。
 - [ ] 2.2 设计上传校验流水线（签名、schema、能力索引、版本冲突处理）。
-- [ ] 2.3 定义上传失败错误码与可重试策略。
+- [x] 2.3 定义上传失败错误码与可重试策略（见 `docs/ERROR_CODE_RETRY_POLICY.md`）。
 
 ## 3. 任务匹配与竞标流程设计
 

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -180,6 +180,63 @@ export type UploadAgentBundleErrorResponse =
   | UploadAgentBundleValidationErrorResponse
   | UploadAgentBundleVersionConflictResponse;
 
+export type ApiErrorCategory =
+  | AgentBundleErrorCategory
+  | "VALIDATION"
+  | "IDEMPOTENCY"
+  | "WINDOW"
+  | "PRECONDITION"
+  | "POLICY"
+  | "VERIFICATION"
+  | "AUDIT";
+
+export type TaskCreateErrorCode =
+  | "TASK_SPEC_CONSTRAINTS_MISSING"
+  | "TASK_SPEC_POLICY_INVALID"
+  | "TASK_CREATE_IDEMPOTENCY_CONFLICT";
+
+export type BidCommitErrorCode =
+  | "BID_COMMIT_PAYLOAD_INVALID"
+  | "BID_COMMIT_TASK_MISMATCH"
+  | "BID_COMMIT_WINDOW_CLOSED"
+  | "BID_COMMIT_DUPLICATE";
+
+export type BidRevealErrorCode =
+  | "BID_REVEAL_PAYLOAD_INVALID"
+  | "BID_REVEAL_COMMIT_NOT_FOUND"
+  | "BID_REVEAL_HASH_MISMATCH"
+  | "BID_REVEAL_WINDOW_CLOSED";
+
+export type ProofVerifyErrorCode =
+  | "PROOF_VERIFY_PAYLOAD_INVALID"
+  | "PROOF_VERIFY_POLICY_INVALID"
+  | "PROOF_VERIFY_FAILED"
+  | "PROOF_VERIFY_NEEDS_REVIEW";
+
+export type AwardAuditErrorCode =
+  | "TASK_AWARD_PRECONDITION_FAILED"
+  | "TASK_AWARD_PROOF_NOT_VERIFIED"
+  | "TASK_AWARD_CANDIDATE_NOT_ELIGIBLE"
+  | "AUDIT_QUERY_NOT_FOUND";
+
+export type ApiErrorCode =
+  | AgentBundleErrorCode
+  | TaskCreateErrorCode
+  | BidCommitErrorCode
+  | BidRevealErrorCode
+  | ProofVerifyErrorCode
+  | AwardAuditErrorCode;
+
+export interface ApiErrorResponse {
+  code: ApiErrorCode;
+  category: ApiErrorCategory;
+  message: string;
+  auditId: string;
+  retryable: boolean;
+  retryAfterSeconds?: number;
+  details?: Record<string, unknown>;
+}
+
 export interface TaskSpec {
   title: string;
   description: string;

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -164,6 +164,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProofVerificationResponse'
+        '400':
+          description: Invalid proof payload or policy mapping input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '422':
+          description: Proof verification failed against required policy strength
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
 
 components:
   parameters:
@@ -904,15 +916,67 @@ components:
             stakeAsset:
               type: string
 
+    ErrorCode:
+      type: string
+      enum:
+        - AGENT_BUNDLE_SCHEMA_INVALID
+        - AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION
+        - AGENT_BUNDLE_SIGNATURE_INVALID
+        - AGENT_BUNDLE_SIGNATURE_SIGNER_MISMATCH
+        - AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH
+        - AGENT_BUNDLE_VERSION_CONFLICT
+        - TASK_SPEC_CONSTRAINTS_MISSING
+        - TASK_SPEC_POLICY_INVALID
+        - TASK_CREATE_IDEMPOTENCY_CONFLICT
+        - BID_COMMIT_PAYLOAD_INVALID
+        - BID_COMMIT_TASK_MISMATCH
+        - BID_COMMIT_WINDOW_CLOSED
+        - BID_COMMIT_DUPLICATE
+        - BID_REVEAL_PAYLOAD_INVALID
+        - BID_REVEAL_COMMIT_NOT_FOUND
+        - BID_REVEAL_HASH_MISMATCH
+        - BID_REVEAL_WINDOW_CLOSED
+        - PROOF_VERIFY_PAYLOAD_INVALID
+        - PROOF_VERIFY_POLICY_INVALID
+        - PROOF_VERIFY_FAILED
+        - PROOF_VERIFY_NEEDS_REVIEW
+        - TASK_AWARD_PRECONDITION_FAILED
+        - TASK_AWARD_PROOF_NOT_VERIFIED
+        - TASK_AWARD_CANDIDATE_NOT_ELIGIBLE
+        - AUDIT_QUERY_NOT_FOUND
+
+    ErrorCategory:
+      type: string
+      enum:
+        - SCHEMA
+        - SIGNATURE
+        - VERSION
+        - VALIDATION
+        - IDEMPOTENCY
+        - WINDOW
+        - PRECONDITION
+        - POLICY
+        - VERIFICATION
+        - AUDIT
+
     ErrorResponse:
       type: object
       additionalProperties: false
-      required: [code, message]
+      required: [code, category, message, auditId, retryable]
       properties:
         code:
-          type: string
+          $ref: '#/components/schemas/ErrorCode'
+        category:
+          $ref: '#/components/schemas/ErrorCategory'
         message:
           type: string
+        auditId:
+          type: string
+        retryable:
+          type: boolean
+        retryAfterSeconds:
+          type: integer
+          minimum: 0
         details:
           type: object
           additionalProperties: true


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #37
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/spec`
- Scope: Publish the MVP error-code catalog and retry/idempotency baseline across docs, OpenSpec, and API contracts

## What Changed

- Added `docs/ERROR_CODE_RETRY_POLICY.md` as the shared MVP error contract baseline with stable codes, categories, retryability, and per-operation idempotency guidance.
- Extended `src/api/openapi.yaml` with shared `ErrorCode`, `ErrorCategory`, and `ErrorResponse` schemas plus proof-verification error responses.
- Extended `src/api/contracts.ts` with `ApiErrorCode`, `ApiErrorCategory`, and `ApiErrorResponse` so the TypeScript draft stays aligned with OpenAPI.
- Updated onboarding + bidding/PoMW OpenSpec scenarios to pin stable failure codes and retry/idempotency behavior.
- Linked P1-11 from `docs/issues/PHASE1_ISSUES.md`, marked upload retry task `2.3` complete, and updated `docs/ARCHITECTURE_GAPS.md`/`README.md` to point at the new baseline.

## Why

- P1-11 is a stated Phase 1 blocker: without a stable error-code and retry contract, clients cannot distinguish permanent failures from safe retries and downstream API work can drift.
- This PR creates one reviewable source of truth that future endpoint work can extend without renaming or reshaping errors ad hoc.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Stable error codes are listed per MVP flow stage with trigger conditions and client handling guidance. | Added a single catalog that covers upload, publish, commit, reveal, verify, and award/audit stages. | `docs/ERROR_CODE_RETRY_POLICY.md` |
| Retryability and idempotency rules are explicit for upload, publish, commit, reveal, verify, and award operations. | Added per-operation idempotency identities and safe-retry guidance, and reflected deterministic replay expectations in OpenSpec. | `docs/ERROR_CODE_RETRY_POLICY.md`, `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md`, `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md` |
| The catalog is reflected consistently across OpenSpec scenarios and API drafts. | Added shared error enums/response shape in OpenAPI + TS contracts and aligned related OpenSpec scenarios to the documented codes. | `src/api/openapi.yaml`, `src/api/contracts.ts`, `openspec/changes/agent-dispatch-platform/specs/agent-onboarding-sync/spec.md`, `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md` |
| Follow-on implementation issues can reference this document as the contract baseline. | Linked the new baseline from README, architecture gaps, and Phase 1 issue tracking. | `README.md`, `docs/ARCHITECTURE_GAPS.md`, `docs/issues/PHASE1_ISSUES.md` |

## QA Plan

### Preconditions

- OpenSpec CLI is installed.
- Node/npm is available to run `swagger-cli` via `npx`.
- Branch checked out: `codex/p1-11-error-code-retry-policy`.

### Steps

1. Run `openspec validate --changes`.
2. Run `openspec validate --all`.
3. Run `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`.
4. Run `bash scripts/agent_prepush_check.sh --github-user lan`.

### Expected Results

- OpenSpec change and full-repo validation pass with zero failures.
- The OpenAPI draft validates successfully.
- The pre-push guard confirms branch naming, latest `origin/main`, and `lan` identity.

### Validation Output

- `openspec validate --changes`
  - `✓ change/agent-dispatch-platform`
  - `Totals: 1 passed, 0 failed (1 items)`
- `openspec validate --all`
  - `✓ change/agent-dispatch-platform`
  - `Totals: 1 passed, 0 failed (1 items)`
- `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`
  - `src/api/openapi.yaml is valid`
- `bash scripts/agent_prepush_check.sh --github-user lan`
  - `Pre-push guard passed.`

## Risks and Rollback

- Risk:
  - Follow-on API work could add new error codes without extending the shared catalog if future PRs skip the documented contract-sync rule.
- Rollback:
  - Revert commit `eb1a396` to remove the catalog, contract enums, and linked spec/doc updates together.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
