### PR TITLE
[P1-32] Turn API example outline into QA-ready handoff pack

### DIFF
--- a/docs/MVP_API_QA_HANDOFF_PACK.md
+++ b/docs/MVP_API_QA_HANDOFF_PACK.md
@@ -1,0 +1,85 @@
+# MVP API QA Handoff Pack
+
+Last updated: 2026-03-16
+
+## Objective
+
+Turn the MVP API example outline into one reviewer-ready handoff pack for the closed-beta happy path:
+`publish -> match -> commit -> reveal -> verify -> award`.
+
+This pack is the contract-facing companion to the smoke materials. Use it when QA, planning, or reviewers
+need one place that names the current request/response surfaces, the canonical enum vocabulary, and the open
+contract blockers that still prevent full end-to-end execution.
+
+## How QA Should Use This Pack
+
+1. Start with the sequence table below and confirm each step against the named source of truth.
+2. Treat any step marked `Blocked` as documentation-only until the listed PR(s) merge.
+3. Reuse the exact field and enum names listed here in smoke assertions and future E2E cases.
+4. Pair this pack with the active beta-readiness gate review and `docs/PHASE1_EPIC_STATUS.md` when updating
+   issue #87 or issue #11.
+
+## Canonical Vocabulary To Reuse Verbatim
+
+| Surface | Canonical values | Source of truth |
+| --- | --- | --- |
+| Identity tier | `T0`, `T1`, `T2` | `openspec/changes/agent-dispatch-platform/design.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |
+| Bid window phase | `COMMIT_OPEN`, `REVEAL_OPEN`, `CLOSED` | `src/api/openapi.yaml`, `src/api/contracts.ts` |
+| Reveal proof tracking status | `PENDING_VERIFY`, `PASS`, `FAIL`, `MANUAL_REVIEW` | `src/api/openapi.yaml`, `src/api/contracts.ts` |
+| Verification terminal result | `PASS`, `FAIL`, `MANUAL_REVIEW` | `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |
+| Proof policy strength | `LOW`, `MEDIUM`, `HIGH`, `VERY_HIGH` | `openspec/changes/agent-dispatch-platform/design.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |
+| Proof challenge profile | `SAMPLE_EXECUTION`, `HASHCASH`, `STAKE`, `HYBRID` | `openspec/changes/agent-dispatch-platform/design.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |
+
+## Happy-Path Sequence
+
+| Step | API / artifact | Minimum request facts QA should expect | Minimum response / evidence QA should expect | Current source of truth | Status | Blocking contract thread |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1. Publish task | `POST /v1/tasks` | `workspaceId` header plus `task.title`, `task.description`, `task.budget`, `task.sla`, `task.constraints`, `task.risk`, `task.powmPolicy`, `task.biddingWindow` | `201` create response proving the task entered marketplace with stable task payload fields | `src/api/openapi.yaml`, `src/api/contracts.ts`, OpenSpec task-marketplace spec | Ready now | None |
+| 2. Match candidates | Publish-side shortlist kickoff after `POST /v1/tasks` | Same publish payload must carry `constraints.identityTierMin`, `constraints.requiredSkills`, risk, and PoMW inputs so matching can run deterministically | Candidate shortlist/ranking evidence is still expected to come from the matching contract rather than ad hoc docs | OpenSpec task-marketplace spec, `src/api/openapi.yaml`, open PR #55 | Blocked | PR #55 / issue #6 |
+| 3. Commit bid | `POST /v1/tasks/{taskId}/bids/commit` | `commit.bidId`, `commit.taskId`, `commit.agentId`, `commit.bidHash`, `idempotencyKey` | `202` with `status=COMMITTED`, echoed commit payload, and `window.currentPhase`, `commitDeadline`, `revealDeadline`, `serverTime`, `nextAction` | `src/api/openapi.yaml`, `src/api/contracts.ts`, OpenSpec task-marketplace spec | Ready now | None |
+| 4. Reveal bid | `POST /v1/tasks/{taskId}/bids/reveal` | `reveal.bidId`, `reveal.taskId`, `reveal.agentId`, commercial fields, and `proof` payload tied to the commit hash | `200` with `status=REVEALED`, `rankingScore`, `decisionTraceHash`, `proofSubmission.proofId`, `proofSubmission.verificationStatus`, and updated window snapshot | `src/api/openapi.yaml`, `src/api/contracts.ts`, OpenSpec task-marketplace spec | Partially ready | Proof read freshness still depends on PR #66 |
+| 5. Resolve proof policy | `POST /v1/tasks/{taskId}/proof-policy` | `agentId`, `identityTier`, optional `trustScore` | `policyTraceId`, `requiredProofStrength`, `challengeProfile`, `verifierParams`, `inputSnapshot`, `persistedAt` | `src/api/openapi.yaml`, `src/api/contracts.ts`, OpenSpec design/spec | Ready now | None |
+| 6. Verify proof | `POST /v1/tasks/{taskId}/proofs/verify` | `policyTraceId` from the persisted policy step plus full `proof` payload | `200` response with `proofId`, `result`, `policyTraceId`, `requiredPolicy`, `requiredDifficulty`, `achievedDifficulty`, optional `reasonCodes`; error path may return `PROOF_VERIFY_FAILED` or `PROOF_VERIFY_NEEDS_REVIEW` | `src/api/openapi.yaml`, `src/api/contracts.ts`, OpenSpec task-marketplace spec, open PR #83 | Blocked | PR #83 / issue #9 and PR #66 / issue #59 |
+| 7. Award decision | Manager shortlist/award read models plus audit trace follow-through | Award flow must preserve shortlist evidence, proof result summary, and audit linkage instead of inventing manager-side fields | QA should expect stable shortlist/award evidence, explicit blockers before award, and audit-ready identifiers (`audit_id`, proof result summary, score trace) | OpenSpec task-marketplace spec, `docs/MVP_TELEMETRY_HANDOFF.md`, open PR #68, open PR #92 | Blocked | PR #68 / issue #58 and PR #92 / issue #10 |
+
+## Step-by-Step Notes For QA
+
+### 1. Publish -> Match handoff
+
+- The publish contract already defines the manager write surface, but it does not yet give QA a merged shortlist/ranking read contract.
+- Treat the publish request as stable enough to validate required inputs now.
+- Do not hard-code shortlist response fields until PR #55 merges.
+
+### 2. Commit -> Reveal handoff
+
+- The commit/reveal write path is the most stable part of the current happy path.
+- Reuse the exact error names already present in the API draft for negative-path prep: `BID_COMMIT_WINDOW_CLOSED`, `BID_REVEAL_COMMIT_NOT_FOUND`, and `BID_REVEAL_HASH_MISMATCH`.
+- Keep `proofSubmission.verificationStatus` distinct from the later verifier `result`; the reveal response can surface `PENDING_VERIFY` before a terminal verifier result exists.
+
+### 3. Proof policy -> verify handoff
+
+- QA should always pair `POST /v1/tasks/{taskId}/proof-policy` with `POST /v1/tasks/{taskId}/proofs/verify`.
+- The verifier request is not valid without the persisted `policyTraceId` from the policy step.
+- Until PR #66 merges, any refresh-safe readback of queued/verifying proof state remains dependency-bounded rather than fully merged contract surface.
+
+### 4. Award handoff
+
+- The award step is still documentation-first because the shortlist read model and audit trace outputs are both under review.
+- For now, QA should assert that award remains blocked until the shortlisted candidate evidence, proof result summary, and audit identifiers come from the same contract set.
+- Treat `docs/MVP_TELEMETRY_HANDOFF.md` as the current checklist for the audit identifiers that cannot be dropped once award surfaces merge.
+
+## Blocker Map
+
+| Step blocked today | Why QA cannot close it yet | Owning thread |
+| --- | --- | --- |
+| Match evidence | Candidate shortlist/ranking response is still being finalized | PR #55 / issue #6 |
+| Verification refresh/readback | Refresh-safe proof status reads are not merged yet | PR #66 / issue #59 |
+| Verifier terminal contract | Final verifier/result-code contract is still under review | PR #83 / issue #9 |
+| Award review fields | Manager shortlist and award-read model is not merged yet | PR #68 / issue #58 |
+| Audit-backed award trace | Audit/event surface needed for final beta sign-off is not merged yet | PR #92 / issue #10 |
+
+## Immediate Follow-Through For Issue #87 And Issue #11
+
+- Issue #87 should use this pack as the source for happy-path step ordering and shared enum names.
+- Issue #11 should keep the same sequence but convert only the `Ready now` steps into executable checks until the blocked contract PRs merge.
+- When any blocker merges, update this pack and `docs/PHASE1_EPIC_STATUS.md` in the same review window so QA and planning stay aligned.

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -1,6 +1,6 @@
 # Phase 1 Checkpoint Board
 
-Last updated: 2026-03-15
+Last updated: 2026-03-16
 
 This is the single review surface for milestone drift across the active execution-track Phase 1 issues and PRs.
 
@@ -11,7 +11,7 @@ This is the single review surface for milestone drift across the active executio
 | M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | Contract finalization, observability baseline, onboarding kickoff | #30 | #90 | On track | PR #90 is the remaining M1 delivery in review; keep the kickoff examples aligned with the merged observability baseline. |
 | M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | Candidate matching, commit-reveal APIs, manager console baseline | #6 | #55 | At risk | Matching contract work is still in review; downstream manager and agent UX must keep honoring the current shortlist contract until it merges. |
 | M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | Verifier contract, agent workspace, bid/proof async status reads | #9, #59, #63, #64 | #66, #73, #76, #83 | At risk | PRs #73 and #76 keep the Lanzhou frontend slices moving, but durable verification/status semantics still depend on the open verifier and status-read contract work. |
-| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, manager award reads, shortlist review, security readiness, QA smoke pass | #10, #11, #58, #62, #72 | #68, #77, #78, #84 | At risk | Manager award reads, auditability, and QA coverage are still blocked on open backend contracts, while security and shortlist follow-through remain in review. |
+| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | Audit trail, manager award reads, shortlist review, security readiness, QA smoke pass, API handoff pack | #10, #11, #58, #62, #72, #100 | #68, #77, #78, #84 | At risk | Manager award reads, auditability, and QA coverage are still blocked on open backend contracts, while the QA handoff pack keeps issue #87 and issue #11 aligned on the same happy-path artifact. |
 
 ## Active P1 Issue Map
 
@@ -28,6 +28,7 @@ This is the single review surface for milestone drift across the active executio
 | #58 `Define manager shortlist and award read-model contracts` | M4 | 2026-04-10 | kestrel | in-review | Backed by PR #68 and still the main contract dependency for manager shortlist/award follow-through. |
 | #62 `Implement shortlist review and award-readiness UI slice` | M4 | 2026-04-10 | lanzhou-fe-agent | in-review | PR #78 keeps the shortlist/award-readiness follow-through visible while award execution remains backend-gated. |
 | #72 `Operationalize closed-beta security readiness checklist` | M4 | 2026-04-10 | albatross-dev-agent | in-review | PR #77 keeps the auth/redaction checklist active while API and contract sync feedback lands. |
+| #100 `[P1-32] Turn API example outline into QA-ready handoff pack` | M4 | 2026-04-10 | lan | ready-next | Produces the ordered contract/evidence pack that QA uses before the blocked backend award/verify slices merge. |
 
 ## Active P1 PR Map
 

--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -1,6 +1,6 @@
 # Phase 1 Epic Status
 
-Last updated: 2026-03-15
+Last updated: 2026-03-16
 
 This document is the execution snapshot for epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`).
 It complements `docs/PHASE1_GOALS.md` by mapping the epic acceptance criteria to the current issue, PR,
@@ -16,7 +16,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
 | OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts` | Keep open PRs #55, #66, #68, #77 aligned with current spec/contracts. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issue #11 | Needs remaining M2-M4 backend/UI contracts plus active QA smoke follow-through in issue #87 / PR #84 before E2E issue #11 can be closed. |
+| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issue #11, `docs/MVP_API_QA_HANDOFF_PACK.md` | Needs remaining M2-M4 backend/UI contracts plus the new QA handoff pack in issue #100 and active smoke follow-through in issue #87 / PR #84 before E2E issue #11 can be closed. |
 | Core negative scenarios are covered | Blocked | issue #11, issue #72, `docs/SECURITY_COMPLIANCE_BASELINE.md` | Convert merged security/readiness guidance into executable QA coverage after verifier and award flows settle. |
 | Audit events cover key state transitions | In progress | issue #10, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md` | Land award/audit trace work after shortlist, status polling, and verifier outputs are stable. |
 
@@ -43,6 +43,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Security gate | issue #72 / PR #77 | Closed-beta auth, secrets, and redaction guidance must merge before epic sign-off. |
 | Planning sync | issue #80 / PR #82 | Planning docs must stay aligned so epic status is not tracking already-merged work as active. |
 | QA smoke coverage | issue #87 / PR #84 | Smoke validation is the bridge between the merged UI slices and final E2E confidence. |
+| QA API handoff pack | issue #100 | The pack converts the API outline into one ordered contract/evidence bundle that issue #87 and issue #11 can both consume. |
 
 ### Remaining blocked slices
 
@@ -66,7 +67,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 - [ ] Proof verification result codes and async status reads are merged.
 - [ ] Award-read contracts and award-readiness UI are merged.
 - [ ] Audit trace outputs are defined for beta review.
-- [ ] QA smoke matrix and MVP E2E coverage are ready to run.
+- [ ] QA smoke matrix, API handoff pack, and MVP E2E coverage are ready to run.
 - [ ] Security/compliance readiness checklist is merged and linked to QA validation.
 
 ## Review Routine

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -39,6 +39,7 @@
 - P1-23 #65: https://github.com/jckhang/agent-indeed/issues/65
 - P1-24 #71: https://github.com/jckhang/agent-indeed/issues/71
 - P1-25 #72: https://github.com/jckhang/agent-indeed/issues/72
+- P1-32 #100: https://github.com/jckhang/agent-indeed/issues/100
 
 ## P0 Readiness
 
@@ -474,3 +475,17 @@ Acceptance criteria:
 Backlog notes:
 - `queued` and `verifying` remain dependency states until the bid/proof status read contract merges.
 - Refresh metadata should stay shared between agent and operator read models.
+
+### P1-32 Turn API example outline into QA-ready handoff pack
+
+References:
+- `docs/MVP_API_QA_HANDOFF_PACK.md`
+- `docs/PHASE1_EPIC_STATUS.md`
+- `docs/PHASE1_CHECKPOINT_BOARD.md`
+- `src/api/openapi.yaml`
+- `src/api/contracts.ts`
+
+Acceptance criteria:
+- One ordered handoff artifact exists for the MVP happy path.
+- Every blocked step cites the owning contract PR or issue.
+- QA can reuse exact field and enum names without guessing missing values.

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -65,6 +65,7 @@
    - 对关键失败族建立最小告警面：上载校验失败、候选检索退化、commit/reveal 完整性异常、PoMW 校验超时、award/audit 缺失。
    - 对审计关联事件、错误日志、trace、指标分别定义最小保留期，优先保留脱敏后的调试上下文而非原始敏感负载。
    - 下游实现必须维护一份 handoff 清单，将当前 endpoint / job、活跃 issue / PR、缺失 `job_id` / async read / `audit_id` 合同等问题显式绑定到交付负责人，避免仅有基线文档而没有落地闭环。
+- 闭测 QA handoff 文档必须对 `publish -> match -> bid -> verify -> award` 提供单一路径说明，逐步标注 source of truth（OpenSpec / OpenAPI / TypeScript contract / open PR）以及未合并合同阻塞，避免 smoke/E2E 用例自行发明字段或枚举别名。
 
 8. 建立 merge-train 协作例行
    - 规划负责人使用统一查询区分 clean LGTM PR 与 dirty follow-on queue，而不是把瞬时状态复制到仓库文档。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -14,6 +14,7 @@
   - agent 上传与生产资料同步能力
   - 任务市场匹配、竞标与 PoMW 验证能力
 - 补充 MVP 生命周期可观测性基线，覆盖事件、trace、日志、指标、告警与保留期约束。
+- 补充 QA handoff pack 约束，要求 happy-path API 示例、阻塞合同与 QA/E2E 资料使用同一套字段与枚举命名。
 - 补充 merge-train 协作手册，统一 clean LGTM PR 合并、dirty queue 回写与 rebase 流程。
 - 明确身份分层（T0/T1/T2）下的 PoMW 强度策略。
 - 定义从任务发布到中标执行的关键状态流转与审计要求。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #100
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Turn the API example outline into a single QA-ready MVP handoff pack and link it into the active Phase 1 planning surfaces.

## What Changed

- added `docs/MVP_API_QA_HANDOFF_PACK.md` as the ordered `publish -> match -> commit -> reveal -> verify -> award` QA handoff artifact
- mapped each happy-path step to its current source of truth plus the blocking contract PR/issue when the step is not fully merged
- updated `docs/PHASE1_EPIC_STATUS.md` and `docs/PHASE1_CHECKPOINT_BOARD.md` so issue #100 is visible in the active M4 readiness stack
- added a durable backlog entry for P1-32 in `docs/issues/PHASE1_ISSUES.md`
- updated the active OpenSpec proposal/design text so the QA handoff-pack requirement is tracked in the spec-first artifacts too

## Why

- QA had an API example outline, but not one compact artifact that says which fields and enums are already canonical versus which steps are still blocked on open backend contract PRs.
- Without that pack, issue #87 and issue #11 risk inventing doc-only field names or drifting from the current OpenSpec/OpenAPI/contracts vocabulary.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| One ordered handoff artifact exists for the MVP happy path | Added one dedicated handoff doc with the full publish/match/commit/reveal/verify/award sequence | `docs/MVP_API_QA_HANDOFF_PACK.md` |
| Every blocked step cites the owning contract PR or issue | Added blocker/status columns plus a blocker map for match, verify refresh, verifier contract, award reads, and audit trace gaps | `docs/MVP_API_QA_HANDOFF_PACK.md` |
| QA can use the pack without guessing missing fields or enum names | Captured canonical enum vocabulary and minimum request/response facts directly from OpenSpec/OpenAPI/contracts | `docs/MVP_API_QA_HANDOFF_PACK.md`, `openspec/changes/agent-dispatch-platform/design.md`, `src/api/openapi.yaml`, `src/api/contracts.ts` |

## QA Plan

### Preconditions

- Repo is on branch `codex/p1-32-qa-handoff-pack`
- GitHub issue #100 is open and the referenced contract PRs (#55, #66, #68, #83, #92) are still open review threads

### Steps

1. Open `docs/MVP_API_QA_HANDOFF_PACK.md` and verify the happy-path sequence is ordered `publish -> match -> commit -> reveal -> verify -> award`.
2. Cross-check the listed field names and enums against `src/api/openapi.yaml` and `src/api/contracts.ts`.
3. Confirm `docs/PHASE1_EPIC_STATUS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, and `docs/issues/PHASE1_ISSUES.md` all reference issue #100 consistently.
4. Run the validation commands below.

### Expected Results

- QA gets one reusable handoff artifact for issue #87 and issue #11.
- Every blocked step in the pack points to the owning backend contract thread.
- Planning/OpenSpec surfaces stay aligned with the new handoff artifact.

### Validation Output

- `openspec validate --all` -> `Totals: 1 passed, 0 failed (1 items)`
- `git diff --check` -> no output
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent` -> `Pre-push guard passed.`

## Risks and Rollback

- Risk:
  - The pack could drift if the open backend contract PRs rename fields or enums before merge.
- Rollback:
  - Revert commit `d45458a` or remove the new handoff doc and linked planning/OpenSpec references if the issue scope changes.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
