### PR TITLE
[Process] Add issue-owner and PR review relation map

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,14 @@ Use one shared enum set across issues and PRs (see `docs/WORK_ITEM_TAXONOMY.md`)
   - `type/chore`
   - `type/spec`
 
+## Owner + Reviewer Assignment (PM Lan)
+
+Use `docs/ORGANIZATION.md` as the source of truth for the relation map.
+
+- PM Lan assigns exactly one `owner:*` label to every issue.
+- PM Lan requests `albatross-dev-agent` as review owner on every PR.
+- If the PR author is `albatross-dev-agent`, PM Lan must add delegated reviewers (domain owner + QA) before merge.
+
 ## Pull Request Checklist
 
 Before requesting review, ensure:

--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -19,7 +19,7 @@ Start with one profile and keep extending as new members onboard.
 ### avery-chen
 
 Role:
-- AI code-review assistant (software quality gate)
+- Code reviewer + QA owner (software quality gate)
 
 Personal statement:
 - I protect contract integrity by catching OpenAPI/TypeScript/OpenSpec drift and enum mismatches early.
@@ -102,6 +102,44 @@ Working style:
 - Confirm acceptance criteria first, then ship small, reviewable PRs with clear rollback boundaries.
 - Design UI as an explicit state machine (happy path + negative path + retries + idempotency hints).
 - Standardize reason-code rendering into user language plus actionable next steps.
+
+## Issue owner and PR review relation map
+
+This map defines who PM Lan assigns as issue owner and who is requested as PR reviewer.
+
+### Assignment principles
+
+- PM Lan is the dispatcher for issue owners and PR reviewer requests.
+- Every issue has exactly one `owner:*` label (single accountable owner).
+- Every PR review always has one review owner: `albatross-dev-agent`.
+- When `albatross-dev-agent` is the PR author, review delegation is mandatory; delegated reviewers execute detailed review, and `albatross-dev-agent` still makes final merge-go/no-go call.
+
+### Issue owner map (assigned by PM Lan)
+
+| Work lane | Required issue labels | Default owner label | Notes |
+| --- | --- | --- | --- |
+| Frontend implementation | `dept/frontend` + one `type/*` | `owner:lanzhou-fe-agent` | UI workflow/state-machine scope. |
+| Backend/API implementation | `dept/backend` + one `type/*` | `owner:kestrel` | Endpoint, contract wiring, persistence, state transition scope. |
+| QA/test execution | `dept/qa` + one `type/*` | `owner:qa` | Smoke/E2E, regression evidence, validation tooling. |
+| Planning/docs/process | `dept/planning` + one `type/*` | `owner:lan` | Scope shaping, roadmap/docs/process updates. |
+| Cross-cutting architecture | keep primary `dept/*` + one `type/*` | `owner:albatross` | Use only when issue mainly controls multi-lane architecture decisions. |
+
+### PR review relation map
+
+| PR author | Review owner (always) | Delegate reviewers (pick by changed surface) |
+| --- | --- | --- |
+| `kestrel-dev-agent` | `albatross-dev-agent` | `avery-chen` (QA/risk) + `lanzhou-fe-agent` when FE contract impact exists |
+| `lanzhou-fe-agent` | `albatross-dev-agent` | `avery-chen` (QA/risk) + `kestrel-dev-agent` when API/contract impact exists |
+| `avery-chen` | `albatross-dev-agent` | `kestrel-dev-agent` for backend/test infra impact, `lanzhou-fe-agent` for FE test impact |
+| `lan` | `albatross-dev-agent` | Domain owner by dept (`kestrel-dev-agent` / `lanzhou-fe-agent` / `avery-chen`) |
+| `albatross-dev-agent` | `albatross-dev-agent` | Mandatory delegation: at least one domain owner + `avery-chen` for independent review |
+
+### PM Lan operating steps
+
+1. On issue creation, apply one `dept/*`, one `type/*`, and one `owner:*` label using the owner map.
+2. When PR opens, request `albatross-dev-agent` as review owner and set `status/in-review`.
+3. Add delegated reviewers from the PR review relation map based on changed files and risk.
+4. Keep one issue -> one branch -> one PR; if scope expands, split into a new issue/PR pair.
 
 ## Member template
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): n/a (direct process update requested by PM)
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Define issue-owner and PR-review relation map for FE/BE/PM/QA collaboration

## What Changed

- Added an explicit "Issue owner and PR review relation map" section to `docs/ORGANIZATION.md`.
- Defined PM Lan's assignment rules for issue ownership (`owner:*` label mapping by lane).
- Defined PR review routing with `albatross-dev-agent` as the always-on review owner and mandatory delegation when the PR author is `albatross-dev-agent`.
- Added a short enforcement section in `CONTRIBUTING.md` so PM Lan has one repeatable operating rule.
- Updated Avery role wording to "Code reviewer + QA owner" for clarity.

## Why

- Team roles are known, but assignment and review routing were not explicitly codified in one place.
- PM Lan needs a deterministic map to assign issue owners and PR reviewers without ambiguity.
- This also makes review accountability explicit while still allowing delegated review coverage on albatross-authored PRs.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| PM Lan can assign one owner per issue using team role mapping | Added owner map by lane (`frontend`, `backend`, `qa`, `planning`, architecture exception) | `docs/ORGANIZATION.md` |
| Every PR has a stable review owner and clear delegate rules | Added PR author -> review owner/delegate matrix with `albatross-dev-agent` always as review owner | `docs/ORGANIZATION.md` |
| Process is executable in day-to-day contribution flow | Added concise assignment rules in contributing guide | `CONTRIBUTING.md` |

## QA Plan

### Preconditions

- Use branch `codex/pr-review-relation-map`.
- Have `openspec` CLI available.

### Steps

1. Open `docs/ORGANIZATION.md` and verify the relation map includes FE Lanzhou, BE Kestrel, PM Lan, and CodeReviewer/QA Avery role intent.
2. Verify the matrix states `albatross-dev-agent` is always the review owner and defines delegation for albatross-authored PRs.
3. Open `CONTRIBUTING.md` and confirm the same rules are captured for execution.
4. Run `openspec validate --all`.

### Expected Results

- PM Lan has a clear assignment and reviewer map for issue/PR dispatch.
- Review ownership and delegation behavior are unambiguous.
- OpenSpec validation remains green.

### Validation Output

- `openspec validate --all`
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`

## Risks and Rollback

- Risk:
  - If team staffing/roles change, this map can become stale unless updated promptly.
- Rollback:
  - Revert this PR to restore previous organization/contributing docs and reintroduce mapping in a refreshed follow-up.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
