### PR TITLE
[P1-31] Convert frontend data-gap notes into contract delta checklist

### DIFF
--- a/docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md
+++ b/docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md
@@ -1,0 +1,52 @@
+# Frontend Contract Delta Checklist (P1-31)
+
+Last updated: 2026-03-16
+
+Related issue: [#99](https://github.com/jckhang/agent-indeed/issues/99)
+
+Input references:
+- PR [#95](https://github.com/jckhang/agent-indeed/pull/95) frontend data-gap notes
+- `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md`
+- `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`
+- `docs/FRONTEND_MVP_SURFACE.md`
+
+## Objective
+
+Turn the frontend data-gap notes into one backend-facing checklist that reviewers can use without rereading every frontend slice document.
+
+Guardrails:
+- Only call out fields and behaviors that already exist in the active contract PRs or current baseline docs.
+- Mark anything that should stay blocked on upstream contract merge as an accepted risk instead of inventing a frontend-only payload.
+- Keep manager shortlist/award and agent verification/status-refresh follow-ups in one owner-grouped list.
+
+## Highest-priority deltas
+
+1. PR [#68](https://github.com/jckhang/agent-indeed/pull/68) must land before manager shortlist and award-readiness UI can move past dependency copy.
+2. PR [#66](https://github.com/jckhang/agent-indeed/pull/66) must land before the agent verification route can promise refresh-safe queued or verifying progress.
+3. PR [#83](https://github.com/jckhang/agent-indeed/pull/83) must stay aligned with PR [#66](https://github.com/jckhang/agent-indeed/pull/66) so terminal proof copy uses the same reason-code and trace vocabulary after polling.
+4. PR [#92](https://github.com/jckhang/agent-indeed/pull/92) closes the audit drill-in gap, but it should not be treated as a prerequisite for the manager shortlist shell itself.
+5. PR [#55](https://github.com/jckhang/agent-indeed/pull/55) remains the ranking baseline dependency that feeds PR [#68](https://github.com/jckhang/agent-indeed/pull/68); its fields should not drift while shortlist review stays in flight.
+
+## Owner-grouped checklist
+
+| Upstream owner | Frontend surface | Concrete contract delta or accepted risk | Why it blocks or shapes FE work |
+| --- | --- | --- | --- |
+| PR [#68](https://github.com/jckhang/agent-indeed/pull/68) shortlist + award read-model owner | Manager shortlist table and detail panel | Confirm `GET /v1/tasks/{taskId}/candidates` returns `agentId`, `bidId`, `identityTier`, `hardFilterPassed`, `eligibilityStatus`, `rankingScore`, optional `scoreBreakdown`, `missingDataStates`, `proofReadiness`, `shortlistAuditId`, and `decisionTraceHash`. | P1-20 depends on these fields to render ranked rows, missing-data fallback chips, proof-readiness badges, and shortlist trace links without hiding partially populated candidates. |
+| PR [#68](https://github.com/jckhang/agent-indeed/pull/68) shortlist + award read-model owner | Manager award-readiness rail | Confirm `GET /v1/tasks/{taskId}/award` exposes `status`, `statusMessage`, `awardedBidId`, `awardedAgentId`, `proofSummary`, `decisionTraceHash`, `auditEventId`, and `handoff.*`. | The award rail needs one manager-readable readiness source; otherwise the UI falls back to generic blocker copy and cannot distinguish review-ready from already-awarded or pending-contract states. |
+| PR [#68](https://github.com/jckhang/agent-indeed/pull/68) shortlist + award read-model owner | Award CTA state | Accepted risk: keep the manager `Award task` CTA disabled until both the award read model and `POST /v1/tasks/{taskId}/award` are on `main`; do not infer that a visible winner summary means the write path is ready. | Prevents the shortlist shell from implying interactive award support before the command and handoff contract are actually merged. |
+| PR [#66](https://github.com/jckhang/agent-indeed/pull/66) bid/proof status-read owner | Agent verification route and bid workspace resume | Confirm `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` stay the refresh-safe source for `commitState`, `revealState`, `proofState`, `awardState`, `requiredDifficulty`, `achievedDifficulty`, `reasonCodes`, `decisionTraceHash`, and `refresh.mode`, `pollAfterSeconds`, `manualRefreshAllowed`, `lastUpdatedAt`. | P1-21 and P1-22 need one honest polling model after reveal submit; without it, queued and verifying states remain dependency notes rather than reload-safe UI states. |
+| PR [#66](https://github.com/jckhang/agent-indeed/pull/66) bid/proof status-read owner | Agent verification refresh policy | Accepted risk: until the read endpoints merge, the post-reveal success screen may only hand off with `proofSubmission.proofId` and `verificationStatus=PENDING_VERIFY`; it must not promise live status recovery after refresh. | Keeps frontend copy aligned with current `main` instead of fabricating a timeline from write responses alone. |
+| PR [#83](https://github.com/jckhang/agent-indeed/pull/83) verifier contract owner | Terminal proof summary copy | Keep `ProofVerificationResponse` and reveal success payload vocabulary aligned on `verificationStatus`, `decisionTraceHash`, `reasonCodes`, `requiredDifficulty`, and `achievedDifficulty`. | Agent, manager, and operator views need the same proof-result nouns once polling returns a terminal decision; otherwise failure messaging drifts across surfaces. |
+| PR [#83](https://github.com/jckhang/agent-indeed/pull/83) verifier contract owner | Immediate reveal confirmation | Accepted risk: before PR [#66](https://github.com/jckhang/agent-indeed/pull/66) merges, terminal verification details from PR [#83](https://github.com/jckhang/agent-indeed/pull/83) should stay out of refresh-safe UI promises and remain limited to post-submit handoff copy. | Avoids implying that proof verification is already queryable when the read contract is still separate work. |
+| PR [#92](https://github.com/jckhang/agent-indeed/pull/92) audit event-stream owner | Manager and operator audit drill-in | Confirm `GET /v1/tasks/{taskId}/events` and `GET /v1/bids/{bidId}/events` expose `eventType`, `eventId`, `actorRole`, `actorId`, `taskId`, `bidId`, `proofId`, `auditId`, `traceHash`, `summary`, `occurredAt`, and `completeness`. | Award review and audit timeline links need a durable event read path so users can inspect trace context instead of relying on raw logs or inferred history. |
+| PR [#92](https://github.com/jckhang/agent-indeed/pull/92) audit event-stream owner | Award trace fallback | Confirm `TASK_AWARDED` event payloads carry `decisionTraceHash`, score summary, proof summary, and completeness markers that match the award-read shell. | Lets manager and operator views distinguish "field intentionally absent" from "audit write missing" when the award outcome is under review. |
+| PR [#55](https://github.com/jckhang/agent-indeed/pull/55) shortlist ranking baseline owner | Ranking chips and shortlist fallback copy | Keep shortlist ranking baseline fields aligned with PR [#68](https://github.com/jckhang/agent-indeed/pull/68): `hardFilterPassed`, `rankingScore`, and optional `scoreBreakdown` must remain the canonical ranking inputs. | The shortlist shell should inherit one scoring vocabulary instead of maintaining separate frontend assumptions for baseline matching versus manager review. |
+| PR [#55](https://github.com/jckhang/agent-indeed/pull/55) shortlist ranking baseline owner | Missing ranking detail behavior | Accepted risk: if `scoreBreakdown` is absent, the UI should continue rendering shortlist rows and show `Pending backend score breakdown` rather than suppressing candidates or inventing zero values. | Keeps shortlist review usable while score detail remains partial and avoids converting incomplete ranking data into false certainty. |
+
+## Merge-order notes for reviewers
+
+- Merge PR [#68](https://github.com/jckhang/agent-indeed/pull/68) before treating manager shortlist or award-readiness acceptance criteria as contract-complete.
+- Merge PR [#66](https://github.com/jckhang/agent-indeed/pull/66) before treating agent verification polling or browser-refresh recovery as shippable.
+- Keep PR [#83](https://github.com/jckhang/agent-indeed/pull/83) and PR [#66](https://github.com/jckhang/agent-indeed/pull/66) synchronized on proof result fields so queued-to-terminal transitions do not fork.
+- Use PR [#92](https://github.com/jckhang/agent-indeed/pull/92) to answer audit drill-in questions, not to backfill the manager award shell with ad hoc event parsing.
+- Treat PR [#55](https://github.com/jckhang/agent-indeed/pull/55) as the ranking baseline; any shortlist-review change that renames or drops those fields should be called out before merge.

--- a/docs/FRONTEND_MVP_SURFACE.md
+++ b/docs/FRONTEND_MVP_SURFACE.md
@@ -4,6 +4,9 @@ Last updated: 2026-03-15
 
 Related issue: [#33](https://github.com/jckhang/agent-indeed/issues/33)
 
+Related follow-up:
+- `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md` converts the current frontend shortlist, award, verification, and audit data gaps into one owner-grouped backend merge checklist for issue [#99](https://github.com/jckhang/agent-indeed/issues/99).
+
 ## Goal
 
 Define the minimum manager, agent, and operator console surface needed to execute the closed-beta lifecycle:

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -36,6 +36,7 @@ Ship the first usable agent dispatch loop for closed beta:
   - historical similarity
 - Manager console baseline is captured in `docs/MANAGER_CONSOLE_BASELINE.md` so task publish, shortlist review, and award-state acceptance criteria stay reviewable while shortlist/award read-model gaps are still backend follow-ups.
 - The focused shortlist/award manager review slice is captured in `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md` so fallback states and award blockers stay explicit while shortlist/award contracts remain under review.
+- The contract-delta checklist in `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md` groups remaining shortlist, award, verification, and audit asks by upstream PR owner so frontend follow-ups stay actionable without inventing payloads.
 
 ### G3. Bidding and PoMW baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,6 +43,7 @@ Scope:
 - Manager console baseline (`docs/MANAGER_CONSOLE_BASELINE.md`, issue #43 / PR #53) keeps the publish form, shortlist evidence, and award-summary dependency notes visible while interactive award APIs are still pending.
 - Manager task-composer frontend slice (`docs/MANAGER_TASK_COMPOSER_UI_SLICE.md`, issue #61 / PR #70) documents the current task-create contract and calls out idempotency follow-up explicitly.
 - Manager shortlist review slice (`docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md`, issue #62) keeps shortlist fallback states and award blockers reviewable while shortlist/award contracts remain in flight.
+- Frontend contract-delta checklist (`docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md`, issue #99) turns the latest shortlist, award, verification, and audit data gaps into one merge-order checklist for backend reviewers.
 - Commit-reveal bidding workflow.
 - Agent bidding console baseline (`docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, issue #44 / PR #56) keeps the broader commit/reveal + verification journey visible.
 - Dedicated bid workspace slice (`docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, issue #63 / PR #76) narrows the next frontend delivery item to one commit/reveal workflow while leaving async refresh on the backend follow-up track (#59).

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -39,6 +39,7 @@
 - P1-23 #65: https://github.com/jckhang/agent-indeed/issues/65
 - P1-24 #71: https://github.com/jckhang/agent-indeed/issues/71
 - P1-25 #72: https://github.com/jckhang/agent-indeed/issues/72
+- P1-31 #99: https://github.com/jckhang/agent-indeed/issues/99
 
 ## P0 Readiness
 
@@ -474,3 +475,16 @@ Acceptance criteria:
 Backlog notes:
 - `queued` and `verifying` remain dependency states until the bid/proof status read contract merges.
 - Refresh metadata should stay shared between agent and operator read models.
+
+### P1-31 Convert frontend data-gap notes into contract delta checklist
+
+References:
+- `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md`
+- `docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md`
+- `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`
+- `docs/FRONTEND_MVP_SURFACE.md`
+
+Acceptance criteria:
+- Every remaining shortlist, award, verification, and audit frontend data gap is written as a concrete contract delta or explicit accepted risk.
+- Each delta points to one owning upstream PR or issue so reviewers can act without rereading all frontend docs.
+- The output stays compact enough to use as a near-term merge checklist instead of a new broad design document.

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -58,6 +58,7 @@
    - agent 侧验证时间线至少区分 queued、verifying、PASS、FAIL、MANUAL_REVIEW 五类状态。
    - 在 bid/proof read contract 合入前，前端不得把 queued/verifying 当作已可查询事实，只能作为受限 pending UX 呈现。
    - MVP 的刷新策略以显式轮询 contract 为目标；若 read endpoint 尚未合入，必须展示依赖说明而不是伪造实时刷新。
+   - 前端后续跟进应通过一份按上游 contract owner 分组的 delta checklist 维护，明确哪些字段仍待合入、哪些风险被显式接受，避免在多个 slice 文档里重复散落同一批 contract ask。
 
 8. 建立 MVP 生命周期可观测性基线
    - 为 `upload -> match -> bid -> verify -> award` 每个阶段定义必选事件、trace 属性、结构化日志字段与指标族。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -25,6 +25,7 @@
 - [ ] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
 - [ ] 3.2 实现候选筛选策略（硬过滤 + 软排序）与评分字段。
 - [x] 3.3 设计 commit-reveal 竞标接口与时序约束。
+- [x] 3.4 输出 `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md`，按 shortlist / award / bid-proof read / audit event 相关上游 PR 分组剩余前端 contract delta 与 accepted risk。
 
 ## 4. PoMW 与审计闭环
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #99
- Department label (pick one): `dept/frontend`
- Type label (pick one): `type/docs`
- Scope: Convert the frontend data-gap notes into a compact, owner-grouped contract delta checklist.

## What Changed

- Added `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md` to group shortlist, award, verification, and audit follow-ups by upstream contract PR owner.
- Linked the new checklist from `docs/FRONTEND_MVP_SURFACE.md`, `docs/PHASE1_GOALS.md`, and `docs/ROADMAP.md` so the frontend lane stays synced with planning docs.
- Added P1-31 tracking to `docs/issues/PHASE1_ISSUES.md`.
- Updated `openspec/changes/agent-dispatch-platform/design.md` and `openspec/changes/agent-dispatch-platform/tasks.md` so the OpenSpec change log reflects the new frontend contract-delta artifact.

## Why

- PR #95 captured the frontend data gaps, but backend reviewers still needed one small checklist they could act on without reopening multiple frontend slice docs.
- This keeps the frontend lane explicit about remaining shortlist, award, verification, and audit dependencies while avoiding any frontend-only contract invention.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Every remaining frontend data gap is written as a concrete contract delta or explicit accepted risk | The new checklist records each remaining shortlist, award, verification, and audit gap as either a concrete upstream ask or an accepted risk. | `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md` |
| Each gap points to one owning backend PR or issue | Every checklist row is grouped under PR #55, #66, #68, #83, or #92 and includes direct links. | `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md` |
| The output is small enough for backend reviewers to use as a merge checklist in the next 24 hours | The doc keeps one compact priority list plus one owner-grouped table, and the surrounding planning docs link back to it instead of duplicating detail. | `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md`, `docs/FRONTEND_MVP_SURFACE.md`, `docs/ROADMAP.md` |

## QA Plan

### Preconditions

- Work from updated `main` on a fresh `codex/p1-31-contract-delta-checklist` branch.

### Steps

1. Open `docs/FRONTEND_CONTRACT_DELTA_CHECKLIST.md`.
2. Verify the checklist covers manager shortlist/award plus agent verification/status-refresh follow-ups.
3. Confirm each row points to one upstream PR and that planning/OpenSpec docs link to the new artifact.
4. Run validation commands.

### Expected Results

- The checklist is compact, owner-grouped, and contains only contract fields already present in active PRs or current docs.
- Planning and OpenSpec references stay aligned with the new P1-31 artifact.
- Validation passes cleanly.

### Validation Output

- `openspec validate --changes`
- `openspec validate --all`
- `git diff --check`

## Risks and Rollback

- Risk:
  - Reviewers may still reorder the backend merge sequence, so the checklist must remain explicit that it is a planning aid rather than a contract source of truth.
- Rollback:
  - Revert this PR to remove the checklist and linked planning/OpenSpec references.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
