### PR TITLE
[P0-10] Codify merge-train coordination playbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,15 @@ Thanks for contributing. This repository is currently API/spec-first, so most ch
 4. Re-run required validation commands.
 5. Push updates (use `git push --force-with-lease` when rebase rewrites history).
 
+## Merge-Train Routine
+
+When planning-owner PRs or cross-lane dependency PRs pile up:
+
+1. Use `docs/MERGE_TRAIN_PLAYBOOK.md` to separate the clean LGTM tranche from the dirty follow-on queue.
+2. Merge only the clean tranche first, in dependency-aware order.
+3. For dirty PRs, leave a signed blocker/rebase note on the PR thread instead of copying transient state into repo docs.
+4. Keep `docs/issues/PHASE1_ISSUES.md` and `docs/PHASE1_CHECKPOINT_BOARD.md` focused on durable links/structure, not day-to-day queue status.
+
 ## Multi-Agent Commit Identity Isolation
 
 When multiple agents share one machine/worktree pool, isolate git commit identity per agent.

--- a/docs/MERGE_TRAIN_PLAYBOOK.md
+++ b/docs/MERGE_TRAIN_PLAYBOOK.md
@@ -1,0 +1,50 @@
+# Merge Train Playbook
+
+Use this playbook when albatross is coordinating the active PR queue. It keeps live status in GitHub while making the merge/rebase routine explicit enough for handoffs.
+
+## Goals
+
+- Move clean LGTM PRs quickly without reopening stale planning-doc churn.
+- Keep dirty follow-on PRs assigned, commented, and ready for their next rebase.
+- Avoid copying volatile issue/PR state into repo docs when a GitHub query is a better source of truth.
+
+## Queue queries
+
+- Clean LGTM queue: [open clean LGTM PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3ALGTM)
+- Dirty queue: [open dirty PR candidates](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+-label%3ALGTM)
+- Planning lane: [owner:albatross issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aalbatross%22)
+- Review-requested planning PRs: [owner:albatross PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22owner%3Aalbatross%22)
+
+## Merge-train routine
+
+1. Refresh `main` locally before touching any queue branch:
+   - `git switch main`
+   - `git fetch origin`
+   - `git pull --ff-only origin main`
+2. Inspect open PRs and separate them into:
+   - clean tranche: `LGTM` + mergeable/clean
+   - dirty follow-ons: conflict/rebase needed or blocked by review comments
+3. Merge the clean tranche in dependency-aware order, re-pulling `main` after each merge if the next PR depends on the newly merged contract/docs baseline.
+4. For every dirty follow-on PR, leave a signed thread note that states:
+   - the owner label already carrying the follow-up
+   - why the PR is blocked or dirty
+   - the exact next step (`rebase origin/main`, rerun validation, or address the named review comment)
+5. Only update repo docs when the planning structure changes. Do not copy day-to-day issue/PR state into `docs/issues/PHASE1_ISSUES.md` or `docs/PHASE1_CHECKPOINT_BOARD.md`.
+
+## Validation gates
+
+Before pushing any queue-fix branch:
+
+- `openspec validate --all`
+- `bash scripts/agent_prepush_check.sh --github-user <agent-github-user>`
+- `git diff --check`
+
+When a PR rebase rewrites history, push with `git push --force-with-lease`.
+
+## Signed comment template
+
+```text
+Merge-train update: <what changed on main>. `owner:<lane>` is already set; next step is to <rebase/fix action>, rerun <validation>, and keep this PR in the follow-on queue.
+
+--<agent-name>
+```

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -71,6 +71,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - End-to-end happy path + key negative paths are covered by automated tests.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is mapped to an M1-M4 checkpoint in `docs/PHASE1_CHECKPOINT_BOARD.md` with an owner and target date.
+- Merge-train coordination follows `docs/MERGE_TRAIN_PLAYBOOK.md` so clean LGTM PRs merge promptly and dirty follow-on PRs keep an explicit owner/blocker note.
 - P0 baseline issues that block collaboration quality are closed or explicitly waived.
 - FE/BE execution ownership and MVP hiring-critical roles are assigned or explicitly risk-accepted.
 - Closed-beta auth, auditability, and sensitive-data guardrails are documented or explicitly risk-accepted.

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -61,6 +61,11 @@
    - 对审计关联事件、错误日志、trace、指标分别定义最小保留期，优先保留脱敏后的调试上下文而非原始敏感负载。
    - 下游实现必须维护一份 handoff 清单，将当前 endpoint / job、活跃 issue / PR、缺失 `job_id` / async read / `audit_id` 合同等问题显式绑定到交付负责人，避免仅有基线文档而没有落地闭环。
 
+8. 建立 merge-train 协作例行
+   - 规划负责人使用统一查询区分 clean LGTM PR 与 dirty follow-on queue，而不是把瞬时状态复制到仓库文档。
+   - clean tranche 合并后，必须在脏 PR 线程写回 owner、blocker、rebase-next-step，并要求重新执行验证命令。
+   - 例行流程写入 `docs/MERGE_TRAIN_PLAYBOOK.md` 并在 `CONTRIBUTING.md` 链接，减少多 agent 并行时的重复沟通和冲突。
+
 ## Backend Module Boundaries
 
 MVP control plane 采用“单仓多模块”边界，而不是在 Phase 1 立即拆成独立微服务。每个模块拥有清晰写入边界，并通过共享 contract layer（OpenSpec + OpenAPI + `contracts.ts`）交互。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -14,6 +14,7 @@
   - agent 上传与生产资料同步能力
   - 任务市场匹配、竞标与 PoMW 验证能力
 - 补充 MVP 生命周期可观测性基线，覆盖事件、trace、日志、指标、告警与保留期约束。
+- 补充 merge-train 协作手册，统一 clean LGTM PR 合并、dirty queue 回写与 rebase 流程。
 - 明确身份分层（T0/T1/T2）下的 PoMW 强度策略。
 - 定义从任务发布到中标执行的关键状态流转与审计要求。
 
@@ -30,5 +31,6 @@
 
 - 新增 OpenSpec 规范文件，作为后续服务拆分与 API 设计依据。
 - 新增 `docs/OBSERVABILITY_BASELINE.md`，作为后续后端埋点、运维告警与审计可视化的统一契约。
+- 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue 与 dirty queue follow-up 的操作基线。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更当前不直接引入运行时代码，但会约束后续实现与测试。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -7,6 +7,7 @@
 - [x] 0.5 输出 `docs/HR_HIRING_PLAN.md`，形成 MVP 人员缺口与招聘执行方案。
 - [x] 0.6 输出 `docs/BACKEND_SERVICE_BOUNDARIES.md`，定义后端模块边界与所有权映射。
 - [x] 0.8 输出 `docs/MVP_STATE_MODEL.md`，冻结 MVP 状态机与关键写入时序约束。
+- [x] 0.9 输出 `docs/MERGE_TRAIN_PLAYBOOK.md`，统一 clean LGTM merge train、dirty queue 回写与 rebase 协作流程。
 
 ## 1. OpenSpec 基础落地
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #86
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: codify the merge-train coordination routine for clean LGTM merges and dirty follow-on PR handoff

## What Changed

- added `docs/MERGE_TRAIN_PLAYBOOK.md` with queue queries, merge/rebase routine, validation gates, and a signed PR-thread comment template
- linked the new playbook from `CONTRIBUTING.md` so the merge-train routine sits alongside the existing branch/rebase/push guidance
- updated `docs/PHASE1_GOALS.md` plus the active OpenSpec proposal/design/tasks artifacts so the planning baseline explicitly requires documented merge-train coordination

## Why

- issue #86 is about moving the clean PR tranche and keeping the dirty queue actionable without reintroducing volatile planning-doc churn
- the repo already has branch/rebase rules, but it did not have one shared playbook for how albatross should merge clean work, annotate blocked PRs, and avoid copying transient queue state into repo docs
- writing down the routine makes future queue handoffs repeatable across automation runs and human follow-up

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Clean LGTM PRs are merged or explicitly blocked with a concrete reason. | The playbook defines a clean-tranche-first merge routine and requires signed blocker notes on non-clean PRs instead of silent queue drift. | `docs/MERGE_TRAIN_PLAYBOOK.md` |
| Dirty PRs have a named owner and an updated rebase/blocker note. | The playbook calls for owner-aware PR comments with explicit next steps and provides a comment template to standardize them. | `docs/MERGE_TRAIN_PLAYBOOK.md`, `CONTRIBUTING.md` |
| Issue/PR state stays aligned after the merge train. | The docs now direct teammates to keep live state in GitHub queries and reserve repo docs for durable planning structure only. | `docs/MERGE_TRAIN_PLAYBOOK.md`, `docs/PHASE1_GOALS.md` |

## QA Plan

### Preconditions

- OpenSpec CLI is available locally.
- Branch is `codex/p0-10-merge-train-playbook` rebased on current `origin/main`.

### Steps

1. Run `openspec validate --all`.
2. Run `git diff --check`.
3. Run `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`.
4. Review `docs/MERGE_TRAIN_PLAYBOOK.md` and confirm the links, validation commands, and signed-comment template match current repo policy.

### Expected Results

- OpenSpec validation passes.
- The branch passes the albatross pre-push identity/rebase guard.
- The merge-train routine is documented once and referenced from the contribution workflow.

### Validation Output

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ git diff --check
(no output)

$ bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent
[ok] Branch 'codex/p0-10-merge-train-playbook' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - The playbook is process-only, so it can drift if future automation labels or validation commands change and the doc is not kept current.
- Rollback:
  - Revert commit `27c0b5d` to remove the playbook and linked guidance.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
