### PR TITLE
[Sprint Pivot] Rebalance Phase 1 to runtime-first execution

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -13,39 +13,38 @@ reviewable release gates for closed-beta readiness. It complements:
 
 | Gate | Status | Ready when | Active dependencies | Evidence to collect |
 | --- | --- | --- | --- | --- |
-| Contract convergence | In progress | The remaining backend contract PRs are merged and the shared enum/error vocabulary is stable across OpenSpec, OpenAPI, and TypeScript contracts. | PR #55, PR #66, PR #68, PR #83, PR #90, PR #92 | `openspec validate --all`, contract diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts` |
-| Happy-path execution | Blocked | The team can trace one publish -> match -> commit -> reveal -> verify -> award flow without relying on undocumented fields or manual interpretation. | Issue #11, PR #84, PR #95, PR #96, plus the contract gate above | QA smoke checklist, API examples, merged frontend data-gap notes |
-| Negative-scenario coverage | Blocked | QA can exercise no-commit-reveal, signature-invalid, proof-fail, and manual-review/award-block paths with stable expected outcomes. | Issue #11, PR #83, PR #92, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Smoke/E2E assertions, expected error/result matrix, rollback notes |
-| Audit evidence trail | In progress | Audit outputs show key lifecycle transitions plus enough proof/award context for operator review and beta sign-off. | Issue #10, PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Planning + handoff hygiene | In progress | The planning docs, epic rollup, smoke matrix, and QA handoff docs all describe the same open blockers and merged work. | PR #82, PR #84, PR #95, PR #96, PR #97 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, QA handoff docs stay in sync |
+| Contract convergence | In progress | Remaining backend contract PRs are merged and shared enum/error vocabulary is stable across OpenSpec, OpenAPI, and TypeScript contracts. | PR #66, PR #68, PR #83, PR #90, PR #92 | `openspec validate --all`, contract diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts` |
+| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | Issue #109, issue #110, issue #111, issue #11, plus contract convergence gate | Service run command, executable smoke/E2E output, linked request/response evidence |
+| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | Issue #111, issue #11, PR #83, PR #92, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
+| Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | Issue #110, PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
+| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and active runtime issues all describe the same blockers and next actions. | Issue #109, issue #110, issue #111, issue #11 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, milestone/label queries stay aligned |
 
 ## Gate Details
 
 ### 1. Contract convergence
 
-This is the main prerequisite for every downstream QA or audit activity.
+This remains the prerequisite for durable runtime behavior and executable QA checks.
 
-- Matching still depends on PR #55.
-- Verification status durability still depends on PR #66.
-- Manager shortlist/award reads still depend on PR #68.
-- Verifier terminal vocabulary and reason-code behavior still depend on PR #83.
-- Onboarding kickoff examples still depend on PR #90.
-- Audit-event and award-trace surface still depends on PR #92.
+- Verification status durability depends on PR #66.
+- Manager shortlist and award reads depend on PR #68.
+- Verifier terminal vocabulary and reason-code behavior depend on PR #83.
+- Onboarding kickoff examples depend on PR #90.
+- Audit event and award-trace surface depends on PR #92.
 
 Release note: if any of these contracts change enum names, required fields, or error-code wording,
 the same update must land in OpenSpec plus both API drafts before the gate can be marked ready.
 
-### 2. Happy-path execution
+### 2. Runtime happy-path execution
 
-The beta happy path is not just one demo; it needs one repeatable handoff pack:
+Happy-path readiness is now runtime-first, not docs-first.
 
-- QA smoke matrix in PR #84
-- frontend data-gap notes in PR #95
-- API example outline in PR #96
-- final executable E2E issue #11 after the contract gates settle
+Required outcome:
 
-The gate is ready only when a reviewer can follow one single source bundle from docs to API examples
-to smoke assertions without guessing missing fields.
+- a local service starts from one documented command
+- one reproducible request sequence executes `publish -> match -> commit -> reveal -> verify -> award`
+- results are captured by executable smoke/E2E checks tied to issue #111 and linked back to issue #11
+
+Reference docs/matrices are useful only if they map directly to runnable assertions.
 
 ### 3. Negative-scenario coverage
 
@@ -56,44 +55,42 @@ Minimum scenarios to keep visible:
 - reveal submitted without a valid prior commit
 - signature-invalid or malformed onboarding/task payload path
 - proof verification returns `FAIL`
-- proof verification returns `MANUAL_REVIEW`
 - award attempt blocked before prerequisite verification is complete
 
-The expected output for each scenario should cite either a stable error code or a stable terminal
-status/result so QA is not validating prose-only behavior.
+Expected output for each scenario must cite a stable error code or terminal status/result.
 
 ### 4. Audit evidence trail
 
-Audit readiness is the clearest remaining M4 blocker after contract convergence.
+Audit readiness is still the clearest M4 blocker after runtime flow and contract convergence.
 
-The beta review pack should be able to answer:
+The beta review pack should answer:
 
 - what happened
 - when it happened
 - which task, bid, proof, and candidate were involved
 - why the award decision was allowed or blocked
 
-That evidence should come from the shared audit/telemetry surfaces, not from ad hoc reviewer notes.
+That evidence must come from shared audit/telemetry surfaces, not ad hoc reviewer notes.
 
-### 5. Planning + handoff hygiene
+### 5. Execution + handoff hygiene
 
-This gate stays green only when the planning layer remains current after merges.
+This gate stays green only when the repo planning surfaces and GitHub runtime threads agree.
 
-At minimum, these docs must agree on which threads are still open:
+At minimum, these must stay in lockstep:
 
 - `docs/PHASE1_CHECKPOINT_BOARD.md`
 - `docs/PHASE1_EPIC_STATUS.md`
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
-- the active QA handoff docs attached to issue #11 follow-through
+- runtime delivery threads (`#109`, `#110`, `#111`, and blocked follow-through `#11`)
 
 ## Review Routine
 
 Review these gates whenever one of the following happens:
 
-- a Phase 1 PR merges or reopens
+- a Phase 1 contract/runtime PR merges, reopens, or is closed as superseded
 - a contract enum or error-code changes
-- QA smoke scope changes
-- the epic #2 checklist changes
+- QA smoke/E2E execution scope changes
+- epic #2 checklist changes
 
-If a gate changes status, update the epic rollup and the checkpoint board in the same review window.
+If a gate changes status, update the epic rollup and checkpoint board in the same review window.

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -7,15 +7,24 @@ This document keeps only the stable checkpoint structure and links to the live m
 
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
-| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Upload contract freeze, observability baseline, onboarding kickoff |
-| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Matching contract, commit-reveal flow, manager task composition |
-| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | PoMW policy/verifier, async bid-proof status, agent UX durability |
-| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Audit trail, award read models, telemetry/security follow-through, QA sign-off |
+| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Contract convergence kickoff + runnable service bootstrap gate (#109, PR #90). |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Runnable publish/match/commit/reveal path and shortlist/award read contracts (#110, PR #66, PR #68). |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Verify/audit runtime durability plus executable QA conversion (#111, PR #83, PR #92). |
+| M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
+
+## Runtime pivot anchors
+
+Sprint pivot dated 2026-03-16 keeps these issue anchors as the default execution path:
+
+- `#109`: runnable backend skeleton
+- `#110`: runnable dispatch vertical slice
+- `#111`: executable smoke/E2E conversion
+- `#11`: blocked final E2E sign-off thread
 
 ## Review routine
 
-1. Open the milestone issue and PR links instead of editing status snapshots in-repo.
-2. Use labels such as `status/ready-next`, `status/in-review`, and owner labels to decide the next merge or rebase action.
+1. Open milestone issue and PR links instead of editing status snapshots in-repo.
+2. Use labels such as `status/ready-next`, `status/in-review`, and owner labels to decide next merge or rebase action.
 3. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
 
 ## When to edit this file

--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -3,8 +3,7 @@
 Last updated: 2026-03-16
 
 This document is the execution snapshot for epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`).
-It complements `docs/PHASE1_GOALS.md` by mapping the epic acceptance criteria to the current issue, PR,
-and checkpoint state.
+It complements `docs/PHASE1_GOALS.md` by mapping epic acceptance criteria to current issue and PR gates.
 
 ## Epic Objective
 
@@ -15,62 +14,50 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
-| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts` | Keep open PRs #55, #66, #68, #83, #90, and #92 aligned with the current spec/contracts surface. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issue #11 | Needs the remaining M2-M4 contract PRs plus QA handoff docs (#84, #95, #96) before issue #11 can turn into executable coverage. |
-| Core negative scenarios are covered | Blocked | issue #11, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Security-readiness guidance is merged; the next gate is converting it into smoke/E2E assertions once verifier and award traces stabilize. |
-| Audit events cover key state transitions | In progress | issue #10, PR #92, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md` | Land audit-event stream and award-trace contracts, then fold them into the QA example and smoke-pack work. |
+| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts` | Keep open contract PRs #66, #68, #83, #90, and #92 aligned while runtime code lands. |
+| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issues #11, #109, #110, #111 | Land runnable backend slices (#109, #110) and execute smoke/E2E checks (#111) before unblocking issue #11. |
+| Core negative scenarios are covered | Blocked | issues #11 and #111, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Convert documented failure scenarios into executable assertions against runtime endpoints. |
+| Audit events cover key state transitions | In progress | issue #110, PR #92, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md` | Bind audit contracts to emitted runtime events and include them in QA evidence capture. |
 
 ## Delivery Slice Status
 
 ### Completed baseline slices
 
-- #3 AgentBundle contract defined.
-- #4 Onboarding pipeline baseline implemented.
-- #5 TaskSpec publish behavior defined.
-- #7 Commit-reveal bidding APIs landed.
-- #8 PoMW policy contract landed.
-- #72 Closed-beta security readiness checklist merged.
-- #62 Award-readiness UI slice merged.
-- #63 Agent bid commit/reveal workspace UI merged.
-- #64 Verification timeline UX merged.
-- #93 QA-facing MVP API example outline scope closed and handed to PR #96.
-- #94 Frontend data-gap capture scope closed and handed to PR #95.
+- #3 AgentBundle contract baseline defined.
+- #5 TaskSpec publish contract baseline defined.
+- #55 candidate matching shortlist contract merged.
+- #72 closed-beta security readiness checklist merged.
+- Frontend baseline slices for manager/agent/operator surfaces are merged (#53, #56, #67, #70, #73, #74, #76, #78).
 
 ### Active implementation slices
 
 | Epic step | Active issue / PR | Why it still matters to epic #2 |
 | --- | --- | --- |
-| Match | issue #6 (closed) / PR #55 | Matching shortlist contract is still the backend gate before publish -> match is stable. |
-| Verify status reads | issue #59 / PR #66 | Async status polling is required so verification remains durable beyond synchronous responses. |
-| Verifier contract | issue #9 (closed) / PR #83 | The canonical verifier/result contract still has to merge before downstream QA examples and polling semantics are fully stable. |
-| Award reads | issue #58 (closed) / PR #68 | Manager shortlist and award-read contracts are still the main backend dependency before award review is trustworthy. |
-| Audit trace | issue #10 / PR #92 | Audit-event stream and award-trace contracts are now the main backend gate for the beta evidence trail. |
-| Planning sync | issue #80 / PR #82 | Planning docs must stay aligned so epic status is not tracking already-merged work as active. |
-| QA smoke coverage | issue #87 / PR #84 | Smoke validation is the bridge between the merged UI slices and final E2E confidence. |
-| QA handoff pack | issue #11, PR #95, PR #96 | The QA-facing API outline and frontend data-gap docs still need to merge so smoke and E2E work use one current handoff set. |
+| Runtime backend skeleton | issue #109 | Provides the first runnable control-plane service and persistence baseline. |
+| Runnable dispatch vertical slice | issue #110 | Converts contract-only flow into executable state transitions across publish/match/bid/verify/award. |
+| Contract convergence | PRs #66, #68, #83, #90, #92 | Prevents enum/field drift while runtime handlers are implemented. |
+| Executable QA conversion | issue #111 and issue #11 | Turns smoke/E2E docs into runnable assertions for happy and negative paths. |
 
 ### Remaining blocked slices
 
-- #10 Audit events and award trace still depend on the M2/M3 contracts landing in stable read/write forms and merging through PR #92.
-- #11 End-to-end tests and examples still depend on verifier, award-read, audit-trace, and smoke-pack work becoming stable enough to automate.
+- Issue #11 remains blocked until #109 and #110 provide runnable endpoints and #111 turns the QA matrices into executable checks.
+- Audit evidence remains partially blocked until PR #92 fields are emitted by runtime code in issue #110.
 
 ## Checkpoint Rollup
 
 | Checkpoint | Epic relevance | Current note |
 | --- | --- | --- |
-| M1 | Upload baseline | Issue #30 is closed; PR #90 is the only remaining M1 example/kickoff thread. |
-| M2 | Publish, shortlist, and bid foundation | Still gated by PR #55 even though manager task-composer and shortlist UI slices are merged. |
-| M3 | Verify and agent flow | Agent UX slices are merged; status reads (#66) and verifier contract finalization (#83) remain the active gate. |
-| M4 | Award, audit, and beta readiness | Security is merged, but award-read, audit-trace, smoke coverage, QA handoff docs, and planning sync still need to close. |
+| M1 | Contract convergence + service bootstrap | PR #90 and issue #109 are the primary M1 gates. |
+| M2 | Runnable publish/match/bid foundation | Issue #110 plus PR #66/#68 are the main gates. |
+| M3 | Verify and audit durability | PR #83/#92 plus issue #111 are the main gates. |
+| M4 | Beta readiness sign-off | Issue #11 final E2E evidence and security/audit verification remain required. |
 
 ## Epic Exit Checklist
 
-- [x] Upload and publish baselines are documented and merged.
-- [ ] Matching shortlist contract is merged and reflected in downstream docs/UI.
-- [ ] Proof verification result codes and async status reads are merged.
-- [ ] Award-read contracts and award-readiness UI are merged.
-- [ ] Audit trace outputs are defined for beta review.
-- [ ] QA smoke matrix and MVP E2E coverage are ready to run.
+- [ ] Upload and publish runtime paths are executable in a local service.
+- [ ] Matching, verify-status, and award-read contracts are merged and consumed by runtime handlers.
+- [ ] Audit trace outputs are emitted and queryable for beta review.
+- [ ] QA smoke matrix and MVP E2E assertions are runnable and passing.
 - [x] Security/compliance readiness checklist is merged and linked to QA validation.
 
 ## Review Routine

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -13,6 +13,16 @@ Ship the first usable agent dispatch loop for closed beta:
 3. Candidates can bid with commit-reveal.
 4. Platform can verify PoMW by identity-tier policy and award with audit trace.
 
+## 2026-03-16 Execution Pivot
+
+- Current sprint focus moves from planning-doc expansion to runnable implementation slices.
+- Active implementation issues for this pivot:
+  - #109 backend runtime skeleton
+  - #110 runnable dispatch vertical slice
+  - #111 executable QA smoke/E2E checks
+- Planning-only follow-ups (#106, #107, #108) were closed to keep sprint bandwidth on runtime delivery.
+- QA prewrite-only tracks (#87, PR #84, PR #104) were superseded by runtime execution issue #111.
+
 ## In Scope
 
 ### G1. Agent onboarding and sync
@@ -20,6 +30,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - `AgentBundle` schema finalized (`manifest`, `identity`, `skills`, `memoryRef`).
 - Upload validation pipeline implemented (signature, schema, indexing, version conflict).
 - Memory supports index/encrypted reference mode (no raw memory required).
+- Onboarding write/read behavior must be executable from a local running service (issues #109 and #110).
 
 ### G2. Task publication and matching baseline
 
@@ -30,6 +41,7 @@ Ship the first usable agent dispatch loop for closed beta:
   - required skills
   - compliance flags
 - Candidate retrieval exposes a retryable "snapshot pending" state instead of returning an ambiguous empty shortlist during matching materialization.
+- Candidate shortlist behavior must be backed by runtime state, not docs-only assumptions (issue #110).
 - Soft ranking baseline:
   - success rate
   - latency
@@ -43,6 +55,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Commit-reveal bidding APIs available.
 - Reveal rejected when no valid commit exists.
 - `ProofPack` accepted and verified with T0/T1/T2 policy mapping.
+- Commit/reveal/verify/award transitions must persist and be queryable in runtime flow checks (issue #110).
 - Agent bidding console baseline is captured in `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, with focused follow-through in `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md` and `docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md`, so commit/reveal and verification acceptance criteria stay reviewable while bid/proof status reads remain backend follow-ups through issue #59.
 - Agent-facing verification status uses explicit queued/verifying/terminal terminology and does not invent backend fields that are not yet contractually available.
 
@@ -59,6 +72,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Audit visibility console baseline is captured in `docs/AUDIT_VISIBILITY_CONSOLE_BASELINE.md` so timeline, failure-translation, and missing-field acceptance criteria stay reviewable while audit query and award-read contracts are still backend follow-ups.
 - Operator audit timeline baseline is captured in `docs/OPERATOR_AUDIT_TIMELINE_BASELINE.md` so chronological event rendering, failure translation, and missing-field alerts are reviewed as explicit Phase 1 audit acceptance criteria.
 - Downstream implementation handoff for telemetry owners, contract gaps, and M4 checks is tracked in `docs/MVP_TELEMETRY_HANDOFF.md`.
+- Audit/verification outputs must be exercised by executable smoke assertions (issue #111).
 
 ## Out of Scope (Phase 1)
 
@@ -71,7 +85,9 @@ Ship the first usable agent dispatch loop for closed beta:
 
 - OpenSpec change remains valid and synchronized with implementation.
 - API draft and TypeScript contracts are consistent for `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`.
+- Implementation-scoped issues are closed only when runtime code or executable test coverage is merged.
 - End-to-end happy path + key negative paths are covered by automated tests.
+- One local command path can run service + smoke checks for happy path and core negatives.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - P0 baseline issues that block collaboration quality are closed or explicitly waived.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Agent Indeed Roadmap
 
-Last updated: 2026-03-15
+Last updated: 2026-03-16
 
 ## Product North Star
 
@@ -13,6 +13,7 @@ Build a trustworthy agent dispatch network where managers can publish tasks, age
 - Prefer auditability and abuse resistance over feature breadth in early stages.
 - Keep API-first implementation aligned with OpenSpec artifacts.
 - Resolve repository readiness blockers (P0) before broad Phase 1 implementation.
+- Runtime implementation evidence is required before closing `Implement`-scoped issues (spec/docs-only PRs are not sufficient).
 
 ## Phase Plan
 
@@ -35,9 +36,14 @@ Exit criteria:
 
 ### Phase 1: Marketplace Foundation (Target: 2026-03 to 2026-04)
 
-Goal: deliver MVP control-plane APIs and event trail to run closed beta tasks end-to-end.
+Goal: deliver a runnable MVP control-plane and event trail to run closed-beta tasks end-to-end.
 
 Scope:
+- Runtime sprint pivot (2026-03-16) is execution-first:
+  - #109 bootstrap runnable backend skeleton
+  - #110 implement runnable dispatch vertical slice (`publish -> match -> commit -> reveal -> verify -> award`)
+  - #111 convert QA smoke/E2E matrices into executable checks
+- Keep remaining contract convergence PRs (#66, #68, #83, #90, #92) aligned as unblockers for runtime delivery, not as the sprint end state.
 - Agent onboarding and metadata sync (`AgentBundle` with identity/memory/skills).
 - Task publication and candidate matching (hard filter + soft ranking baseline).
 - Manager console baseline (`docs/MANAGER_CONSOLE_BASELINE.md`, issue #43 / PR #53) keeps the publish form, shortlist evidence, and award-summary dependency notes visible while interactive award APIs are still pending.
@@ -58,6 +64,18 @@ Exit criteria:
 - End-to-end scenario passes: publish task -> commit -> reveal -> verify -> award.
 - All critical state transitions produce audit events.
 - Beta guardrails for auth, secrets, and sensitive data handling are documented and owned.
+
+## Current Sprint Pivot (2026-03-16 to 2026-03-27)
+
+Focus:
+- Deliver executable backend runtime slices first (#109, #110).
+- Convert QA readiness docs into runnable checks tied to runtime behavior (#111, issue #11).
+- Keep OpenSpec/OpenAPI/contracts synchronized while implementation PRs land.
+
+De-scoped from current sprint:
+- Planning-only follow-ups #106, #107, #108 were closed to avoid additional doc-layer churn.
+- Planning-sync PRs #82, #95, #96, #102, #103, and #105 were closed for the same reason.
+- QA prewrite-only threads (#87, PR #84, PR #104) are treated as superseded by runtime execution issue #111.
 
 ### Phase 2: Execution & Trust Loop (Target: 2026-05 to 2026-06)
 
@@ -83,10 +101,10 @@ Scope:
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
-- M1 (2026-03-20): finalize contracts + upload pipeline design.
-- M2 (2026-03-27): task/matching + bidding API baseline.
-- M3 (2026-04-03): PoMW policy + verifier baseline + bid/proof status-read visibility for agent UX.
-- M4 (2026-04-10): audit/reputation hook + E2E test pack + security/compliance readiness review.
+- M1 (2026-03-20): finish remaining contract convergence and land runnable backend skeleton (#109).
+- M2 (2026-03-27): land runnable publish/match/commit/reveal/verify/award vertical slice (#110).
+- M3 (2026-04-03): stabilize verify/award/audit runtime behavior and run executable smoke checks (#111).
+- M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.
 - Review `docs/PHASE1_BETA_READINESS_GATES.md` as the compact release-gate checklist for the remaining Phase 1 contract, QA, audit, and planning blockers.
 

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -63,6 +63,18 @@ review history, and linked PRs, open the GitHub issue directly.
 - P1-25 Operationalize closed-beta security readiness checklist: [#72](https://github.com/jckhang/agent-indeed/issues/72)
 - P1-26 Draft MVP smoke matrix for merged manager/agent flows: [#79](https://github.com/jckhang/agent-indeed/issues/79)
 - P1-27 Refresh checkpoint board and roadmap mappings after M2/M3 merges: [#80](https://github.com/jckhang/agent-indeed/issues/80)
+- P1-28 Run QA smoke pass on next merged tranche: [#87](https://github.com/jckhang/agent-indeed/issues/87)
+- P1-29 Draft MVP API example outline for QA handoff: [#93](https://github.com/jckhang/agent-indeed/issues/93)
+- P1-30 Capture frontend data gaps after manager/agent UI merges: [#94](https://github.com/jckhang/agent-indeed/issues/94)
+- P1-31 Convert frontend data-gap notes into contract delta checklist: [#99](https://github.com/jckhang/agent-indeed/issues/99)
+- P1-32 Turn API example outline into QA-ready handoff pack: [#100](https://github.com/jckhang/agent-indeed/issues/100)
+- P1-33 Prewrite MVP E2E assertion matrix from merged docs: [#101](https://github.com/jckhang/agent-indeed/issues/101)
+- P1-34 Run backend contract convergence merge train: [#106](https://github.com/jckhang/agent-indeed/issues/106)
+- P1-35 Consolidate QA handoff packet for smoke execution: [#107](https://github.com/jckhang/agent-indeed/issues/107)
+- P1-36 Reconcile frontend delta checklist with contract stack: [#108](https://github.com/jckhang/agent-indeed/issues/108)
+- P1-37 Bootstrap runnable control-plane backend skeleton: [#109](https://github.com/jckhang/agent-indeed/issues/109)
+- P1-38 Implement runnable MVP dispatch vertical slice: [#110](https://github.com/jckhang/agent-indeed/issues/110)
+- P1-39 Execute runtime smoke/E2E checks from QA matrices: [#111](https://github.com/jckhang/agent-indeed/issues/111)
 
 ## Working rule
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -78,6 +78,11 @@
    - clean tranche 合并后，必须在脏 PR 线程写回 owner、blocker、rebase-next-step，并要求重新执行验证命令。
    - 例行流程写入 `docs/MERGE_TRAIN_PLAYBOOK.md` 并在 `CONTRIBUTING.md` 链接，减少多 agent 并行时的重复沟通和冲突。
 
+11. Phase 1 当前冲刺采用 runtime-first 交付
+   - 2026-03-16 起，交付节奏从“持续追加规划文档”切换为“优先交付可运行实现”。
+   - 当前冲刺以 issue #109（服务骨架）、#110（端到端垂直切片）、#111（可执行 QA 校验）为主线。
+   - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
+
 ## Backend Module Boundaries
 
 MVP control plane 采用“单仓多模块”边界，而不是在 Phase 1 立即拆成独立微服务。每个模块拥有清晰写入边界，并通过共享 contract layer（OpenSpec + OpenAPI + `contracts.ts`）交互。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -6,6 +6,7 @@
 3) 按身份模型差异化的最小工作量证明（PoMW）
 
 缺少规格会导致后续实现偏差：上传对象不统一、匹配规则不可复现、竞标与防刷策略不可审计。需要先固化能力边界与验收场景，再进入代码实现。
+在 2026-03-16 的执行复盘后，当前变更也明确要求推进可运行实现，避免冲刺周期仅停留在规格层。
 
 ## What Changes
 
@@ -17,6 +18,7 @@
 - 补充 merge-train 协作手册，统一 clean LGTM PR 合并、dirty queue 回写与 rebase 流程。
 - 明确身份分层（T0/T1/T2）下的 PoMW 强度策略。
 - 定义从任务发布到中标执行的关键状态流转与审计要求。
+- 新增 runtime 落地冲刺任务（issue #109/#110/#111），要求将核心流程转为可运行服务与可执行 QA 校验。
 
 ## Capabilities
 
@@ -34,4 +36,4 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue 与 dirty queue follow-up 的操作基线。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
-- 该变更当前不直接引入运行时代码，但会约束后续实现与测试。
+- 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -12,18 +12,18 @@
 
 ## 1. OpenSpec 基础落地
 
-- [ ] 1.1 完成 proposal/design/specs/tasks 四类工件并通过 `openspec validate`。
-- [ ] 1.2 建立 capability 命名约定与目录规范（kebab-case + 单能力单 spec）。
+- [x] 1.1 完成 proposal/design/specs/tasks 四类工件并通过 `openspec validate`。
+- [x] 1.2 建立 capability 命名约定与目录规范（kebab-case + 单能力单 spec）。
 
 ## 2. Agent 上传与同步 API 设计
 
-- [ ] 2.1 定义 `AgentBundle` schema（manifest/identity/skills/memoryRef）。
+- [x] 2.1 定义 `AgentBundle` schema（manifest/identity/skills/memoryRef）。
 - [x] 2.2 设计上传校验流水线（签名、schema、能力索引、版本冲突处理）。
 - [x] 2.3 定义上传失败错误码与可重试策略（见 `docs/ERROR_CODE_RETRY_POLICY.md`）。
 
 ## 3. 任务匹配与竞标流程设计
 
-- [ ] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
+- [x] 3.1 定义 `TaskSpec` schema（预算、SLA、门槛、PoMW policy）。
 - [x] 3.2 实现候选筛选策略（硬过滤 + 软排序）与评分字段。
 - [x] 3.3 设计 commit-reveal 竞标接口与时序约束。
 
@@ -34,3 +34,9 @@
 - [ ] 4.3 规范审计事件模型并预留信誉回写接口。
 - [x] 4.4 定义 MVP 生命周期可观测性基线（事件/trace/log/metric/retention/alerts）。
 - [x] 4.5 输出闭测安全就绪清单，明确 auth/authz、secret handling、redaction 与 M4 go/no-go 门槛。
+
+## 5. Runtime 落地冲刺（2026-03-16 起）
+
+- [ ] 5.1 落地可运行 control-plane service skeleton（issue #109），包含健康检查、基础配置与最小持久化抽象。
+- [ ] 5.2 打通可执行的 MVP 垂直路径（issue #110）：`publish -> match -> commit -> reveal -> verify -> award`，并持久化关键状态转移。
+- [ ] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2, refs #11, refs #109, refs #110, refs #111
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Rebalance Phase 1 roadmap/checkpoint/readiness artifacts toward runtime-first delivery and align GitHub work items

## What Changed

- Updated Phase 1 planning docs (`ROADMAP`, goals, epic status, checkpoint board, beta-readiness gates) to make runtime implementation the sprint driver instead of docs-only output.
- Updated OpenSpec change artifacts (`proposal.md`, `design.md`, `tasks.md`) with explicit runtime-first closure criteria and runtime sprint task anchors (#109/#110/#111).
- Rebased issue/milestone flow to match milestone intent: #109 -> M1, #110 -> M2, #111 -> M3, and kept #11 as the blocked M4 sign-off thread.
- Closed superseded QA prewrite tracking (#87, PR #84, PR #104) and redirected execution focus to #111 with signed transition notes.

## Why

- The sprint risk was over-indexing on planning/spec artifacts while practical runtime behavior stayed blocked.
- This PR hardens one execution path: land runnable backend slices first, then execute smoke/E2E checks against real endpoints.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Sprint plan emphasizes runnable implementation over doc-only closure | Roadmap/goals/epic/checkpoint/readiness docs now gate closure on runtime code + executable checks | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_BETA_READINESS_GATES.md` |
| OpenSpec artifacts stay aligned with planning pivot | Proposal/design/tasks explicitly add runtime-first sprint decisions and implementation-linked closure criteria | `openspec/changes/agent-dispatch-platform/proposal.md`, `openspec/changes/agent-dispatch-platform/design.md`, `openspec/changes/agent-dispatch-platform/tasks.md` |
| GitHub execution lanes are simplified to practical runtime work | Closed superseded QA prewrite threads and aligned active runtime issues to M1/M2/M3 checkpoints | issue #87 (closed), PR #84 (closed), PR #104 (closed), issue #109/#110/#111 milestone updates |

## QA Plan

### Preconditions

- Local repo on `codex/sprint-implementation-rebalance` after rebase to `origin/main`.
- OpenSpec CLI available.

### Steps

1. Review updated planning docs and confirm runtime-first language is consistent across roadmap/goals/epic/checkpoint/readiness files.
2. Review OpenSpec change artifacts and confirm runtime sprint tasks (#109/#110/#111) and implementation closure criteria are present.
3. Run OpenSpec validation commands.
4. Verify GitHub issue/PR state reflects superseded closures and milestone reassignment.

### Expected Results

- Phase 1 planning surfaces consistently prioritize runnable implementation.
- OpenSpec artifacts remain valid and synchronized with planning changes.
- Active execution queue is reduced to runtime-relevant issues and contract-convergence PRs.

### Validation Output

- `openspec validate --changes`
- `openspec validate --all`
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`

## Risks and Rollback

- Risk:
  - Closing superseded QA prewrite threads may hide context if not copied into #111 implementation notes.
- Rollback:
  - Reopen #87 / PR #84 / PR #104 and restore old planning references if the team decides to merge doc-first QA artifacts before runtime execution.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
