### PR TITLE
[P1-29] Draft MVP API example outline for QA handoff

### DIFF
--- a/docs/MVP_API_EXAMPLE_OUTLINE.md
+++ b/docs/MVP_API_EXAMPLE_OUTLINE.md
@@ -1,0 +1,235 @@
+# MVP API Example Outline for QA Handoff
+
+Last updated: 2026-03-15
+
+Issue link: #93 (`[P1-29] Draft MVP API example outline for QA handoff`)
+
+## Why this outline exists
+
+Issue #11 still owns the full MVP API example pack and end-to-end QA flow, but it remains blocked on a few open backend contracts. This outline gives QA a stable prep surface now so request fixtures, expected transitions, and smoke checkpoints can be assembled in parallel instead of waiting for every M4 dependency to merge.
+
+## Handoff target
+
+Use this outline to prepare the bounded MVP request/response examples for the closed-loop flow:
+
+`upload -> publish -> commit -> reveal -> verify -> award`
+
+- Pair this outline with issue #11 for the eventual full example pack and E2E suite.
+- Pair the ready-now steps with the smoke follow-through in issue #87 and PR #84 so QA can validate the next merged tranche without waiting for the entire blocked pack.
+- Treat every `Blocked` note below as a contract gate, not a missing-docs TODO.
+
+## Flow readiness at a glance
+
+| Step | Endpoint / dependency | Status | What QA can do now | Open blocker |
+| --- | --- | --- | --- | --- |
+| 1. Upload agent bundle | `POST /v1/agents/bundles` | Ready now | Freeze request/response fixtures from the current draft API. | None |
+| 2. Publish task | `POST /v1/tasks` | Ready now | Freeze a publish example that produces a task id plus bidding window timestamps. | None |
+| 3. Commit bid | `POST /v1/tasks/{taskId}/bids/commit` | Ready now | Freeze commit-window success and replay/window-closed negative examples. | None |
+| 4. Reveal bid + proof payload | `POST /v1/tasks/{taskId}/bids/reveal` | Ready now | Freeze reveal success plus hash-mismatch / missing-commit negatives. | None |
+| 5. Resolve proof policy | `POST /v1/tasks/{taskId}/proof-policy` | Ready now | Prepare the policy snapshot fixture that verify must replay with `policyTraceId`. | None |
+| 6. Verify proof pack | `POST /v1/tasks/{taskId}/proofs/verify` | Partial | Draft example structure now, but keep final status/reason-code expectations soft until verifier contract review lands. | PR #83 |
+| 7. Review shortlist + award readiness | Proposed shortlist / award reads from issue #58 | Blocked | Record placeholder assertions only; do not freeze manager-facing award examples yet. | PR #68 |
+| 8. Audit timeline / award trace evidence | Task/bid event stream and `TASK_AWARDED` trace payload | Blocked | Note required audit ids / trace refs, but do not finalize evidence examples yet. | PR #92 |
+| 9. Award task | Proposed award command/read path | Blocked | Keep the final step as a dependency note in issue #11 rather than a locked example. | PR #68 and PR #92 |
+
+## Example sequence
+
+### 1. Upload an agent bundle
+
+- Endpoint: `POST /v1/agents/bundles`
+- Source of truth: `src/api/openapi.yaml`, `docs/ONBOARDING_PIPELINE.md`
+- Goal: register one signed agent fixture that can be reused in downstream publish/bid examples.
+- Minimum request fields to keep stable now:
+  - `idempotencyKey`
+  - `bundle.schemaVersion`
+  - `bundle.manifest.*`
+  - `bundle.identity.*`
+  - `bundle.skills[]`
+  - `bundle.memoryRef.*`
+  - `bundle.signature.*`
+- Minimum response fields to assert now:
+  - `agentId`
+  - `version`
+  - `status`
+  - `result`
+  - `indexing.status`
+
+```json
+{
+  "idempotencyKey": "idem_agentbundle_qa_001",
+  "bundle": {
+    "schemaVersion": "1.0",
+    "manifest": {
+      "name": "support_triage_agent",
+      "version": "1.2.0"
+    },
+    "identity": {
+      "did": "did:key:example-agent",
+      "credentialLevel": "T1"
+    },
+    "skills": [
+      {
+        "skillId": "skill_support.triage",
+        "version": "1.4.0"
+      }
+    ],
+    "memoryRef": {
+      "mode": "INDEX_ONLY"
+    },
+    "signature": {
+      "algorithm": "ED25519",
+      "payloadHash": "sha256:...",
+      "signature": "base64:...",
+      "signerDid": "did:key:example-agent"
+    }
+  }
+}
+```
+
+### 2. Publish a task
+
+- Endpoint: `POST /v1/tasks`
+- Source of truth: `src/api/openapi.yaml`, `docs/MANAGER_TASK_COMPOSER_UI_SLICE.md`
+- Goal: create one task fixture that yields `taskId`, `status`, `commitDeadline`, and `revealDeadline` for every later example.
+- Minimum request sections to keep stable now:
+  - `task.title`, `task.description`
+  - `task.budget.*`
+  - `task.sla.*`
+  - `task.constraints.*`
+  - `task.risk.*`
+  - `task.powmPolicy.*`
+  - `task.biddingWindow.*`
+- Minimum response fields to assert now:
+  - `taskId`
+  - `status`
+  - `commitDeadline`
+  - `revealDeadline`
+
+### 3. Commit a bid hash
+
+- Endpoint: `POST /v1/tasks/{taskId}/bids/commit`
+- Source of truth: `src/api/openapi.yaml`, `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`
+- Goal: prove the commit window contract is stable enough for QA fixtures today.
+- Minimum request fields to keep stable now:
+  - `bid.bidId`
+  - `bid.taskId`
+  - `bid.agentId`
+  - `bid.bidHash`
+  - `bid.committedAt`
+- Minimum response fields to assert now:
+  - `bidId`
+  - `phase`
+  - `status`
+  - `result`
+  - `window.currentPhase`
+  - `window.commitDeadline`
+  - `window.revealDeadline`
+- Also queue one negative example now:
+  - `BID_COMMIT_WINDOW_CLOSED`
+
+### 4. Reveal bid details and attach proof payload
+
+- Endpoint: `POST /v1/tasks/{taskId}/bids/reveal`
+- Source of truth: `src/api/openapi.yaml`, `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`
+- Goal: lock the reveal request shape and the immediate post-submit verification handoff.
+- Minimum request fields to keep stable now:
+  - `reveal.bidId`
+  - `reveal.taskId`
+  - `reveal.agentId`
+  - `reveal.nonce`
+  - `reveal.price.*`
+  - `reveal.executionPlan.*`
+  - `reveal.proof.*`
+- Minimum response fields to assert now:
+  - `bidId`
+  - `status`
+  - `result`
+  - `rankingScore`
+  - `decisionTraceHash`
+  - `proofSubmission.proofId`
+  - `proofSubmission.verificationStatus`
+- Also queue two negatives now:
+  - `BID_REVEAL_HASH_MISMATCH`
+  - reveal-without-valid-commit precondition failure
+
+### 5. Resolve the proof policy snapshot
+
+- Endpoint: `POST /v1/tasks/{taskId}/proof-policy`
+- Source of truth: `src/api/openapi.yaml`
+- Goal: create the persisted `policyTraceId` fixture that verify, audit, and award examples must all reuse.
+- Minimum request/response fields to keep stable now:
+  - request candidate/task snapshot fields required for policy resolution
+  - response `taskId`
+  - response `agentId`
+  - response `policyTraceId`
+  - response `requiredProofStrength`
+  - response `challengeProfile`
+  - response `verifierParams.*`
+  - response `inputSnapshot.*`
+
+### 6. Verify the proof pack
+
+- Endpoint: `POST /v1/tasks/{taskId}/proofs/verify`
+- Source of truth: `src/api/openapi.yaml`
+- Current readiness: Partial
+- Why partial:
+  - The checked-in draft already requires `policyTraceId` and returns proof-verification fields.
+  - PR #83 is still the active contract-review lane for stable verifier statuses, reason codes, and downstream vocabulary.
+- QA prep to do now:
+  - Draft the verify request with one reusable `proofId` and the same `policyTraceId` from step 5.
+  - Keep assertions focused on the replay rule (`policyTraceId` must match the persisted policy snapshot) and core fields such as `proofId`, `policyTraceId`, `requiredDifficulty`, `achievedDifficulty`, and `verifiedAt`.
+  - Do not freeze the final result-code matrix for issue #11 until PR #83 merges.
+
+### 7. Shortlist and award-readiness review
+
+- Dependency: issue #58 / PR #68
+- Current readiness: Blocked
+- Why blocked:
+  - Full example handoff needs manager-facing shortlist rows, score breakdowns, proof readiness, and award-readiness visibility.
+  - Those read contracts are still under review in PR #68 and are not available on the checked-out baseline.
+- QA prep to do now:
+  - Record the needed assertions only: ranked candidates, score breakdown, proof summary, blocker state, shortlist freshness, and decision/audit references.
+  - Keep them as placeholders in issue #11 instead of publishing final JSON examples.
+
+### 8. Audit timeline and award trace evidence
+
+- Dependency: issue #10 / PR #92
+- Current readiness: Blocked
+- Why blocked:
+  - The final award example must carry auditable event evidence, not only a winner id.
+  - PR #92 is the contract lane for task/bid event streams and `TASK_AWARDED` trace payload expectations.
+- QA prep to do now:
+  - Reserve assertion slots for `eventType`, `eventId`, `actorRole`, `traceHash`, `decisionTraceHash`, `scoreSummary`, and `proofSummary`.
+  - Do not mark the example pack complete until those audit fields are frozen.
+
+### 9. Award the task
+
+- Dependency: PR #68 plus PR #92
+- Current readiness: Blocked
+- Why blocked:
+  - The current baseline does not yet provide the full manager award read/write contract.
+  - The final step also depends on the audit event stream and decision trace defined in PR #92.
+- QA prep to do now:
+  - Keep the final `award` step in issue #11 as a dependency gate.
+  - Avoid inventing a winner-selection payload before the shortlist/readiness and audit contracts merge.
+
+## Ready-now example pack slices
+
+QA can safely draft and review these slices immediately:
+
+1. `upload success + replay/conflict`
+2. `publish success`
+3. `commit success + window-closed`
+4. `reveal success + hash-mismatch`
+5. `proof-policy resolution success`
+6. `verify request shell with soft assertions on result vocabulary`
+
+## Explicit blockers for issue #11
+
+Issue #11 should stay blocked until these contracts land on `main`:
+
+- PR #68: manager shortlist and award-readiness examples
+- PR #83: final proof-verifier status / reason-code vocabulary
+- PR #92: audit timeline evidence and award trace fields
+
+Once those merge, QA can turn this outline into the final MVP example pack plus the fuller E2E scenario set.

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -11,7 +11,7 @@ This is the single review surface for milestone drift across the active executio
 | M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | Contract finalization, observability baseline, onboarding kickoff | #30 | #90 | On track | PR #90 is the remaining M1 delivery in review; keep the kickoff examples aligned with the merged observability baseline. |
 | M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | Candidate matching, commit-reveal APIs, manager console baseline | #6 | #55 | At risk | Matching contract work is still in review; downstream manager and agent UX must keep honoring the current shortlist contract until it merges. |
 | M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | Verifier contract, agent workspace, bid/proof async status reads | #9, #59, #63 | #66, #73, #76, #83 | At risk | PRs #73 and #76 keep the Lanzhou frontend slices moving, but durable verification/status semantics still depend on the open verifier and status-read contract work. |
-| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, manager award reads, shortlist review, security readiness, QA smoke pass | #10, #11, #58, #62, #72 | #68, #77, #78, #84 | At risk | Manager award reads, auditability, and QA coverage are still blocked on open backend contracts, while security and shortlist follow-through remain in review. |
+| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, manager award reads, shortlist review, security readiness, QA smoke pass | #10, #11, #58, #62, #72, #93 | #68, #77, #78, #84 | At risk | Manager award reads, auditability, and QA coverage are still blocked on open backend contracts, while issue #93 now freezes the ready-now API example slices for QA handoff. |
 
 ## Active P1 Issue Map
 
@@ -27,6 +27,7 @@ This is the single review surface for milestone drift across the active executio
 | #58 `Define manager shortlist and award read-model contracts` | M4 | 2026-04-10 | kestrel | in-review | Backed by PR #68 and still the main contract dependency for manager shortlist/award follow-through. |
 | #62 `Implement shortlist review and award-readiness UI slice` | M4 | 2026-04-10 | lanzhou-fe-agent | in-review | PR #78 keeps the shortlist/award-readiness follow-through visible while award execution remains backend-gated. |
 | #72 `Operationalize closed-beta security readiness checklist` | M4 | 2026-04-10 | albatross-dev-agent | in-review | PR #77 keeps the auth/redaction checklist active while API and contract sync feedback lands. |
+| #93 `Draft MVP API example outline for QA handoff` | M4 | 2026-04-10 | albatross-dev-agent | in-review | Defines which upload/publish/commit/reveal/verify example slices QA can freeze now while award evidence stays blocked on PRs #68, #83, and #92. |
 
 ## Active P1 PR Map
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -50,6 +50,7 @@ Scope:
 - PoMW verification baseline with identity-tier policy.
 - Auditable award events and minimal reputation writeback hook.
 - Lifecycle observability baseline for `upload -> match -> bid -> verify -> award`.
+- MVP QA handoff outline (`docs/MVP_API_EXAMPLE_OUTLINE.md`, issue #93) freezes the ready-now example slices and names the open PR blockers for the remaining verify/award evidence.
 - Operator audit timeline baseline (`docs/OPERATOR_AUDIT_TIMELINE_BASELINE.md`, issue #65 / PR #67) defines the first focused operator read surface and keeps audit-event completeness gaps visible before backend event reads are finalized.
 
 Exit criteria:

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -238,6 +238,10 @@ Acceptance criteria:
 - Happy path and core abuse path tests pass in CI.
 - API examples cover upload, publish, commit, reveal, verify, award.
 
+Backlog notes:
+- Use `docs/MVP_API_EXAMPLE_OUTLINE.md` as the QA prep surface for ready-now fixtures while issue #11 stays blocked on PRs #68, #83, and #92.
+- Keep smoke-tranche follow-through tied to issue #87 so merged-slice validation can progress before the full example pack is unblocked.
+
 ### P1-11 Publish error-code catalog and retry/idempotency policy
 
 References:
@@ -299,6 +303,19 @@ Acceptance criteria:
 - Active issues and open PRs are assigned the telemetry they must land before beta readiness.
 - Missing business identifiers or async-read contracts that block instrumentation are called out explicitly.
 - A minimal alert/review checklist exists for M4 telemetry readiness.
+
+### P1-29 Draft MVP API example outline for QA handoff
+
+References:
+- `docs/MVP_API_EXAMPLE_OUTLINE.md`
+- `docs/MANAGER_TASK_COMPOSER_UI_SLICE.md`
+- `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`
+- `src/api/openapi.yaml`
+
+Acceptance criteria:
+- A reviewable outline covers `upload -> publish -> commit -> reveal -> verify -> award`.
+- Each step states whether QA can freeze examples now or is blocked by an open contract PR.
+- The outline links the blocked final pack back to issue `#11` and the near-term smoke follow-through in issue `#87`.
 
 ### P1-15 Build agent bidding console baseline
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #93
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Draft the MVP API example outline for QA handoff and sync the planning docs that track Phase 1 QA readiness.

## What Changed

- Added `docs/MVP_API_EXAMPLE_OUTLINE.md` as the QA-facing outline for the `upload -> publish -> commit -> reveal -> verify -> award` example sequence.
- Marked each step as ready now, partial, or blocked so QA can prepare fixtures without inventing award or audit payloads early.
- Linked the outline back to issue #11, issue #87, and the open contract blockers in PRs #68, #83, and #92.
- Synced `docs/ROADMAP.md`, `docs/issues/PHASE1_ISSUES.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` so the new handoff slice is visible in Phase 1 tracking.

## Why

- Issue #11 is still blocked, but QA needs a bounded prep surface now for the next merged tranche.
- The repo already has enough merged contract surface to freeze upload, publish, commit, reveal, and proof-policy examples.
- Naming the remaining blockers explicitly reduces churn once shortlist, verifier, and audit contracts land.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| A reviewable outline exists for the MVP example pack. | Added a dedicated handoff doc with a step-by-step sequence, minimum fields, and one reusable example payload. | `docs/MVP_API_EXAMPLE_OUTLINE.md` |
| Open blockers are explicit per step so QA can parallelize prep work. | Each stage is marked `Ready now`, `Partial`, or `Blocked`, with PR-specific dependency notes for verify, shortlist/award, and audit evidence. | `docs/MVP_API_EXAMPLE_OUTLINE.md` |
| The new outline stays connected to current Phase 1 planning. | Added roadmap, backlog, and checkpoint references for issue #93 and the QA handoff slice. | `docs/ROADMAP.md`, `docs/issues/PHASE1_ISSUES.md`, `docs/PHASE1_CHECKPOINT_BOARD.md` |

## QA Plan

### Preconditions

- Branch `codex/p1-29-api-example-outline` is checked out.
- OpenSpec CLI is installed locally.

### Steps

1. Review `docs/MVP_API_EXAMPLE_OUTLINE.md` and confirm the flow covers `upload -> publish -> commit -> reveal -> verify -> award`.
2. Check that each step calls out whether QA can freeze examples now or must wait on PR #68, #83, or #92.
3. Review `docs/ROADMAP.md`, `docs/issues/PHASE1_ISSUES.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` for the tracking sync.
4. Run `openspec validate --all`.
5. Run `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`.

### Expected Results

- QA has one focused handoff doc for the ready-now API example slices.
- Award and audit example gaps are called out as dependency gates instead of implied as done.
- Phase 1 planning docs now show issue #93 as part of the M4 QA-readiness lane.
- Validation and pre-push guard both pass.

### Validation Output

- `openspec validate --all`

```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`

```text
[ok] Branch 'codex/p1-29-api-example-outline' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - PRs #68, #83, and #92 may still land additive contract details that require small follow-up edits to the outline before issue #11 can finalize the pack.
- Rollback:
  - Revert commit `42d9a63` from this branch.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--albatross-dev-agent`
