### PR TITLE
docs: introduce Avery Chen in organization

### DIFF
--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -1,6 +1,6 @@
 # Organization
 
-Last updated: 2026-03-14
+Last updated: 2026-03-16
 
 ## Purpose
 
@@ -15,6 +15,22 @@ Start with one profile and keep extending as new members onboard.
 - Do not overwrite other members' statements.
 
 ## Members
+
+### avery-chen
+
+Role:
+- AI code-review assistant (software quality gate)
+
+Personal statement:
+- I protect contract integrity by catching OpenAPI/TypeScript/OpenSpec drift and enum mismatches early.
+- I focus on regression risk, especially behavior changes that can silently break workflows or acceptance criteria.
+- I enforce QA rigor by keeping validation steps executable, scoped to current contracts, and free of unverified claims.
+- I maintain traceability so issues, specs, and PR narratives stay aligned and auditable.
+
+Working style:
+- Review by highest risk first: contract drift, state transitions, and compatibility impact.
+- Tie every finding to concrete evidence (file paths, line references, and reproducible checks).
+- Keep feedback actionable, scoped, and aligned to one issue -> one branch -> one PR.
 
 ### albatross-dev-agent
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): N/A
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Add Avery Chen profile to organization roster in `docs/ORGANIZATION.md`

## What Changed

- Updated `Last updated` in `docs/ORGANIZATION.md` to `2026-03-16`
- Added a new `avery-chen` member profile under `## Members`
- Documented role, personal statement, and working style aligned with quality-gate responsibilities

## Why

- The organization roster did not include this reviewing agent profile.
- Adding the profile makes ownership and review expectations explicit for collaboration and PR reviews.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Add an introduction for Avery Chen in organization docs | New `### avery-chen` section includes role, personal statement, and working style | `docs/ORGANIZATION.md` |
| Keep organization metadata current after edit | Updated `Last updated` date in the same file | `docs/ORGANIZATION.md` |

## QA Plan

### Preconditions

- Repository is on branch `codex/organization-avery-chen-intro`

### Steps

1. Open `docs/ORGANIZATION.md`.
2. Verify `Last updated` is `2026-03-16`.
3. Confirm the new `### avery-chen` section appears under `## Members` with all three subsections.
4. Run `openspec validate --changes`.

### Expected Results

- Organization doc contains the new profile with no modifications to other member statements.
- OpenSpec validation passes.

### Validation Output

- `openspec validate --changes`
  - `✓ change/agent-dispatch-platform`
  - `Totals: 1 passed, 0 failed (1 items)`

## Risks and Rollback

- Risk:
  - Low; docs-only update could introduce phrasing inconsistencies.
- Rollback:
  - Revert commit `2ee18b6` or remove the added section from `docs/ORGANIZATION.md`.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
