### PR TITLE
docs: sync phase 1 beta readiness gates

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -14,10 +14,10 @@ reviewable release gates for closed-beta readiness. It complements:
 | Gate | Status | Ready when | Active dependencies | Evidence to collect |
 | --- | --- | --- | --- | --- |
 | Contract convergence | In progress | The remaining backend contract PRs are merged and the shared enum/error vocabulary is stable across OpenSpec, OpenAPI, and TypeScript contracts. | PR #55, PR #66, PR #68, PR #83, PR #90, PR #92 | `openspec validate --all`, contract diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts` |
-| Happy-path execution | Blocked | The team can trace one publish -> match -> commit -> reveal -> verify -> award flow without relying on undocumented fields or manual interpretation. | Issue #11, PR #84, PR #95, PR #96, plus the contract gate above | QA smoke checklist, API examples, merged frontend data-gap notes |
-| Negative-scenario coverage | Blocked | QA can exercise no-commit-reveal, signature-invalid, proof-fail, and manual-review/award-block paths with stable expected outcomes. | Issue #11, PR #83, PR #92, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Smoke/E2E assertions, expected error/result matrix, rollback notes |
+| Happy-path execution | Blocked | The team can trace one publish -> match -> commit -> reveal -> verify -> award flow without relying on undocumented fields or manual interpretation. | Issue #11, issue #101, PR #84, PR #95, PR #96, plus the contract gate above | QA smoke checklist, merged assertion matrix, API examples, merged frontend data-gap notes |
+| Negative-scenario coverage | Blocked | QA can exercise no-commit-reveal, signature-invalid, proof-fail, and manual-review/award-block paths with stable expected outcomes. | Issue #11, issue #101, PR #83, PR #92, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Smoke/E2E assertions, expected error/result matrix, rollback notes |
 | Audit evidence trail | In progress | Audit outputs show key lifecycle transitions plus enough proof/award context for operator review and beta sign-off. | Issue #10, PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Planning + handoff hygiene | In progress | The planning docs, epic rollup, smoke matrix, and QA handoff docs all describe the same open blockers and merged work. | PR #82, PR #84, PR #95, PR #96, PR #97 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, QA handoff docs stay in sync |
+| Planning + handoff hygiene | In progress | The planning docs, epic rollup, smoke matrix, and QA handoff docs all describe the same open blockers and merged work. | PR #82, issue #87, issue #101, PR #95, PR #96 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/MVP_E2E_ASSERTION_MATRIX.md`, QA handoff docs stay in sync |
 
 ## Gate Details
 
@@ -39,13 +39,14 @@ the same update must land in OpenSpec plus both API drafts before the gate can b
 
 The beta happy path is not just one demo; it needs one repeatable handoff pack:
 
+- prewritten assertion matrix in issue #101 / `docs/MVP_E2E_ASSERTION_MATRIX.md`
 - QA smoke matrix in PR #84
 - frontend data-gap notes in PR #95
 - API example outline in PR #96
 - final executable E2E issue #11 after the contract gates settle
 
 The gate is ready only when a reviewer can follow one single source bundle from docs to API examples
-to smoke assertions without guessing missing fields.
+to smoke assertions without guessing missing fields or relying on an open-PR-only document on `main`.
 
 ### 3. Negative-scenario coverage
 
@@ -60,7 +61,8 @@ Minimum scenarios to keep visible:
 - award attempt blocked before prerequisite verification is complete
 
 The expected output for each scenario should cite either a stable error code or a stable terminal
-status/result so QA is not validating prose-only behavior.
+status/result so QA is not validating prose-only behavior. Issue #101 is the prewritten matrix that
+should carry these scenarios forward into issue #87 smoke coverage and later issue #11 automation.
 
 ### 4. Audit evidence trail
 
@@ -83,6 +85,7 @@ At minimum, these docs must agree on which threads are still open:
 
 - `docs/PHASE1_CHECKPOINT_BOARD.md`
 - `docs/PHASE1_EPIC_STATUS.md`
+- `docs/MVP_E2E_ASSERTION_MATRIX.md`
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
 - the active QA handoff docs attached to issue #11 follow-through

--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -16,8 +16,8 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
 | OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts` | Keep open PRs #55, #66, #68, #83, #90, and #92 aligned with the current spec/contracts surface. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issue #11 | Needs the remaining M2-M4 contract PRs plus QA handoff docs (#84, #95, #96) before issue #11 can turn into executable coverage. |
-| Core negative scenarios are covered | Blocked | issue #11, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Security-readiness guidance is merged; the next gate is converting it into smoke/E2E assertions once verifier and award traces stabilize. |
+| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issue #11, `docs/MVP_E2E_ASSERTION_MATRIX.md` | Needs the remaining M2-M4 contract PRs plus the QA handoff chain in issue #87, issue #101, PR #95, and PR #96 before issue #11 can turn into executable coverage. |
+| Core negative scenarios are covered | Blocked | issue #11, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/MVP_E2E_ASSERTION_MATRIX.md` | Security-readiness guidance is merged; the next gate is converting it into smoke/E2E assertions once verifier and award traces stabilize. |
 | Audit events cover key state transitions | In progress | issue #10, PR #92, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md` | Land audit-event stream and award-trace contracts, then fold them into the QA example and smoke-pack work. |
 
 ## Delivery Slice Status
@@ -48,6 +48,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Planning sync | issue #80 / PR #82 | Planning docs must stay aligned so epic status is not tracking already-merged work as active. |
 | QA smoke coverage | issue #87 / PR #84 | Smoke validation is the bridge between the merged UI slices and final E2E confidence. |
 | QA handoff pack | issue #11, PR #95, PR #96 | The QA-facing API outline and frontend data-gap docs still need to merge so smoke and E2E work use one current handoff set. |
+| QA assertion prewrite | issue #101 | The assertion matrix now holds the ready-now vs blocked checkpoints that smoke and E2E should reuse verbatim while the handoff pack is still landing. |
 
 ### Remaining blocked slices
 
@@ -61,7 +62,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | M1 | Upload baseline | Issue #30 is closed; PR #90 is the only remaining M1 example/kickoff thread. |
 | M2 | Publish, shortlist, and bid foundation | Still gated by PR #55 even though manager task-composer and shortlist UI slices are merged. |
 | M3 | Verify and agent flow | Agent UX slices are merged; status reads (#66) and verifier contract finalization (#83) remain the active gate. |
-| M4 | Award, audit, and beta readiness | Security is merged, but award-read, audit-trace, smoke coverage, QA handoff docs, and planning sync still need to close. |
+| M4 | Award, audit, and beta readiness | Security is merged, but award-read, audit-trace, smoke coverage, QA handoff docs, QA assertion prewrite, and planning sync still need to close. |
 
 ## Epic Exit Checklist
 
@@ -70,7 +71,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 - [ ] Proof verification result codes and async status reads are merged.
 - [ ] Award-read contracts and award-readiness UI are merged.
 - [ ] Audit trace outputs are defined for beta review.
-- [ ] QA smoke matrix and MVP E2E coverage are ready to run.
+- [ ] QA smoke matrix, prewritten assertion matrix, and MVP E2E coverage are ready to run.
 - [x] Security/compliance readiness checklist is merged and linked to QA validation.
 
 ## Review Routine

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -58,6 +58,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Audit visibility console baseline is captured in `docs/AUDIT_VISIBILITY_CONSOLE_BASELINE.md` so timeline, failure-translation, and missing-field acceptance criteria stay reviewable while audit query and award-read contracts are still backend follow-ups.
 - Operator audit timeline baseline is captured in `docs/OPERATOR_AUDIT_TIMELINE_BASELINE.md` so chronological event rendering, failure translation, and missing-field alerts are reviewed as explicit Phase 1 audit acceptance criteria.
 - Downstream implementation handoff for telemetry owners, contract gaps, and M4 checks is tracked in `docs/MVP_TELEMETRY_HANDOFF.md`.
+- QA-ready M4 handoff also depends on `docs/MVP_E2E_ASSERTION_MATRIX.md` so smoke and E2E coverage reuse one ordered set of ready-now versus blocked assertions.
 
 ## Out of Scope (Phase 1)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -87,7 +87,7 @@ Scope:
 - M2 (2026-03-27): task/matching + bidding API baseline.
 - M3 (2026-04-03): PoMW policy + verifier baseline + bid/proof status-read visibility for agent UX.
 - M4 (2026-04-10): audit/reputation hook + E2E test pack + security/compliance readiness review.
-- M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.
+- M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md`, and `docs/MVP_E2E_ASSERTION_MATRIX.md` so telemetry owners plus auth, secret-handling, redaction, and QA assertion follow-ons stay reviewable.
 - Review `docs/PHASE1_BETA_READINESS_GATES.md` as the compact release-gate checklist for the remaining Phase 1 contract, QA, audit, and planning blockers.
 
 Checkpoint status board:

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -63,6 +63,8 @@ review history, and linked PRs, open the GitHub issue directly.
 - P1-25 Operationalize closed-beta security readiness checklist: [#72](https://github.com/jckhang/agent-indeed/issues/72)
 - P1-26 Draft MVP smoke matrix for merged manager/agent flows: [#79](https://github.com/jckhang/agent-indeed/issues/79)
 - P1-27 Refresh checkpoint board and roadmap mappings after M2/M3 merges: [#80](https://github.com/jckhang/agent-indeed/issues/80)
+- P1-28 Run QA smoke pass on next merged tranche: [#87](https://github.com/jckhang/agent-indeed/issues/87)
+- P1-33 Prewrite MVP E2E assertion matrix from merged docs: [#101](https://github.com/jckhang/agent-indeed/issues/101)
 
 ## Working rule
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): Refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: sync the Phase 1 beta-readiness planning docs with the current QA assertion/handoff chain

## What Changed

- updated `docs/PHASE1_BETA_READINESS_GATES.md` so the happy-path, negative-path, and planning gates include issue #101 and stop pointing at merged PR #97 as an active dependency
- refreshed `docs/PHASE1_EPIC_STATUS.md` so the epic acceptance snapshot and M4 checklist now call out the assertion-matrix dependency explicitly
- added the assertion-matrix dependency to `docs/PHASE1_GOALS.md` and `docs/ROADMAP.md`
- extended `docs/issues/PHASE1_ISSUES.md` with stable links for issues #87 and #101

## Why

- the planning docs had drifted after the assertion matrix landed, so the beta-readiness view was still missing issue #101 and still listed a merged PR as active
- syncing these docs keeps epic #2 reviewable from one consistent set of QA blockers and handoff artifacts

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| OpenSpec artifacts 与 API/实现保持一致 | Keeps the active planning docs aligned with the current OpenSpec-driven QA handoff surfaces without changing product scope. | `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/PHASE1_EPIC_STATUS.md` |
| E2E happy path 可跑通 | Makes the happy-path gate explicitly depend on the assertion matrix plus the smoke/handoff docs QA needs before issue #11 can turn executable. | `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md` |
| 核心负面场景（无 commit reveal、签名错误、PoMW 不达标）有测试 | Adds the assertion matrix to the negative-path planning gate so reviewers know which artifact prewrites those cases now. | `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/PHASE1_EPIC_STATUS.md` |

## QA Plan

### Preconditions

- repository is on this branch
- OpenSpec CLI is available locally

### Steps

1. Open the updated planning docs and verify that issue #101 is listed as part of the QA dependency chain.
2. Confirm `docs/PHASE1_BETA_READINESS_GATES.md` no longer lists PR #97 as an active dependency.
3. Run `openspec validate --all`.

### Expected Results

- beta-readiness, roadmap, goals, and epic status docs all reference the same QA blocker chain
- stable issue index includes issues #87 and #101
- OpenSpec validation passes

### Validation Output

- `openspec validate --all`

## Risks and Rollback

- Risk:
  - planning-only drift if later QA PRs merge without a matching doc refresh
- Rollback:
  - revert this PR to restore the previous planning docs, then resync against the latest open QA threads

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
