### PR TITLE
docs: add phase 1 beta readiness gates

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -1,0 +1,99 @@
+# Phase 1 Beta Readiness Gates
+
+Last updated: 2026-03-16
+
+This document turns epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`) into a small set of
+reviewable release gates for closed-beta readiness. It complements:
+
+- `docs/PHASE1_GOALS.md` for the MVP definition of done
+- `docs/ROADMAP.md` for phase checkpoints and milestone dates
+- `docs/PHASE1_EPIC_STATUS.md` for the current issue/PR rollup
+
+## Gate Summary
+
+| Gate | Status | Ready when | Active dependencies | Evidence to collect |
+| --- | --- | --- | --- | --- |
+| Contract convergence | In progress | The remaining backend contract PRs are merged and the shared enum/error vocabulary is stable across OpenSpec, OpenAPI, and TypeScript contracts. | PR #55, PR #66, PR #68, PR #83, PR #90, PR #92 | `openspec validate --all`, contract diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts` |
+| Happy-path execution | Blocked | The team can trace one publish -> match -> commit -> reveal -> verify -> award flow without relying on undocumented fields or manual interpretation. | Issue #11, PR #84, PR #95, PR #96, plus the contract gate above | QA smoke checklist, API examples, merged frontend data-gap notes |
+| Negative-scenario coverage | Blocked | QA can exercise no-commit-reveal, signature-invalid, proof-fail, and manual-review/award-block paths with stable expected outcomes. | Issue #11, PR #83, PR #92, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Smoke/E2E assertions, expected error/result matrix, rollback notes |
+| Audit evidence trail | In progress | Audit outputs show key lifecycle transitions plus enough proof/award context for operator review and beta sign-off. | Issue #10, PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
+| Planning + handoff hygiene | In progress | The planning docs, epic rollup, smoke matrix, and QA handoff docs all describe the same open blockers and merged work. | PR #82, PR #84, PR #95, PR #96, PR #97 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, QA handoff docs stay in sync |
+
+## Gate Details
+
+### 1. Contract convergence
+
+This is the main prerequisite for every downstream QA or audit activity.
+
+- Matching still depends on PR #55.
+- Verification status durability still depends on PR #66.
+- Manager shortlist/award reads still depend on PR #68.
+- Verifier terminal vocabulary and reason-code behavior still depend on PR #83.
+- Onboarding kickoff examples still depend on PR #90.
+- Audit-event and award-trace surface still depends on PR #92.
+
+Release note: if any of these contracts change enum names, required fields, or error-code wording,
+the same update must land in OpenSpec plus both API drafts before the gate can be marked ready.
+
+### 2. Happy-path execution
+
+The beta happy path is not just one demo; it needs one repeatable handoff pack:
+
+- QA smoke matrix in PR #84
+- frontend data-gap notes in PR #95
+- API example outline in PR #96
+- final executable E2E issue #11 after the contract gates settle
+
+The gate is ready only when a reviewer can follow one single source bundle from docs to API examples
+to smoke assertions without guessing missing fields.
+
+### 3. Negative-scenario coverage
+
+Closed beta needs confidence in failure handling, not just the green path.
+
+Minimum scenarios to keep visible:
+
+- reveal submitted without a valid prior commit
+- signature-invalid or malformed onboarding/task payload path
+- proof verification returns `FAIL`
+- proof verification returns `MANUAL_REVIEW`
+- award attempt blocked before prerequisite verification is complete
+
+The expected output for each scenario should cite either a stable error code or a stable terminal
+status/result so QA is not validating prose-only behavior.
+
+### 4. Audit evidence trail
+
+Audit readiness is the clearest remaining M4 blocker after contract convergence.
+
+The beta review pack should be able to answer:
+
+- what happened
+- when it happened
+- which task, bid, proof, and candidate were involved
+- why the award decision was allowed or blocked
+
+That evidence should come from the shared audit/telemetry surfaces, not from ad hoc reviewer notes.
+
+### 5. Planning + handoff hygiene
+
+This gate stays green only when the planning layer remains current after merges.
+
+At minimum, these docs must agree on which threads are still open:
+
+- `docs/PHASE1_CHECKPOINT_BOARD.md`
+- `docs/PHASE1_EPIC_STATUS.md`
+- `docs/PHASE1_GOALS.md`
+- `docs/ROADMAP.md`
+- the active QA handoff docs attached to issue #11 follow-through
+
+## Review Routine
+
+Review these gates whenever one of the following happens:
+
+- a Phase 1 PR merges or reopens
+- a contract enum or error-code changes
+- QA smoke scope changes
+- the epic #2 checklist changes
+
+If a gate changes status, update the epic rollup and the checkpoint board in the same review window.

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -73,6 +73,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - End-to-end happy path + key negative paths are covered by automated tests.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Epic #2 execution status is maintained in `docs/PHASE1_EPIC_STATUS.md` so acceptance gaps stay tied to live issue/PR state.
+- Closed-beta exit gates are tracked in `docs/PHASE1_BETA_READINESS_GATES.md` so contract, QA, audit, and planning blockers stay reviewable in one place.
 - Every active P1 issue/PR is mapped to an M1-M4 checkpoint in `docs/PHASE1_CHECKPOINT_BOARD.md` with an owner and target date.
 - Merge-train coordination follows `docs/MERGE_TRAIN_PLAYBOOK.md` so clean LGTM PRs merge promptly and dirty follow-on PRs keep an explicit owner/blocker note.
 - P0 baseline issues that block collaboration quality are closed or explicitly waived.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,6 +88,7 @@ Scope:
 - M3 (2026-04-03): PoMW policy + verifier baseline + bid/proof status-read visibility for agent UX.
 - M4 (2026-04-10): audit/reputation hook + E2E test pack + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.
+- Review `docs/PHASE1_BETA_READINESS_GATES.md` as the compact release-gate checklist for the remaining Phase 1 contract, QA, audit, and planning blockers.
 
 Checkpoint status board:
 - Review `docs/PHASE1_CHECKPOINT_BOARD.md` for the one-screen issue/PR map, target owners, and drift callouts.


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Add a compact Phase 1 beta-readiness gate tracker and wire it into the core planning docs

## What Changed

- added `docs/PHASE1_BETA_READINESS_GATES.md` to track the remaining closed-beta gates across contracts, QA, audit evidence, and planning hygiene
- linked the new gate tracker from `docs/PHASE1_GOALS.md` so the MVP definition of done points at one release-gate checklist
- linked the new gate tracker from `docs/ROADMAP.md` so the M4 readiness section points at the same source of truth

## Why

- epic #2 still has only broad status rollups, which makes it hard to see the exact beta sign-off gates and the evidence each gate still needs
- a compact gate tracker reduces review churn across planning, QA handoff, and backend contract threads by making the release blockers explicit in one place

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| OpenSpec artifacts 与 API/实现保持一致 | Adds a release-gate tracker that names the remaining contract-sync PRs and requires shared enum/error vocabulary to stay aligned before the gate is marked ready. | `docs/PHASE1_BETA_READINESS_GATES.md` |
| E2E happy path 可跑通 | Defines the happy-path gate in terms of the current QA smoke, API example, and frontend handoff dependencies that issue #11 still needs. | `docs/PHASE1_BETA_READINESS_GATES.md` |
| 核心负面场景（无 commit reveal、签名错误、PoMW 不达标）有测试 | Lists the minimum negative scenarios that must map to stable status or error outputs before beta sign-off. | `docs/PHASE1_BETA_READINESS_GATES.md` |
| 审计事件覆盖关键状态变迁 | Turns the audit trail into an explicit release gate tied to issue #10 / PR #92 and the telemetry handoff docs. | `docs/PHASE1_BETA_READINESS_GATES.md` |

## QA Plan

### Preconditions

- GitHub CLI authenticated for current issue/PR state checks
- Branch rebased on current `origin/main`

### Steps

1. Open `docs/PHASE1_BETA_READINESS_GATES.md`.
2. Verify the five gates point at the current open contract, QA, audit, and planning threads for epic #2.
3. Open `docs/PHASE1_GOALS.md` and `docs/ROADMAP.md` and confirm both link to the new gate tracker.

### Expected Results

- Reviewers can see the remaining beta blockers and required evidence in one document.
- The MVP definition of done and roadmap both point to the same release-gate checklist.
- No planning doc invents blocker states that are not represented in the active GitHub queue.

### Validation Output

- `openspec validate --all` -> pass (`1 passed, 0 failed`)
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent` -> pass
- `git diff --check` -> pass

## Risks and Rollback

- Risk:
  - The gate tracker can drift if follow-on merges are not reflected promptly.
- Rollback:
  - Revert commit `191c272` from this branch or remove `docs/PHASE1_BETA_READINESS_GATES.md` and the corresponding links.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
