### PR TITLE
[P1-30] Capture frontend data gaps after manager/agent UI merges

### DIFF
--- a/docs/ARCHITECTURE_GAPS.md
+++ b/docs/ARCHITECTURE_GAPS.md
@@ -31,6 +31,7 @@ Identify the smallest set of missing decisions that block delivery of the Phase 
 - Manager shortlist/award-readiness guidance now exists in `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md`, but the shortlist and award contracts are still pending backend merge work.
 - Agent-side bidding baseline is now documented in `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, but bid/proof read contracts are still missing.
 - Focused commit/reveal workspace guidance now exists in `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, but it still depends on backend window/proof reads staying synchronized.
+- The merged manager and agent UI slices now share one follow-up ledger in `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md`, but the underlying shortlist, verification, and verifier contracts are still open review work.
 - Operator audit timeline baseline is now documented in `docs/OPERATOR_AUDIT_TIMELINE_BASELINE.md`, but task-scoped event reads and completeness guarantees are still missing.
 - No contract for sync/async updates (polling, event stream, or both).
 - Commit/reveal/proof error codes are documented, but route-level UX mapping still needs to stay synchronized with backend responses.

--- a/docs/FRONTEND_MVP_SURFACE.md
+++ b/docs/FRONTEND_MVP_SURFACE.md
@@ -101,9 +101,12 @@ Minimum frontend state model to avoid race conditions and dead-end UX:
 | No audit event query contract | Operator and manager cannot verify decisions without logs | Add task/bid event stream endpoint with pagination |
 | No audit-field completeness contract | Operator cannot distinguish incomplete records from clean lifecycle history | Add required-vs-optional event fields or explicit completeness markers |
 
+Detailed post-merge frontend dependency tracking now lives in `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md`, which compares the merged manager/agent UI slices with the still-open contract PRs.
+
 ## Recommended Contract Follow-Ups
 
 1. Add frontend-critical read APIs before Manager F1 and Agent F2 implementation starts.
 2. Standardize error shape (`code`, `category`, `message`, `retryable`, `details`, `auditId`) across all write endpoints.
 3. Add task-scoped bid/proof read endpoints that reuse the existing `window` snapshot shape so the unified bid workspace can recover state after refresh.
 4. Freeze state enums for task, bid, proof, and award in `openapi.yaml` and `contracts.ts` to reduce UI branching drift.
+5. Keep `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md` aligned with PRs #68, #73, and #83 so merged UI docs do not drift from the next contract round.

--- a/docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md
+++ b/docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md
@@ -1,0 +1,99 @@
+# Frontend Post-Merge Data Gap Ledger (P1-30)
+
+Last updated: 2026-03-15
+
+Related issue: [#94](https://github.com/jckhang/agent-indeed/issues/94)
+
+## Objective
+
+Capture the remaining frontend data gaps after the focused manager and agent UI slices merged, so the next review cycle stays anchored to real contract blockers instead of drifting into ad hoc payload guesses.
+
+This ledger compares:
+- merged manager and agent UI slices from PR [#76](https://github.com/jckhang/agent-indeed/pull/76) and PR [#78](https://github.com/jckhang/agent-indeed/pull/78)
+- open backend/frontend dependency PRs [#68](https://github.com/jckhang/agent-indeed/pull/68), [#73](https://github.com/jckhang/agent-indeed/pull/73), and [#83](https://github.com/jckhang/agent-indeed/pull/83)
+- the current planning baseline in `docs/FRONTEND_MVP_SURFACE.md`
+
+## Source baseline after merges
+
+| Surface | Merged or active source | What is already defined |
+| --- | --- | --- |
+| Manager shortlist and award-readiness review | merged PR `#78`, `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md` | Review shell, partial-data shortlist behavior, and award blocker UX |
+| Agent commit/reveal workspace | merged PR `#76`, `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md` | Unified commit/reveal workflow, window handling, and proof-pack validation |
+| Agent verification timeline | open PR `#73`, `docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md` | Post-reveal verification states and refresh assumptions |
+| Manager shortlist/award contracts | open PR `#68` | Candidate read model, award summary/readiness payloads, and award handoff write path |
+| Proof verifier contract | open PR `#83` | Canonical verification result shape, reason codes, and policy-trace fields |
+
+## Remaining frontend data gaps
+
+| Gap area | Why the merged UI still cannot finalize behavior on `main` | Required fields or states | Current dependency |
+| --- | --- | --- | --- |
+| Award-review shortlist freshness | Manager review needs to show whether the shortlist snapshot is stale or still generating | `shortlistGeneratedAt` or equivalent freshness field, plus candidate-count completeness signal | issue `#58` / PR `#68` |
+| Partial ranking evidence | Manager rows stay visible with missing score dimensions, but the API still needs to distinguish missing evidence from zero scores | `scoreBreakdown`, `missingDataStates`, `hardFilterPassed`, `proofReadiness` | issue `#58` / PR `#68` |
+| Award-readiness blocker model | Manager UI has blocker copy, but cannot safely decide when award is actionable without a typed readiness payload | `readiness`, `blockingReasons[]`, `recommendedBidId`, `proofSummary`, `decisionTraceHash`, `auditEventId` | issue `#58` / PR `#68` |
+| Verification restore-after-refresh | The merged bid workspace can hand off after reveal, but it still cannot recover long-running verification after browser refresh or cross-device resume | task-scoped bid/proof read payload with `phase`, `status`, `proofId`, `window`, and latest verification snapshot | issue `#59` / PR `#66` plus PR `#73` |
+| Verification result vocabulary | Timeline and review docs must keep one enum set across frontend docs, OpenAPI, and TS contracts | stable terminal result values, manual-review semantics, and reason-code catalog | issue `#9` / PR `#83` |
+| Failure-copy mapping | The merged slices define blocked/error shells, but frontend copy still depends on which verifier and shortlist reasons become first-class backend fields | shortlist blocker list, verification `reasonCodes`, operator/manual-review hints | PR `#68`, PR `#73`, PR `#83` |
+| Audit-link completeness for manager review | Manager review can point to downstream audit visibility, but cannot prove whether missing audit references mean "not emitted yet" or "not returned" | explicit audit reference fields or completeness markers on shortlist/award payloads | issue `#58` / PR `#68`, issue `#10` |
+
+## Verify follow-through gaps
+
+### Data still missing
+
+- A refresh-safe bid/proof read model that returns the latest task phase, proof status, and server-authored window snapshot.
+- Canonical verification result literals and reason codes that match the verifier contract instead of frontend-only wording.
+- A clear manual-review handoff shape so the timeline can distinguish `needs operator action` from `still processing`.
+
+### Loading and fallback states the UI must preserve
+
+| Situation | UX behavior that should stay explicit |
+| --- | --- |
+| Reveal just succeeded, but no read endpoint exists yet | Show immediate post-submit result and warn that refresh-safe progress tracking still depends on issue `#59` / PR `#66`. |
+| Verification is queued or still running | Show `Waiting for verification snapshot` rather than inventing timestamps or terminal outcomes. |
+| Result vocabulary is drifting across docs/contracts | Normalize to the current shared contract vocabulary and point to PR `#83` as the contract source of truth. |
+| Reason codes are absent | Render `Reason codes pending verifier contract` rather than collapsing to a generic success/failure timeline. |
+
+### Failure-state copy still needed
+
+- `Verification is still running for this proof. Refresh-safe status reads are not merged yet.`
+- `Verification returned a failure outcome, but detailed reason codes are still pending the verifier contract follow-up.`
+- `This proof needs manual review. Operator handoff fields are still limited until the verifier and audit contracts land.`
+
+## Award-review follow-through gaps
+
+### Data still missing
+
+- Ranked candidate rows need a durable freshness marker plus explicit `missingDataStates` so the manager can tell `still computing` apart from `no supporting evidence`.
+- Award-readiness needs a typed blocker list and a recommended-candidate summary that can survive partial proof or audit data.
+- The manager surface still needs explicit audit linkage fields before it can hand off cleanly to the audit timeline.
+
+### Loading and fallback states the UI must preserve
+
+| Situation | UX behavior that should stay explicit |
+| --- | --- |
+| Shortlist request is loading | Keep task summary visible and use skeleton rows instead of placeholder rankings. |
+| Shortlist is partial | Keep all candidate rows visible and badge missing score or proof evidence. |
+| Award payload is missing blocker fields | Show `Award readiness is partially visible; contract follow-up is still in review.` |
+| No awardable candidate exists yet | Explain whether the blocker is task phase, proof status, or missing shortlist evidence. |
+
+### Failure-state copy still needed
+
+- `Award stays blocked until shortlist and verification settle.`
+- `Verification detail pending; this candidate stays visible but is not award-ready yet.`
+- `Audit reference pending contract merge; review can continue, but final trace linkage is not available yet.`
+
+## Handoff map for the next review cycle
+
+| Frontend concern | Backend/frontend owner path | What to review next |
+| --- | --- | --- |
+| Manager shortlist data completeness | issue `#58` / PR `#68` | Candidate row fields, blocker payload, audit refs |
+| Verification refresh and resume | issue `#59` / PR `#66` | Bid/proof read model and server-authored window snapshot |
+| Verification result vocabulary and reason codes | issue `#9` / PR `#83` | Canonical result enums, reason-code catalog, manual-review semantics |
+| Timeline copy and dependency honesty | issue `#64` / PR `#73` | Verification state wording after verifier/status-read contracts settle |
+
+## Acceptance criteria mapping
+
+| Acceptance criterion | How this ledger satisfies it |
+| --- | --- |
+| Remaining frontend dependencies are written down in one place. | This document consolidates the post-merge manager and agent data gaps into a single review ledger. |
+| Each dependency is mapped to the owning backend/frontend issue or PR. | Every gap row and handoff item points to issue `#58`, issue `#59`, issue `#64`, issue `#9`, or the matching open PR. |
+| Missing fields, loading states, and failure-state copy are explicit for verify and award review. | Separate verify and award sections list the concrete fields, fallback behavior, and copy that must remain visible until the contracts land. |

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -10,8 +10,8 @@ This is the single review surface for milestone drift across the active executio
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | Contract finalization, observability baseline, onboarding kickoff | #30 | #90 | On track | PR #90 is the remaining M1 delivery in review; keep the kickoff examples aligned with the merged observability baseline. |
 | M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | Candidate matching, commit-reveal APIs, manager console baseline | #6 | #55 | At risk | Matching contract work is still in review; downstream manager and agent UX must keep honoring the current shortlist contract until it merges. |
-| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | Verifier contract, agent workspace, bid/proof async status reads | #9, #59, #63 | #66, #73, #76, #83 | At risk | PRs #73 and #76 keep the Lanzhou frontend slices moving, but durable verification/status semantics still depend on the open verifier and status-read contract work. |
-| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, manager award reads, shortlist review, security readiness, QA smoke pass | #10, #11, #58, #62, #72 | #68, #77, #78, #84 | At risk | Manager award reads, auditability, and QA coverage are still blocked on open backend contracts, while security and shortlist follow-through remain in review. |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | Verifier contract, verification timeline, bid/proof async status reads | #9, #59, #64 | #66, #73, #83 | At risk | The bid workspace slice merged on 2026-03-15, but durable verification/status semantics still depend on the open verifier and status-read contract work. |
+| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, manager award reads, merged UI follow-through, security readiness, QA smoke pass | #10, #11, #58, #72, #94 | #68, #77, #84 | At risk | The manager shortlist slice merged on 2026-03-15, but award-readiness fields, audit linkage, and QA coverage still depend on open backend contracts. |
 
 ## Active P1 Issue Map
 
@@ -21,11 +21,11 @@ This is the single review surface for milestone drift across the active executio
 | #6 `Implement candidate matching baseline` | M2 | 2026-03-27 | kestrel | in-review | Backed by PR #55; this remains the main M2 backend merge dependency. |
 | #9 `Implement ProofPack verifier and result codes` | M3 | 2026-04-03 | kestrel | blocked | Blocked on the final verifier contract shape and should stay aligned with PR #83. |
 | #59 `Define bid/proof status reads and async refresh contract` | M3 | 2026-04-03 | kestrel | in-review | Backed by PR #66; this is the contract gate for refresh-safe verification UX. |
-| #63 `Implement agent bid commit/reveal workspace UI` | M3 | 2026-04-03 | lanzhou-fe-agent | in-review | PR #76 carries the focused bid workspace slice while keeping async refresh assumptions tied to issue #59. |
+| #64 `Implement bid/proof verification timeline UX` | M3 | 2026-04-03 | lanzhou-fe-agent | in-review | Backed by PR #73; keep the timeline vocabulary and refresh assumptions aligned with PR #66 and PR #83. |
 | #10 `Implement audit events and award decision trace` | M4 | 2026-04-10 | kestrel | blocked | Depends on the M3 verification/result contract outputs plus final manager award reads. |
 | #11 `Add E2E tests and API examples for MVP flow` | M4 | 2026-04-10 | QA | blocked | QA coverage stays gated on the open manager/agent read contracts and shortlist-to-award flow stability. |
 | #58 `Define manager shortlist and award read-model contracts` | M4 | 2026-04-10 | kestrel | in-review | Backed by PR #68 and still the main contract dependency for manager shortlist/award follow-through. |
-| #62 `Implement shortlist review and award-readiness UI slice` | M4 | 2026-04-10 | lanzhou-fe-agent | in-review | PR #78 keeps the shortlist/award-readiness follow-through visible while award execution remains backend-gated. |
+| #94 `Capture frontend data gaps after manager/agent UI merges` | M4 | 2026-04-10 | lanzhou-fe-agent | ready-next | Consolidates the remaining verify + award-review gaps after PRs #76 and #78 merged, so frontend follow-through stays tied to PRs #68, #73, and #83. |
 | #72 `Operationalize closed-beta security readiness checklist` | M4 | 2026-04-10 | albatross-dev-agent | in-review | PR #77 keeps the auth/redaction checklist active while API and contract sync feedback lands. |
 
 ## Active P1 PR Map
@@ -36,15 +36,13 @@ This is the single review surface for milestone drift across the active executio
 | #55 `[P1-04] Define candidate matching shortlist contract` | M2 | It anchors the shortlist/ranking contract that gates matching implementation and manager UI wiring. | This is still the main M2 backend merge dependency. |
 | #66 `Define bid/proof status polling contract` | M3 | It defines the async proof-status read model needed for refresh-safe agent and operator flows. | Keep queued/verifying read fields honest until this contract lands. |
 | #73 `[P1-22] Implement bid/proof verification timeline UX` | M3 | It documents the verification timeline slice that sits on top of the open status-read and verifier contract work. | Keep enum vocabulary aligned with the current API/contracts until PR #83 merges. |
-| #76 `[P1-21] Implement agent bid commit/reveal workspace UI` | M3 | It narrows the next frontend delivery to one bid workspace while keeping async refresh scoped to the backend follow-up. | Keep issue #63 open until merge and track verification refresh against PR #66 / PR #83. |
 | #83 `[P1-07] Define ProofPack verifier contract` | M3 | It is the canonical verifier/result contract that downstream UX and docs must follow. | Merge this before renaming shared verification enums anywhere else in the repo. |
-| #68 `[P1-17] Define manager shortlist and award read-model contracts` | M4 | It defines the shortlist/award read contract that manager review and award-readiness UX depend on. | This is the main backend gate for PR #78 and the remaining manager follow-through. |
+| #68 `[P1-17] Define manager shortlist and award read-model contracts` | M4 | It defines the shortlist/award read contract that manager review and award-readiness UX depend on. | This is the main backend gate for the merged manager review slice and the remaining manager follow-through. |
 | #77 `[P1-25] Operationalize closed-beta security readiness checklist` | M4 | It keeps the beta auth/redaction checklist reviewable and syncs the security draft back into the API/contracts docs. | Blocking API sync feedback has been addressed; watch for final review and merge. |
-| #78 `[P1-20] Implement shortlist review and award-readiness UI slice` | M4 | It isolates the post-publish manager review experience while keeping shortlist and award contract gaps visible. | Keep issue #62 open until merge and rebase as merge-train updates land. |
 | #84 `[P1-26] Draft MVP smoke matrix for merged manager/agent flows` | M4 | It captures the QA smoke coverage needed once the manager and agent milestone slices start merging together. | Keep expected manager/agent checkpoints aligned with the latest merged frontend/backend contracts. |
 
 ## Normalizations Applied
 
 - Removed merged PRs (`#50`, `#53`, `#56`, `#81`) from the active checkpoint tables so only currently open PRs appear here.
-- Removed closed issues (`#7`, `#8`, `#38`, `#43`, `#44`, `#47`, `#61`, `#71`) from the active issue map to match current GitHub state.
-- Kept the active Lanzhou frontend slices (`#62` / PR #78, `#63` / PR #76, PR #73) visible alongside their open backend contract dependencies.
+- Removed closed issues (`#7`, `#8`, `#38`, `#43`, `#44`, `#47`, `#61`, `#62`, `#63`, `#71`) from the active issue map to match current GitHub state.
+- Removed merged Lanzhou frontend PRs (`#76`, `#78`) from the active PR map and replaced them with issue `#94` as the post-merge frontend follow-through ledger.

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -36,6 +36,7 @@ Ship the first usable agent dispatch loop for closed beta:
   - historical similarity
 - Manager console baseline is captured in `docs/MANAGER_CONSOLE_BASELINE.md` so task publish, shortlist review, and award-state acceptance criteria stay reviewable while shortlist/award read-model gaps are still backend follow-ups.
 - The focused shortlist/award manager review slice is captured in `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md` so fallback states and award blockers stay explicit while shortlist/award contracts remain under review.
+- The merged manager and agent frontend slices feed their remaining data gaps into `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md` so issue #58 and related contract PRs have one frontend follow-through ledger.
 
 ### G3. Bidding and PoMW baseline
 
@@ -43,6 +44,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Reveal rejected when no valid commit exists.
 - `ProofPack` accepted and verified with T0/T1/T2 policy mapping.
 - Agent bidding console baseline is captured in `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, and the focused execution slice is refined in `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md` so commit/reveal workspace behavior stays reviewable while bid/proof status reads remain backend follow-ups through issue #59.
+- Post-reveal verification loading/failure follow-through is tracked in `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md` so issue #64 and PRs #73/#83 stay tied to concrete UI gaps.
 
 ### G4. Audit and observability baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -46,6 +46,7 @@ Scope:
 - Commit-reveal bidding workflow.
 - Agent bidding console baseline (`docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, issue #44 / PR #56) keeps the broader commit/reveal + verification journey visible.
 - Dedicated bid workspace slice (`docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, issue #63 / PR #76) narrows the next frontend delivery item to one commit/reveal workflow while leaving async refresh on the backend follow-up track (#59).
+- Post-merge frontend data-gap ledger (`docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md`, issue #94) keeps the merged manager/agent UI slices aligned with open contract PRs #68, #73, and #83.
 - Audit visibility console baseline (`docs/AUDIT_VISIBILITY_CONSOLE_BASELINE.md`, issue #47) keeps task/bid timeline review, failure translation, and missing-field alert requirements visible while audit query and award-read contracts are still pending.
 - PoMW verification baseline with identity-tier policy.
 - Auditable award events and minimal reputation writeback hook.

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -31,6 +31,7 @@
 - P1-19 #61 (closed): https://github.com/jckhang/agent-indeed/issues/61
 - P1-21 #63: https://github.com/jckhang/agent-indeed/issues/63
 - P1-23 #65: https://github.com/jckhang/agent-indeed/issues/65
+- P1-30 #94: https://github.com/jckhang/agent-indeed/issues/94
 
 ## P0 Readiness
 
@@ -373,6 +374,27 @@ Acceptance criteria:
 Backlog notes:
 - The shortlisted-candidate experience still depends on the contract proposal in PR `#68`; until it merges, the UI must preserve partial-data states and dependency copy.
 - Award-readiness visibility must stay separate from the eventual award command execution path so manager UX does not imply unsupported write behavior.
+
+### P1-30 Capture frontend data gaps after manager/agent UI merges
+
+References:
+- `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md`
+- `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md`
+- `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`
+- `docs/FRONTEND_MVP_SURFACE.md`
+- issue `#58` / PR `#68`
+- issue `#64` / PR `#73`
+- issue `#9` / PR `#83`
+
+Acceptance criteria:
+- Remaining verify and award-review frontend data gaps are consolidated into one reviewable ledger after the manager and agent UI slices merge.
+- The ledger explicitly names the missing backend fields, loading states, and failure-copy follow-through still needed for verification and award review.
+- Every gap is mapped back to the owning issue or PR instead of being left as anonymous frontend debt.
+- Planning surfaces stay synchronized so the merged UI docs do not imply contracts that are still under review.
+
+Backlog notes:
+- Verification refresh and result-copy gaps remain downstream of issue `#59`, issue `#64`, and PR `#83`.
+- Award-readiness field and audit-link gaps remain downstream of issue `#58` / PR `#68` and later audit follow-through in issue `#10`.
 
 ### P1-16 Build audit visibility console baseline
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #94
- Department label (pick one): `dept/frontend`
- Type label (pick one): `type/docs`
- Scope: capture the remaining verify + award-review frontend data gaps after the focused manager/agent UI slices merged

## What Changed

- added `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md` to compare the merged manager/agent UI slices with the still-open contract PRs #68, #73, and #83
- updated `docs/FRONTEND_MVP_SURFACE.md` and `docs/ARCHITECTURE_GAPS.md` so the shared frontend planning surface points to one post-merge dependency ledger
- updated `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, and `docs/issues/PHASE1_ISSUES.md` so issue #94 is tracked as the follow-through item after PRs #76/#78 merged on 2026-03-15
- normalized the checkpoint board to remove merged frontend PRs from the active PR map and replace them with the new post-merge follow-up issue

## Why

- PRs #76 and #78 merged, but the remaining frontend gaps for verification and award review were still spread across multiple docs and stale checkpoint notes.
- Issue #94 asks for one concrete list of the missing fields, loading states, and failure-state copy still needed from the open contract work.
- A single ledger keeps Lanzhou follow-through tied to the real dependency PRs instead of drifting into hidden frontend-only assumptions.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Remaining frontend dependencies are written down in one place. | Adds one post-merge ledger covering verify + award-review follow-through after the manager/agent slices merged. | `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md` |
| Each dependency is mapped to the owning backend/frontend issue or PR. | Gap tables and handoff map tie every item back to #58/#68, #59/#66, #64/#73, or #9/#83. | `docs/FRONTEND_POST_MERGE_DATA_GAP_LEDGER.md` |
| Planning surfaces stay synchronized with the new follow-through issue. | Frontend planning docs, roadmap/goals, checkpoint board, and issue backlog now reference issue #94 and the merged state of PRs #76/#78. | `docs/FRONTEND_MVP_SURFACE.md`, `docs/ARCHITECTURE_GAPS.md`, `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/issues/PHASE1_ISSUES.md` |

## QA Plan

### Preconditions

- OpenSpec CLI is available in the workspace.
- Branch is rebased on current `origin/main`.

### Steps

1. Run `git diff --check`.
2. Run `openspec validate --changes`.
3. Run `openspec validate --all`.
4. Run `bash scripts/agent_prepush_check.sh --github-user lanzhou-fe-agent`.

### Expected Results

- Documentation edits have no whitespace or patch-formatting issues.
- OpenSpec validation remains green.
- The pre-push guard confirms the branch naming, ancestry, and Lanzhou git identity.

### Validation Output

- `git diff --check`
- `openspec validate --changes`
- `openspec validate --all`
- `bash scripts/agent_prepush_check.sh --github-user lanzhou-fe-agent`

## Risks and Rollback

- Risk:
  - The dependency ledger can go stale if PRs #68, #73, or #83 change shape without the planning docs being updated in lockstep.
- Rollback:
  - Revert commit `4a83819` if the issue #94 follow-through needs to be rewritten.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--lanzhou-fe-agent`
