### PR TITLE
[P1-05] Implement commit-reveal bidding APIs

### DIFF
--- a/docs/ERROR_CODE_RETRY_POLICY.md
+++ b/docs/ERROR_CODE_RETRY_POLICY.md
@@ -34,10 +34,10 @@ All MVP error responses should follow this shape:
 | Commit bid | `BID_COMMIT_PAYLOAD_INVALID` | `VALIDATION` | Missing required `Bid` commit fields | Fix request and retry |
 | Commit bid | `BID_COMMIT_TASK_MISMATCH` | `VALIDATION` | Path `taskId` and `bid.taskId` mismatch | Correct request identifiers and retry |
 | Commit bid | `BID_COMMIT_WINDOW_CLOSED` | `WINDOW` | Commit after commit deadline | Do not retry; workflow state has advanced |
-| Commit bid | `BID_COMMIT_DUPLICATE` | `IDEMPOTENCY` | Duplicate commit for same bid | Treat as already-submitted unless payload differs |
+| Commit bid | `BID_COMMIT_DUPLICATE` | `IDEMPOTENCY` | Duplicate commit for same bid/idempotency key | Treat as already-submitted unless payload differs; reuse returned window snapshot |
 | Reveal bid | `BID_REVEAL_PAYLOAD_INVALID` | `VALIDATION` | Missing nonce/price/execution plan/proof fields | Fix request and retry |
 | Reveal bid | `BID_REVEAL_COMMIT_NOT_FOUND` | `PRECONDITION` | No valid commit exists for reveal | Do not retry until commit exists |
-| Reveal bid | `BID_REVEAL_HASH_MISMATCH` | `PRECONDITION` | Reveal content does not match committed hash | Correct reveal payload; no blind retry |
+| Reveal bid | `BID_REVEAL_HASH_MISMATCH` | `PRECONDITION` | Reveal content does not match committed hash | Correct reveal payload using `expectedBidHash`; no blind retry |
 | Reveal bid | `BID_REVEAL_WINDOW_CLOSED` | `WINDOW` | Reveal after reveal deadline | Do not retry; submit is permanently rejected |
 | Verify proof | `PROOF_VERIFY_PAYLOAD_INVALID` | `VALIDATION` | Invalid or incomplete `ProofPack` | Fix proof payload and retry |
 | Verify proof | `PROOF_VERIFY_POLICY_INVALID` | `POLICY` | Policy input incompatible with task/identity tier | Correct policy inputs and retry |

--- a/docs/FRONTEND_MVP_SURFACE.md
+++ b/docs/FRONTEND_MVP_SURFACE.md
@@ -69,8 +69,8 @@ Define the minimum manager, agent, and operator console surface needed to execut
 | Page | API endpoint | Required request fields from UI | Response fields required by UI | Contract status |
 | --- | --- | --- | --- | --- |
 | `/agent/onboarding` | `POST /v1/agents/bundles` | `idempotencyKey`, `bundle.manifest.*`, `bundle.identity.*`, `bundle.skills[]`, `bundle.memoryRef.*`, `bundle.signature.*` | `agentId`, `version`, `status`, `result`, `indexedAt`; error `code`, `category`, `auditId`, `retryable`, `details`, `conflict` | Ready for create/replay/conflict/error paths in the current draft API; `bundle.schemaVersion` stays pending until the AgentBundle contract update in PR #31 lands |
-| `/agent/tasks/{taskId}/commit` | `POST /v1/tasks/{taskId}/bids/commit` | `bid.bidId`, `bid.taskId`, `bid.agentId`, `bid.phase`, `bid.commit.bidHash`, `bid.commit.committedAt` | `bidId`, `taskId`, `agentId`, `phase`, `status` | Ready for write path, but no typed commit-window reason codes |
-| `/agent/tasks/{taskId}/reveal` | `POST /v1/tasks/{taskId}/bids/reveal` | `bid.bidId`, `bid.taskId`, `bid.agentId`, `bid.phase`, `bid.reveal.nonce`, `bid.reveal.price.*`, `bid.reveal.executionPlan.*`, `bid.reveal.proof.*` | `bidId`, `phase`, `status`, `rankingScore`, `decisionTraceHash` | Ready for write path, but failure body is generic `ErrorResponse` |
+| `/agent/tasks/{taskId}/commit` | `POST /v1/tasks/{taskId}/bids/commit` | `idempotencyKey`, `commit.bidId`, `commit.taskId`, `commit.agentId`, `commit.bidHash`, `commit.committedAt` | `bidId`, `taskId`, `agentId`, `phase`, `status`, `result`, `window.*` | Ready for write path with typed commit reason codes and explicit window snapshot |
+| `/agent/tasks/{taskId}/reveal` | `POST /v1/tasks/{taskId}/bids/reveal` | `idempotencyKey`, `reveal.bidId`, `reveal.taskId`, `reveal.agentId`, `reveal.nonce`, `reveal.price.*`, `reveal.executionPlan.*`, `reveal.proof.*` | `bidId`, `phase`, `status`, `result`, `rankingScore`, `decisionTraceHash`, `proofSubmission.*`, `window.*` | Ready for write path with typed reveal failures; proof read endpoint still needed for refresh |
 | `/agent/tasks/{taskId}/verification` | `GET /v1/tasks/{taskId}/proofs/{proofId}` (proposed read endpoint) | `taskId`, `proofId` | `result`, `requiredDifficulty`, `achievedDifficulty`, `reasonCodes`, `verifiedAt` | Missing read endpoint; only `POST /v1/tasks/{taskId}/proofs/verify` exists |
 
 ### Operator pages
@@ -78,7 +78,7 @@ Define the minimum manager, agent, and operator console surface needed to execut
 | Page | API endpoint | Required request fields from UI | Response fields required by UI | Contract status |
 | --- | --- | --- | --- | --- |
 | `/operator/proofs/queue` | `GET /v1/proofs` (proposed) | `result`, `updatedSince`, `cursor` | `proofId`, `taskId`, `agentId`, `result`, `reasonCodes`, `verifiedAt`, `needsManualReview` | Missing in current API |
-| `/operator/proofs/{proofId}/review` | `POST /v1/tasks/{taskId}/proofs/verify` + `PATCH /v1/proofs/{proofId}/decision` (proposed override) | verify payload `proof.*`; override payload `decision`, `reason`, `operatorId` | `proofId`, `result`, `reasonCodes`, `verifiedAt`, `decisionTraceHash` | Partial: verify exists, manual override missing |
+| `/operator/proofs/{proofId}/review` | `POST /v1/tasks/{taskId}/proofs/verify` + `PATCH /v1/proofs/{proofId}/decision` (proposed override) | verify payload `proof.*`; override payload `decision`, `reason`, `operatorId` | `proofId`, `result`, `reasonCodes`, `verifiedAt`, `decisionTraceHash`; error `code`, `category`, `retryable`, `details.policyTraceId` | Partial: verify now has typed proof failure codes, manual override still missing |
 | `/operator/tasks/{taskId}/audit` | `GET /v1/tasks/{taskId}/events` (proposed) | `taskId`, `cursor`, `limit` | `eventType`, `eventId`, `actorRole`, `actorId`, `entityId`, `summary`, `traceHash`, `occurredAt` | Missing in current API |
 
 ## State-Driven UI Requirements
@@ -96,8 +96,7 @@ Minimum frontend state model to avoid race conditions and dead-end UX:
 | --- | --- | --- |
 | Missing candidate retrieval endpoint | Manager cannot inspect ranking before award | Add `GET /v1/tasks/{taskId}/candidates` with score breakdown |
 | Missing award write/read endpoints | Closed loop cannot finish in UI | Add award APIs with `decisionTraceHash` and `auditEventId` |
-| Missing list/read endpoints for bids/proofs | UI cannot refresh status without ad-hoc polling hacks | Add read endpoints for bid/proof status by `taskId`, `bidId`, `proofId` |
-| Generic `ErrorResponse` for commit/reveal/verify failures | User-facing reason code mapping is unstable | Publish stable error code catalog with category + retryability |
+| Missing list/read endpoints for bids/proofs after write success | UI cannot refresh long-running verification without ad-hoc polling hacks | Add read endpoints for bid/proof status by `taskId`, `bidId`, `proofId` |
 | No idempotency support beyond bundle upload | Retry-safe UX cannot be guaranteed for task publish/award | Add idempotency key contract to task and award writes |
 | No audit event query contract | Operator and manager cannot verify decisions without logs | Add task/bid event stream endpoint with pagination |
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -39,8 +39,9 @@
    - 软排序：历史成功率、延迟、预算拟合度、相似任务表现。
 
 4. 竞标采用 commit-reveal
-   - Commit 阶段提交 `bid_hash`，避免抄袭与围标。
-   - Reveal 阶段提交价格、执行计划、PoMW 证明。
+   - Commit 阶段提交 `bid_hash` 与写入幂等键，避免抄袭、围标以及网络重放导致的重复状态。
+   - Reveal 阶段提交价格、执行计划、PoMW 证明，并回显 `proofId` / verification status 供读侧轮询。
+   - Commit / reveal 响应都返回窗口快照（当前 phase、commit/reveal deadline、server time、next action），减少客户端时钟漂移导致的误判。
 
 5. PoMW 策略按身份层级动态调节
    - T0（高可信企业）: 低强度

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -17,12 +17,20 @@
 - **THEN** 平台记录竞标承诺并允许后续 reveal
 
 #### Scenario: Reveal without prior commit is rejected
-- **WHEN** 候选 agent 在 reveal 阶段提交价格与方案，但不存在对应 commit
+- **WHEN** 候选 agent 在 reveal 阶段提交价格、执行计划与 `ProofPack`，但不存在对应 commit
 - **THEN** 平台拒绝该 reveal 并返回稳定前置条件错误码（`BID_REVEAL_COMMIT_NOT_FOUND`）
 
 #### Scenario: Commit after deadline is rejected deterministically
 - **WHEN** 候选 agent 在 commit deadline 之后提交 commit
-- **THEN** 平台返回 `BID_COMMIT_WINDOW_CLOSED`，并标记该错误为不可重试
+- **THEN** 平台返回 `BID_COMMIT_WINDOW_CLOSED`，标记该错误为不可重试，并附带当前窗口快照
+
+#### Scenario: Duplicate commit replays the recorded outcome
+- **WHEN** 客户端重放同一 `bid_id` 与 `idempotencyKey` 的 commit 请求
+- **THEN** 平台返回与首次提交一致的 commit 结果，而不会创建新的 bid 分叉
+
+#### Scenario: Reveal response echoes proof tracking metadata
+- **WHEN** reveal 请求通过 hash 校验并提交 `ProofPack`
+- **THEN** 平台返回 `proofId`、验证状态和当前窗口快照，供客户端继续轮询 proof 结果
 
 ### Requirement: PoMW Must Be Policy-Driven By Identity Tier
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -23,7 +23,7 @@
 
 - [ ] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
 - [ ] 3.2 实现候选筛选策略（硬过滤 + 软排序）与评分字段。
-- [ ] 3.3 设计 commit-reveal 竞标接口与时序约束。
+- [x] 3.3 设计 commit-reveal 竞标接口与时序约束。
 
 ## 4. PoMW 与审计闭环
 

--- a/src/api/contracts.ts
+++ b/src/api/contracts.ts
@@ -324,26 +324,132 @@ export interface ProofPack {
   };
 }
 
-export interface Bid {
+export type BidWindowPhase = "COMMIT_OPEN" | "REVEAL_OPEN" | "CLOSED";
+
+export interface BidWindowSnapshot {
+  currentPhase: BidWindowPhase;
+  commitDeadline: string;
+  revealDeadline: string;
+  serverTime: string;
+  nextAction:
+    | "WAIT_FOR_REVEAL_WINDOW"
+    | "SUBMIT_REVEAL"
+    | "TRACK_PROOF_VERIFICATION"
+    | "NO_FURTHER_ACTION";
+}
+
+export interface BidCommitCommand {
   bidId: string;
   taskId: string;
   agentId: string;
-  phase: "COMMIT" | "REVEAL";
-  commit?: {
-    bidHash: string;
-    committedAt: string;
+  bidHash: string;
+  committedAt: string;
+}
+
+export interface BidRevealCommand {
+  bidId: string;
+  taskId: string;
+  agentId: string;
+  nonce: string;
+  price: {
+    currency: string;
+    amount: number;
   };
-  reveal?: {
-    nonce: string;
-    price: {
-      currency: string;
-      amount: number;
-    };
-    executionPlan: {
-      summary: string;
-      etaSeconds: number;
-      requiredTools?: string[];
-    };
-    proof?: ProofPack;
+  executionPlan: {
+    summary: string;
+    etaSeconds: number;
+    requiredTools?: string[];
+  };
+  proof: ProofPack;
+}
+
+export type Bid = BidCommitCommand | BidRevealCommand;
+
+export interface CommitBidRequest {
+  idempotencyKey: string;
+  commit: BidCommitCommand;
+}
+
+export interface RevealBidRequest {
+  idempotencyKey: string;
+  reveal: BidRevealCommand;
+}
+
+export interface BidProofSubmission {
+  proofId: string;
+  verificationStatus: "PENDING_VERIFY" | "PASS" | "FAIL" | "MANUAL_REVIEW";
+}
+
+export interface CommitBidAcceptedResponse {
+  bidId: string;
+  taskId: string;
+  agentId: string;
+  phase: "COMMIT";
+  status: "COMMITTED";
+  result: "COMMITTED" | "RETURNED_EXISTING";
+  commit: BidCommitCommand;
+  window: BidWindowSnapshot;
+}
+
+export interface RevealBidAcceptedResponse {
+  bidId: string;
+  taskId: string;
+  agentId: string;
+  phase: "REVEAL";
+  status: "REVEALED" | "SCORED";
+  result: "REVEALED" | "SCORED";
+  rankingScore?: number;
+  decisionTraceHash?: string;
+  revealAcceptedAt: string;
+  proofSubmission: BidProofSubmission;
+  window: BidWindowSnapshot;
+}
+
+export interface CommitBidErrorResponse extends ApiErrorResponse {
+  code: BidCommitErrorCode;
+  details?: {
+    bidId?: string;
+    taskId?: string;
+    currentPhase?: BidWindowPhase;
+    commitDeadline?: string;
+    revealDeadline?: string;
+    serverTime?: string;
+    existingCommitAuditId?: string;
+  };
+}
+
+export interface RevealBidErrorResponse extends ApiErrorResponse {
+  code: BidRevealErrorCode;
+  details?: {
+    bidId?: string;
+    taskId?: string;
+    currentPhase?: BidWindowPhase;
+    commitRecordedAt?: string;
+    revealDeadline?: string;
+    expectedBidHash?: string;
+  };
+}
+
+export interface VerifyProofPackRequest {
+  proof: ProofPack;
+}
+
+export interface ProofVerificationResponse {
+  proofId: string;
+  result: "PASS" | "FAIL" | "MANUAL_REVIEW";
+  requiredDifficulty: number;
+  achievedDifficulty: number;
+  reasonCodes?: string[];
+  verifiedAt?: string;
+}
+
+export interface ProofVerifyErrorResponse extends ApiErrorResponse {
+  code: ProofVerifyErrorCode;
+  details?: {
+    proofId?: string;
+    taskId?: string;
+    policyTraceId?: string;
+    requiredDifficulty?: number;
+    achievedDifficulty?: number;
   };
 }

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -249,19 +249,55 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BidResponse'
+                $ref: '#/components/schemas/CommitBidAcceptedResponse'
+              examples:
+                committed:
+                  summary: Commit recorded during the open window
+                  value:
+                    bidId: bid_alpha_commit_01
+                    taskId: task_ops_triage_001
+                    agentId: agent_kestrel_alpha
+                    phase: COMMIT
+                    status: COMMITTED
+                    result: COMMITTED
+                    commit:
+                      bidId: bid_alpha_commit_01
+                      taskId: task_ops_triage_001
+                      agentId: agent_kestrel_alpha
+                      bidHash: sha256:3b6447d58f3386261f9fcb3f298e51fb67dbf0fa7ed9f4a186b2d0f4ed57f3c2
+                      committedAt: '2026-03-14T13:05:00Z'
+                    window:
+                      currentPhase: COMMIT_OPEN
+                      commitDeadline: '2026-03-14T13:30:00Z'
+                      revealDeadline: '2026-03-14T15:00:00Z'
+                      serverTime: '2026-03-14T13:05:01Z'
+                      nextAction: WAIT_FOR_REVEAL_WINDOW
         '400':
           description: Invalid commit payload
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/CommitBidErrorResponse'
         '409':
           description: Commit window closed or duplicate commit
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/CommitBidErrorResponse'
+              examples:
+                windowClosed:
+                  summary: Commit rejected after the commit phase closed
+                  value:
+                    code: BID_COMMIT_WINDOW_CLOSED
+                    category: WINDOW
+                    message: commit window already closed for task task_ops_triage_001
+                    auditId: audit_bid_commit_001
+                    retryable: false
+                    details:
+                      currentPhase: REVEAL_OPEN
+                      commitDeadline: '2026-03-14T13:30:00Z'
+                      revealDeadline: '2026-03-14T15:00:00Z'
+                      serverTime: '2026-03-14T13:35:04Z'
 
   /v1/tasks/{taskId}/bids/reveal:
     post:
@@ -282,19 +318,61 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BidResponse'
+                $ref: '#/components/schemas/RevealBidAcceptedResponse'
+              examples:
+                revealed:
+                  summary: Reveal accepted with proof queued for verification
+                  value:
+                    bidId: bid_alpha_commit_01
+                    taskId: task_ops_triage_001
+                    agentId: agent_kestrel_alpha
+                    phase: REVEAL
+                    status: REVEALED
+                    result: REVEALED
+                    rankingScore: 0.91
+                    decisionTraceHash: sha256:44d306afd06c8d0ef82b0a5e2ab3abfbc8b1d67d3fd6c1ed44d7ed0f40c5c27f
+                    revealAcceptedAt: '2026-03-14T14:02:12Z'
+                    proofSubmission:
+                      proofId: proof_alpha_01
+                      verificationStatus: PENDING_VERIFY
+                    window:
+                      currentPhase: REVEAL_OPEN
+                      commitDeadline: '2026-03-14T13:30:00Z'
+                      revealDeadline: '2026-03-14T15:00:00Z'
+                      serverTime: '2026-03-14T14:02:12Z'
+                      nextAction: TRACK_PROOF_VERIFICATION
         '400':
           description: Commit missing or reveal mismatch
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/RevealBidErrorResponse'
+              examples:
+                hashMismatch:
+                  summary: Reveal payload does not match the committed hash
+                  value:
+                    code: BID_REVEAL_HASH_MISMATCH
+                    category: PRECONDITION
+                    message: reveal payload does not match the committed bid hash
+                    auditId: audit_bid_reveal_002
+                    retryable: false
+                    details:
+                      bidId: bid_alpha_commit_01
+                      expectedBidHash: sha256:3b6447d58f3386261f9fcb3f298e51fb67dbf0fa7ed9f4a186b2d0f4ed57f3c2
+                      currentPhase: REVEAL_OPEN
+                      revealDeadline: '2026-03-14T15:00:00Z'
+        '409':
+          description: Reveal window closed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RevealBidErrorResponse'
         '422':
           description: PoMW verification failed
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ProofVerifyErrorResponse'
 
   /v1/tasks/{taskId}/proofs/verify:
     post:
@@ -321,13 +399,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ProofVerifyErrorResponse'
         '422':
           description: Proof verification failed against required policy strength
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse'
+                $ref: '#/components/schemas/ProofVerifyErrorResponse'
 
 components:
   parameters:
@@ -587,43 +665,270 @@ components:
     CommitBidRequest:
       type: object
       additionalProperties: false
-      required: [bid]
+      required: [idempotencyKey, commit]
       properties:
-        bid:
-          $ref: '#/components/schemas/Bid'
+        idempotencyKey:
+          type: string
+          minLength: 8
+          maxLength: 128
+        commit:
+          $ref: '#/components/schemas/BidCommitCommand'
 
     RevealBidRequest:
       type: object
       additionalProperties: false
-      required: [bid]
+      required: [idempotencyKey, reveal]
       properties:
-        bid:
-          $ref: '#/components/schemas/Bid'
+        idempotencyKey:
+          type: string
+          minLength: 8
+          maxLength: 128
+        reveal:
+          $ref: '#/components/schemas/BidRevealCommand'
 
-    BidResponse:
+    BidWindowSnapshot:
       type: object
       additionalProperties: false
-      required: [bidId, taskId, agentId, phase, status]
+      required: [currentPhase, commitDeadline, revealDeadline, serverTime, nextAction]
+      properties:
+        currentPhase:
+          type: string
+          enum: [COMMIT_OPEN, REVEAL_OPEN, CLOSED]
+        commitDeadline:
+          type: string
+          format: date-time
+        revealDeadline:
+          type: string
+          format: date-time
+        serverTime:
+          type: string
+          format: date-time
+        nextAction:
+          type: string
+          enum: [WAIT_FOR_REVEAL_WINDOW, SUBMIT_REVEAL, TRACK_PROOF_VERIFICATION, NO_FURTHER_ACTION]
+
+    BidCommitCommand:
+      type: object
+      additionalProperties: false
+      required: [bidId, taskId, agentId, bidHash, committedAt]
       properties:
         bidId:
           type: string
           pattern: '^bid_[a-zA-Z0-9_-]{8,64}$'
         taskId:
           type: string
+          pattern: '^task_[a-zA-Z0-9_-]{8,64}$'
         agentId:
           type: string
+          pattern: '^agent_[a-zA-Z0-9_-]{8,64}$'
+        bidHash:
+          type: string
+          pattern: '^sha256:[a-f0-9]{64}$'
+          description: Hash over reveal payload plus a secret nonce.
+        committedAt:
+          type: string
+          format: date-time
+
+    BidRevealCommand:
+      type: object
+      additionalProperties: false
+      required: [bidId, taskId, agentId, nonce, price, executionPlan, proof]
+      properties:
+        bidId:
+          type: string
+          pattern: '^bid_[a-zA-Z0-9_-]{8,64}$'
+        taskId:
+          type: string
+          pattern: '^task_[a-zA-Z0-9_-]{8,64}$'
+        agentId:
+          type: string
+          pattern: '^agent_[a-zA-Z0-9_-]{8,64}$'
+        nonce:
+          type: string
+          minLength: 8
+        price:
+          type: object
+          additionalProperties: false
+          required: [currency, amount]
+          properties:
+            currency:
+              type: string
+              minLength: 3
+              maxLength: 3
+            amount:
+              type: number
+              minimum: 0
+        executionPlan:
+          type: object
+          additionalProperties: false
+          required: [summary, etaSeconds]
+          properties:
+            summary:
+              type: string
+              minLength: 10
+            etaSeconds:
+              type: integer
+              minimum: 1
+            requiredTools:
+              type: array
+              items:
+                type: string
+        proof:
+          $ref: '#/components/schemas/ProofPack'
+
+    BidProofSubmission:
+      type: object
+      additionalProperties: false
+      required: [proofId, verificationStatus]
+      properties:
+        proofId:
+          type: string
+          pattern: '^proof_[a-zA-Z0-9_-]{8,64}$'
+        verificationStatus:
+          type: string
+          enum: [PENDING_VERIFY, PASS, FAIL, MANUAL_REVIEW]
+
+    CommitBidAcceptedResponse:
+      type: object
+      additionalProperties: false
+      required: [bidId, taskId, agentId, phase, status, result, commit, window]
+      properties:
+        bidId:
+          type: string
+          pattern: '^bid_[a-zA-Z0-9_-]{8,64}$'
+        taskId:
+          type: string
+          pattern: '^task_[a-zA-Z0-9_-]{8,64}$'
+        agentId:
+          type: string
+          pattern: '^agent_[a-zA-Z0-9_-]{8,64}$'
         phase:
           type: string
-          enum: [COMMIT, REVEAL]
+          enum: [COMMIT]
         status:
           type: string
-          enum: [COMMITTED, REVEALED, REJECTED, SCORED]
+          enum: [COMMITTED]
+        result:
+          type: string
+          enum: [COMMITTED, RETURNED_EXISTING]
+        commit:
+          $ref: '#/components/schemas/BidCommitCommand'
+        window:
+          $ref: '#/components/schemas/BidWindowSnapshot'
+
+    RevealBidAcceptedResponse:
+      type: object
+      additionalProperties: false
+      required: [bidId, taskId, agentId, phase, status, result, revealAcceptedAt, proofSubmission, window]
+      properties:
+        bidId:
+          type: string
+          pattern: '^bid_[a-zA-Z0-9_-]{8,64}$'
+        taskId:
+          type: string
+          pattern: '^task_[a-zA-Z0-9_-]{8,64}$'
+        agentId:
+          type: string
+          pattern: '^agent_[a-zA-Z0-9_-]{8,64}$'
+        phase:
+          type: string
+          enum: [REVEAL]
+        status:
+          type: string
+          enum: [REVEALED, SCORED]
+        result:
+          type: string
+          enum: [REVEALED, SCORED]
         rankingScore:
           type: number
           minimum: 0
         decisionTraceHash:
           type: string
+          pattern: '^sha256:[a-f0-9]{64}$'
           description: Digest of scoring details for audit lookup.
+        revealAcceptedAt:
+          type: string
+          format: date-time
+        proofSubmission:
+          $ref: '#/components/schemas/BidProofSubmission'
+        window:
+          $ref: '#/components/schemas/BidWindowSnapshot'
+
+    CommitBidErrorCode:
+      type: string
+      enum:
+        - BID_COMMIT_PAYLOAD_INVALID
+        - BID_COMMIT_TASK_MISMATCH
+        - BID_COMMIT_WINDOW_CLOSED
+        - BID_COMMIT_DUPLICATE
+
+    RevealBidErrorCode:
+      type: string
+      enum:
+        - BID_REVEAL_PAYLOAD_INVALID
+        - BID_REVEAL_COMMIT_NOT_FOUND
+        - BID_REVEAL_HASH_MISMATCH
+        - BID_REVEAL_WINDOW_CLOSED
+
+    CommitBidErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          additionalProperties: false
+          properties:
+            code:
+              $ref: '#/components/schemas/CommitBidErrorCode'
+            details:
+              type: object
+              additionalProperties: false
+              properties:
+                bidId:
+                  type: string
+                taskId:
+                  type: string
+                currentPhase:
+                  type: string
+                  enum: [COMMIT_OPEN, REVEAL_OPEN, CLOSED]
+                commitDeadline:
+                  type: string
+                  format: date-time
+                revealDeadline:
+                  type: string
+                  format: date-time
+                serverTime:
+                  type: string
+                  format: date-time
+                existingCommitAuditId:
+                  type: string
+
+    RevealBidErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          additionalProperties: false
+          properties:
+            code:
+              $ref: '#/components/schemas/RevealBidErrorCode'
+            details:
+              type: object
+              additionalProperties: false
+              properties:
+                bidId:
+                  type: string
+                taskId:
+                  type: string
+                currentPhase:
+                  type: string
+                  enum: [COMMIT_OPEN, REVEAL_OPEN, CLOSED]
+                commitRecordedAt:
+                  type: string
+                  format: date-time
+                revealDeadline:
+                  type: string
+                  format: date-time
+                expectedBidHash:
+                  type: string
+                  pattern: '^sha256:[a-f0-9]{64}$'
 
     VerifyProofPackRequest:
       type: object
@@ -657,6 +962,39 @@ components:
         verifiedAt:
           type: string
           format: date-time
+
+    ProofVerifyErrorCode:
+      type: string
+      enum:
+        - PROOF_VERIFY_PAYLOAD_INVALID
+        - PROOF_VERIFY_POLICY_INVALID
+        - PROOF_VERIFY_FAILED
+        - PROOF_VERIFY_NEEDS_REVIEW
+
+    ProofVerifyErrorResponse:
+      allOf:
+        - $ref: '#/components/schemas/ErrorResponse'
+        - type: object
+          additionalProperties: false
+          properties:
+            code:
+              $ref: '#/components/schemas/ProofVerifyErrorCode'
+            details:
+              type: object
+              additionalProperties: false
+              properties:
+                proofId:
+                  type: string
+                taskId:
+                  type: string
+                policyTraceId:
+                  type: string
+                requiredDifficulty:
+                  type: number
+                  minimum: 0
+                achievedDifficulty:
+                  type: number
+                  minimum: 0
 
     AgentBundle:
       type: object
@@ -970,68 +1308,9 @@ components:
               format: date-time
 
     Bid:
-      type: object
-      additionalProperties: false
-      required: [bidId, taskId, agentId, phase]
-      properties:
-        bidId:
-          type: string
-          pattern: '^bid_[a-zA-Z0-9_-]{8,64}$'
-        taskId:
-          type: string
-          pattern: '^task_[a-zA-Z0-9_-]{8,64}$'
-        agentId:
-          type: string
-          pattern: '^agent_[a-zA-Z0-9_-]{8,64}$'
-        phase:
-          type: string
-          enum: [COMMIT, REVEAL]
-        commit:
-          type: object
-          additionalProperties: false
-          required: [bidHash, committedAt]
-          properties:
-            bidHash:
-              type: string
-              description: Hash over reveal payload + secret nonce.
-            committedAt:
-              type: string
-              format: date-time
-        reveal:
-          type: object
-          additionalProperties: false
-          required: [nonce, price, executionPlan]
-          properties:
-            nonce:
-              type: string
-            price:
-              type: object
-              additionalProperties: false
-              required: [currency, amount]
-              properties:
-                currency:
-                  type: string
-                  minLength: 3
-                  maxLength: 3
-                amount:
-                  type: number
-                  minimum: 0
-            executionPlan:
-              type: object
-              additionalProperties: false
-              required: [summary, etaSeconds]
-              properties:
-                summary:
-                  type: string
-                etaSeconds:
-                  type: integer
-                  minimum: 1
-                requiredTools:
-                  type: array
-                  items:
-                    type: string
-            proof:
-              $ref: '#/components/schemas/ProofPack'
+      oneOf:
+        - $ref: '#/components/schemas/BidCommitCommand'
+        - $ref: '#/components/schemas/BidRevealCommand'
 
     ProofPack:
       type: object


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #7
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/feature`
- Scope: implement the commit-reveal bidding contract and deterministic timing/error behavior for P1-05 only

## What Changed

- Added commit/reveal contract coverage in `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`, including deadline rejection and idempotent retry expectations.
- Expanded `src/api/openapi.yaml` with commit/reveal request-response wrappers, window snapshots, bid status details, stable error enums, and examples for write-side bidding flows.
- Synced `src/api/contracts.ts` with the commit/reveal request, response, state, and error-code types used by the API draft.
- Updated `docs/ERROR_CODE_RETRY_POLICY.md` and `docs/FRONTEND_MVP_SURFACE.md` so client handling and UI assumptions align with the new backend contract.
- Marked OpenSpec task `3.3` complete in `openspec/changes/agent-dispatch-platform/tasks.md` and refreshed the design notes for Bid Ledger timing rules.

## Why

- Issue #7 is the next ready-next kestrel backend dependency on the MVP critical path after candidate matching.
- Issue #8 (PoMW policy) and downstream frontend bid/reveal work both depend on a stable commit-reveal write contract and deterministic failure semantics.
- The existing repo state had only partial bidding shapes; this PR freezes the workflow contract before implementation/test work continues.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Commit accepted only during commit window. | Added explicit commit window snapshot fields, deterministic `BID_COMMIT_WINDOW_CLOSED` handling, and commit endpoint request/response schemas. | `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |
| Reveal requires prior valid commit. | Added reveal precondition rules plus stable `BID_REVEAL_COMMIT_NOT_FOUND` / mismatch errors across OpenSpec, OpenAPI, and TypeScript contracts. | `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`, `src/api/openapi.yaml`, `src/api/contracts.ts`, `docs/ERROR_CODE_RETRY_POLICY.md` |
| Reveal payload includes bid details and `ProofPack`. | The reveal request and bid response now carry price, execution plan, nonce/hash linkage, and `ProofPack` detail aligned with the draft model used by frontend/API consumers. | `src/api/openapi.yaml`, `src/api/contracts.ts`, `docs/FRONTEND_MVP_SURFACE.md` |

## QA Plan

### Preconditions

- OpenSpec CLI is installed locally.
- Repository is on branch `codex/p1-05-commit-reveal-bidding` rebased onto current `origin/main`.

### Steps

1. Run `openspec validate --all`.
2. Run `ruby -e 'require "yaml"; data = YAML.load_file("src/api/openapi.yaml"); puts "openapi=#{data["openapi"]} paths=#{data["paths"].size} schemas=#{data.dig("components", "schemas").size}"'`.
3. Run `bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent`.
4. Review the commit/reveal sections in `src/api/openapi.yaml` and `src/api/contracts.ts` for matching request/response and error enum names.

### Expected Results

- OpenSpec validation passes for the active change.
- The OpenAPI draft parses successfully and exposes the commit/reveal endpoints and related schemas.
- Pre-push guard confirms branch naming, baseline ancestry, and isolated kestrel identity.
- OpenSpec, OpenAPI, TypeScript contracts, and client guidance stay aligned for the commit-reveal workflow.

### Validation Output

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ ruby -e 'require "yaml"; data = YAML.load_file("src/api/openapi.yaml"); puts "openapi=#{data["openapi"]} paths=#{data["paths"].size} schemas=#{data.dig("components", "schemas").size}"'
openapi=3.1.0 paths=5 schemas=39

$ bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent
[ok] Branch 'codex/p1-05-commit-reveal-bidding' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (kestrel-dev-agent).
[ok] git user.email matches expected account (kestrel-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - The current PR freezes write-side bid workflow semantics before read-side status polling and PoMW verification contracts land, so later additive follow-ups are still expected.
  - No runnable service/tests exist yet, so contract review remains the main validation mechanism for now.
- Rollback:
  - Revert commit `de264e0` from this branch.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--kestrel`
