### PR TITLE
[P0-09] Operationalize roadmap checkpoints as GitHub milestones/status board

### DIFF
--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -1,0 +1,47 @@
+# Phase 1 Checkpoint Board
+
+Last updated: 2026-03-14
+
+This is the single review surface for milestone drift across active Phase 1 issues and PRs.
+
+## Checkpoint Summary
+
+| Checkpoint | Target date | Checkpoint owner | Scope | Active issues | Active PRs | Status | Drift / next action |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | Contract finalization, observability baseline, onboarding kickoff | #30, #38 | #50 | On track | Finish PR #50 review, then start #30 from the merged contract baseline. |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | Candidate matching, commit-reveal APIs, manager console baseline | #6, #7, #43 | #53, #55 | At risk | Matching contract is in review, but commit-reveal work has not started and manager UI still depends on backend status/read details. |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | PoMW policy, verifier, agent console, bid/proof async status reads | #8, #9, #44, #59 | #56 | At risk | #56 is active, but verifier and policy slices are still unmerged and issue #59 remains queued behind them. |
+| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, operator console, manager award reads, E2E pack | #10, #11, #47, #58 | None | At risk | Audit/event work and QA remain blocked on M2/M3 backend outputs; keep this checkpoint visible as the main beta-readiness risk. |
+
+## Active P1 Issue Map
+
+| Issue | Checkpoint | Target date | Owner | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| #30 `Kestrel backend onboarding kickoff` | M1 | 2026-03-20 | kestrel | ready-next | Starts once the merged onboarding contract baseline is settled. |
+| #38 `Define observability baseline for MVP lifecycle` | M1 | 2026-03-20 | albatross-dev-agent | in-review | Reopened because PR #50 is still active; keep issue open until merge for traceability. |
+| #6 `Implement candidate matching baseline` | M2 | 2026-03-27 | kestrel | in-review | Backed by PR #55. |
+| #7 `Implement commit-reveal bidding APIs` | M2 | 2026-03-27 | kestrel | ready-next | Immediate follow-on after shortlist/matching contract merge. |
+| #43 `Build manager console baseline` | M2 | 2026-03-27 | lanzhou-fe-agent | in-review | Reopened because PR #53 is still active; manager award view depends on read-model/API follow-up. |
+| #8 `Implement PoMW policy engine` | M3 | 2026-04-03 | kestrel | ready-next | Drives the verifier and status-read work behind it. |
+| #9 `Implement ProofPack verifier and result codes` | M3 | 2026-04-03 | kestrel | blocked | Blocked on the policy baseline in #8. |
+| #44 `Build agent bidding console baseline` | M3 | 2026-04-03 | lanzhou-fe-agent | in-review | Reopened because PR #56 is still active; async verification status remains a dependency. |
+| #59 `Define bid/proof status reads and async refresh contract` | M3 | 2026-04-03 | kestrel | ready-next | Required to make PR #56 durable once verifier status becomes asynchronous. |
+| #10 `Implement audit events and award decision trace` | M4 | 2026-04-10 | kestrel | blocked | Depends on M2 and M3 state/result contracts. |
+| #11 `Add E2E tests and API examples for MVP flow` | M4 | 2026-04-10 | QA | blocked | No dedicated owner label exists yet; keep this visible as a staffing + sequencing risk. |
+| #47 `Build audit visibility console baseline` | M4 | 2026-04-10 | lanzhou-fe-agent | ready-next | Depends on audit event payloads and failure codes from #10. |
+| #58 `Define manager shortlist and award read-model contracts` | M4 | 2026-04-10 | kestrel | ready-next | Unblocks the final manager award experience and keeps M2 UI work from drifting. |
+
+## Active P1 PR Map
+
+| PR | Checkpoint | Why it belongs there | Review note |
+| --- | --- | --- | --- |
+| #50 `Define MVP lifecycle observability baseline` | M1 | It defines cross-cutting telemetry contracts needed before downstream implementation slices diverge. | Keep issue #38 open until merge; validation evidence is already attached in the thread. |
+| #53 `Build manager console baseline` | M2 | It is the frontend execution slice for task publish, shortlist review, and award summary. | Monitor for read-model contract gaps feeding into issue #58. |
+| #55 `Define candidate matching shortlist contract` | M2 | It anchors the shortlist/ranking contract that gates matching implementation and manager UI wiring. | This is the main M2 backend merge dependency. |
+| #56 `Build agent bidding console baseline` | M3 | It covers the agent commit/reveal loop that depends on verifier/status-read semantics. | Keep issue #44 open until merge and pair follow-up work with issue #59. |
+
+## Normalizations Applied
+
+- Reopened issues #38, #43, and #44 because they were closed while their linked PRs (#50, #53, #56) were still active.
+- Created GitHub milestones for M1-M4 and assigned every active P1 issue plus every open P1 PR to a checkpoint.
+- Moved issue #57 (`P0-09`) to `owner:albatross` so planning execution stays with albatross instead of lan.

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -63,6 +63,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - API draft and TypeScript contracts are consistent for `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`.
 - End-to-end happy path + key negative paths are covered by automated tests.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
+- Every active P1 issue/PR is mapped to an M1-M4 checkpoint in `docs/PHASE1_CHECKPOINT_BOARD.md` with an owner and target date.
 - P0 baseline issues that block collaboration quality are closed or explicitly waived.
 - FE/BE execution ownership and MVP hiring-critical roles are assigned or explicitly risk-accepted.
 - Closed-beta auth, auditability, and sensitive-data guardrails are documented or explicitly risk-accepted.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,10 +74,13 @@ Scope:
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
-- M1 (Week 1): finalize contracts + upload pipeline design.
-- M2 (Week 2): task/matching + bidding API baseline.
-- M3 (Week 3): PoMW policy + verifier baseline.
-- M4 (Week 4): audit/reputation hook + E2E test pack + security/compliance readiness review.
+- M1 (2026-03-20): finalize contracts + upload pipeline design.
+- M2 (2026-03-27): task/matching + bidding API baseline.
+- M3 (2026-04-03): PoMW policy + verifier baseline.
+- M4 (2026-04-10): audit/reputation hook + E2E test pack + security/compliance readiness review.
+
+Checkpoint status board:
+- Review `docs/PHASE1_CHECKPOINT_BOARD.md` for the one-screen issue/PR map, target owners, and drift callouts.
 
 ## Phase 1 KPIs
 

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -11,6 +11,7 @@
 - P0-06 #32: https://github.com/jckhang/agent-indeed/issues/32
 - P0-07 #33: https://github.com/jckhang/agent-indeed/issues/33
 - P0-08 #34: https://github.com/jckhang/agent-indeed/issues/34
+- P0-09 #57: https://github.com/jckhang/agent-indeed/issues/57
 - Epic #2: https://github.com/jckhang/agent-indeed/issues/2
 - P1-01 #3: https://github.com/jckhang/agent-indeed/issues/3
 - P1-02 #4: https://github.com/jckhang/agent-indeed/issues/4
@@ -138,6 +139,13 @@ Acceptance criteria:
 - Invalid or out-of-order transitions are explicitly rejected.
 - Write sequencing and idempotency expectations are defined for commit/reveal/verify/award.
 - Output provides direct implementation direction for follow-on P1 issues.
+
+### P0-09 Operationalize roadmap checkpoints as milestone/status board (`docs/PHASE1_CHECKPOINT_BOARD.md`)
+
+Acceptance criteria:
+- Every active P1 issue is mapped to a checkpoint owner/date.
+- Duplicate or prematurely closed issue states are called out and normalized.
+- The repo has one obvious place to review checkpoint drift at a glance.
 
 ## P1 Epic
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #57
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/chore`
- Scope: operationalize the Phase 1 roadmap checkpoints as GitHub milestones plus a one-screen repo status board

## What Changed

- added `docs/PHASE1_CHECKPOINT_BOARD.md` as the single milestone/issue/PR drift view for active Phase 1 work
- updated `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, and `docs/issues/PHASE1_ISSUES.md` to link the checkpoint board and encode M1-M4 target dates
- created GitHub milestones for M1-M4, assigned all active P1 issues/open PRs, reopened prematurely closed in-review issues (#38, #43, #44), and moved issue #57 to `owner:albatross`

## Why

- the roadmap already defined M0-M4 checkpoints, but there was no canonical GitHub milestone setup or repo-local board showing drift
- several active P1 items were either unmapped to checkpoints or prematurely closed while their PRs were still open, which made milestone review misleading

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Every active P1 issue is mapped to a checkpoint owner/date. | The new checkpoint board lists every active P1 issue with checkpoint, owner, target date, and status; GitHub milestones were created and applied to the corresponding issues/PRs. | `docs/PHASE1_CHECKPOINT_BOARD.md` |
| Duplicate or prematurely closed issue states are called out and normalized. | The board records the normalization work and issues #38, #43, and #44 were reopened because their review PRs are still active. | `docs/PHASE1_CHECKPOINT_BOARD.md` |
| The repo has one obvious place to review checkpoint drift at a glance. | The roadmap and Phase 1 docs now point directly at the one-screen checkpoint board. | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/issues/PHASE1_ISSUES.md` |

## QA Plan

### Preconditions

- GitHub CLI is authenticated for repository milestone and issue updates.
- OpenSpec CLI is installed in the local environment.

### Steps

1. Review `docs/PHASE1_CHECKPOINT_BOARD.md` and confirm each active P1 issue/PR is mapped to M1-M4 with a target date, owner, and drift note.
2. Confirm `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, and `docs/issues/PHASE1_ISSUES.md` all point to the checkpoint board.
3. In GitHub, verify milestones `M1 Contract Freeze + Upload`, `M2 Matching + Bidding Baseline`, `M3 Verify + Agent Flow`, and `M4 Audit + Beta Readiness` exist and are attached to the active P1 issues/PRs.
4. Run `openspec validate --all`.

### Expected Results

- The repository has one obvious status board for checkpoint drift.
- Active P1 issues and PRs are mapped consistently in both docs and GitHub milestones.
- Prematurely closed in-review issues are reopened for accurate tracking.
- `openspec validate --all` passes.

### Validation Output

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

## Risks and Rollback

- Risk:
  - The checkpoint mapping may need adjustment if milestone sequencing changes during review.
- Rollback:
  - Revert this PR and remove or reassign the milestone mappings/issues if the team chooses a different checkpoint structure.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
