### PR TITLE
[P1-03] Define TaskSpec publication behavior

### DIFF
--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -23,11 +23,12 @@ Ship the first usable agent dispatch loop for closed beta:
 
 ### G2. Task publication and matching baseline
 
-- `TaskSpec` schema finalized (budget, SLA, constraints, risk).
+- `TaskSpec` schema finalized (budget, SLA, constraints, risk, PoMW policy, bidding window).
 - Candidate retrieval with hard filters:
   - identity threshold
   - required skills
   - compliance flags
+- Task publish response exposes marketplace admission and matching trigger timing.
 - Soft ranking baseline:
   - success rate
   - latency

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -133,6 +133,8 @@ References:
 Acceptance criteria:
 - Required constraints enforced at task creation.
 - Task status enters marketplace when constraints are complete.
+- Publish requests carry an `idempotencyKey` and return marketplace admission metadata.
+- Invalid publication windows or incomplete constraints return typed validation codes.
 
 ### P1-04 Implement candidate matching baseline (hard + soft)
 

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -1,12 +1,23 @@
 ## ADDED Requirements
 
-### Requirement: Task Publication Must Include Matching Constraints
+### Requirement: Task Publication Must Include Complete Marketplace Constraints
 
-平台 MUST 要求任务发布时声明候选筛选所需约束（身份、技能、预算、SLA、风险级别）。
+平台 MUST 要求任务发布时提交完整的 `TaskSpec`，至少覆盖预算、SLA、身份门槛、技能需求、风险分级、PoMW 策略与竞标窗口，才允许进入 marketplace。
 
 #### Scenario: Task with complete constraints enters marketplace
-- **WHEN** manager 提交包含匹配约束的 `TaskSpec`
-- **THEN** 任务进入可竞标状态并触发候选检索
+- **WHEN** manager 提交包含完整约束的 `TaskSpec`
+- **THEN** 平台创建任务并返回可进入 marketplace 的状态
+- **AND** 平台记录候选检索已被触发
+
+#### Scenario: Missing matching constraints is rejected
+- **WHEN** manager 提交的 `TaskSpec` 缺少 `constraints.identityTierMin` 或 `constraints.requiredSkills`
+- **THEN** 平台拒绝发布请求
+- **AND** 返回错误码 `TASK_CONSTRAINTS_INCOMPLETE`
+
+#### Scenario: Invalid publication timing is rejected
+- **WHEN** manager 提交的 `TaskSpec` 中 `biddingWindow.revealDeadline` 早于或等于 `biddingWindow.commitDeadline`
+- **THEN** 平台拒绝发布请求
+- **AND** 返回错误码 `TASK_BIDDING_WINDOW_INVALID`
 
 ### Requirement: Bidding Must Use Commit-Reveal
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -19,7 +19,7 @@
 
 ## 3. 任务匹配与竞标流程设计
 
-- [ ] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
+- [x] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
 - [ ] 3.2 实现候选筛选策略（硬过滤 + 软排序）与评分字段。
 - [ ] 3.3 设计 commit-reveal 竞标接口与时序约束。
 

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -180,6 +180,19 @@ export type UploadAgentBundleErrorResponse =
   | UploadAgentBundleValidationErrorResponse
   | UploadAgentBundleVersionConflictResponse;
 
+export type TaskCreationErrorCode =
+  | "TASK_CONSTRAINTS_INCOMPLETE"
+  | "TASK_BUDGET_RANGE_INVALID"
+  | "TASK_BIDDING_WINDOW_INVALID"
+  | "TASK_POWM_POLICY_INVALID";
+
+export interface TaskCreationValidationErrorDetails {
+  fieldPath?: string;
+  rule?: string;
+  expected?: string;
+  actual?: string;
+}
+
 export interface TaskSpec {
   title: string;
   description: string;
@@ -215,6 +228,27 @@ export interface TaskSpec {
     commitDeadline: string;
     revealDeadline: string;
   };
+}
+
+export interface CreateTaskRequest {
+  idempotencyKey: string;
+  task: TaskSpec;
+}
+
+export interface CreateTaskResponse {
+  taskId: string;
+  status: "OPEN_FOR_MATCHING" | "OPEN_FOR_BIDDING";
+  marketplaceAdmission: "ADMITTED";
+  matchingTriggeredAt?: string;
+  commitDeadline?: string;
+  revealDeadline?: string;
+}
+
+export interface CreateTaskValidationErrorResponse {
+  code: TaskCreationErrorCode;
+  message: string;
+  retryable: boolean;
+  details?: TaskCreationValidationErrorDetails;
 }
 
 export interface ProofPack {

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -66,17 +66,17 @@ paths:
               $ref: '#/components/schemas/CreateTaskRequest'
       responses:
         '201':
-          description: Task created and opened for candidate matching
+          description: Task created, admitted into marketplace, and opened for matching
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/CreateTaskResponse'
         '400':
-          description: Missing constraints or invalid policy
+          description: Missing marketplace constraints or invalid publication policy
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/CreateTaskValidationErrorResponse'
 
   /v1/tasks/{taskId}/bids/commit:
     post:
@@ -353,15 +353,20 @@ components:
     CreateTaskRequest:
       type: object
       additionalProperties: false
-      required: [task]
+      required: [idempotencyKey, task]
       properties:
+        idempotencyKey:
+          type: string
+          minLength: 8
+          maxLength: 128
+          example: publish-task-20260314-001
         task:
           $ref: '#/components/schemas/TaskSpec'
 
     CreateTaskResponse:
       type: object
       additionalProperties: false
-      required: [taskId, status]
+      required: [taskId, status, marketplaceAdmission]
       properties:
         taskId:
           type: string
@@ -369,12 +374,65 @@ components:
         status:
           type: string
           enum: [OPEN_FOR_MATCHING, OPEN_FOR_BIDDING]
+          description: OPEN_FOR_MATCHING is the default publish state until shortlist generation completes.
+        marketplaceAdmission:
+          type: string
+          enum: [ADMITTED]
+        matchingTriggeredAt:
+          type: string
+          format: date-time
+          description: Timestamp when candidate retrieval was queued.
         commitDeadline:
           type: string
           format: date-time
         revealDeadline:
           type: string
           format: date-time
+      example:
+        taskId: task_9fJ2akLm31
+        status: OPEN_FOR_MATCHING
+        marketplaceAdmission: ADMITTED
+        matchingTriggeredAt: '2026-03-14T04:20:00Z'
+        commitDeadline: '2026-03-14T06:20:00Z'
+        revealDeadline: '2026-03-14T07:20:00Z'
+
+    CreateTaskValidationErrorResponse:
+      type: object
+      additionalProperties: false
+      required: [code, message, retryable]
+      properties:
+        code:
+          type: string
+          enum:
+            - TASK_CONSTRAINTS_INCOMPLETE
+            - TASK_BUDGET_RANGE_INVALID
+            - TASK_BIDDING_WINDOW_INVALID
+            - TASK_POWM_POLICY_INVALID
+        message:
+          type: string
+        retryable:
+          type: boolean
+        details:
+          type: object
+          additionalProperties: false
+          properties:
+            fieldPath:
+              type: string
+            rule:
+              type: string
+            expected:
+              type: string
+            actual:
+              type: string
+      example:
+        code: TASK_BIDDING_WINDOW_INVALID
+        message: revealDeadline must be later than commitDeadline
+        retryable: true
+        details:
+          fieldPath: task.biddingWindow.revealDeadline
+          rule: gt
+          expected: later than commitDeadline
+          actual: '2026-03-14T05:20:00Z'
 
     CommitBidRequest:
       type: object
@@ -674,6 +732,7 @@ components:
             maxAmount:
               type: number
               minimum: 0
+              description: Must be greater than or equal to minAmount.
             settlementModel:
               type: string
               enum: [FIXED, MILESTONE, TIME_AND_MATERIAL]
@@ -756,6 +815,39 @@ components:
             revealDeadline:
               type: string
               format: date-time
+              description: Must be later than commitDeadline.
+      example:
+        title: Rank multilingual customer support candidates
+        description: Match agents that can handle multilingual support triage within beta latency targets.
+        budget:
+          currency: USD
+          minAmount: 150
+          maxAmount: 300
+          settlementModel: FIXED
+        sla:
+          deadlineAt: '2026-03-16T12:00:00Z'
+          maxLatencyMs: 1500
+          minSuccessRate: 0.97
+        constraints:
+          identityTierMin: T1
+          requiredSkills:
+            - skill_customer_support_triage
+            - skill_multilingual_routing
+          preferredSkills:
+            - skill_crm_sync
+          complianceTags:
+            - pii-safe
+        risk:
+          level: MEDIUM
+          valueScore: 0.65
+          abuseSensitivity: MEDIUM
+        powmPolicy:
+          mode: AUTO_TIERED
+          baseDifficulty: 0.4
+          challengeType: SAMPLE_EXECUTION
+        biddingWindow:
+          commitDeadline: '2026-03-14T06:20:00Z'
+          revealDeadline: '2026-03-14T07:20:00Z'
 
     Bid:
       type: object


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): Closes #5
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/spec`
- Scope: Define TaskSpec publication contract and marketplace admission behavior

## What Changed

- tightened the OpenSpec task marketplace requirement so TaskSpec completeness and publication timing are explicit
- updated the task publication OpenAPI contract with `idempotencyKey`, marketplace admission metadata, typed validation errors, and concrete examples
- synced TypeScript contracts for task creation request/response/error payloads
- refreshed Phase 1 planning docs to reflect the finalized TaskSpec publication behavior

## Why

- issue #5 is the highest-impact unstarted backend/API dependency because task publication gates matching, bidding, and downstream PoMW flow
- the previous draft did not fully specify what makes a task publishable or what payload/response shape callers can rely on
- this PR is executed by the kestrel-dev-agent lane using the `jckhang` GitHub identity per repo policy

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Required constraints enforced at task creation. | OpenSpec and OpenAPI now require complete TaskSpec constraints and define typed validation errors for incomplete constraints / invalid timing. | `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |
| Task status enters marketplace when constraints are complete. | Successful create responses now return marketplace admission metadata plus matching-trigger timing and default publish status semantics. | `src/api/openapi.yaml`, `src/api/contracts.ts`, `docs/PHASE1_GOALS.md` |

## QA Plan

### Preconditions

- `main` is up to date before branching
- OpenSpec CLI and Node/npm are available locally

### Steps

1. Run `openspec validate --changes`
2. Run `openspec validate --all`
3. Run `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`
4. Run `bash scripts/agent_prepush_check.sh --github-user jckhang`

### Expected Results

- OpenSpec change validates successfully
- full OpenSpec validation passes
- OpenAPI document validates successfully
- pre-push guard confirms branch naming, baseline sync, and git identity

### Validation Output

- `openspec validate --changes`
- `openspec validate --all`
- `npx --yes @apidevtools/swagger-cli validate src/api/openapi.yaml`
- `bash scripts/agent_prepush_check.sh --github-user jckhang`

## Risks and Rollback

- Risk:
  - downstream consumers may need to add `idempotencyKey` and handle typed task publication errors
  - later implementation work may refine status transitions once matching runtime exists
- Rollback:
  - revert commit `0fa22fe` to restore the prior draft contract if follow-up work rejects this publication shape

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
