### PR TITLE
feat: add runtime bootstrap smoke command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,4 @@ Agent dispatch platform prototype.
 - HR hiring plan: `docs/HR_HIRING_PLAN.md`
 - Runtime control-plane scaffold: `src/runtime/README.md`
 - Runnable dispatch smoke command: `npm run smoke:dispatch`
+- Runtime bootstrap smoke command: `npm run smoke:bootstrap`

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -4,7 +4,7 @@ Last updated: 2026-03-16
 
 ## Repository Maturity Snapshot
 
-Current repository focus is still specification-led delivery, but the runnable Node.js control-plane runtime now lives in `src/runtime/` with built-in local tests and a one-command dispatch smoke path.
+Current repository focus is still specification-led delivery, but the runnable Node.js control-plane runtime now lives in `src/runtime/` with built-in local tests plus one-command bootstrap and dispatch smoke paths.
 
 ## Stack Inventory
 
@@ -14,8 +14,8 @@ Current repository focus is still specification-led delivery, but the runnable N
 | HTTP API contract | OpenAPI 3.1 (YAML) | `src/api/openapi.yaml` | Defines onboarding, task publish/match, bidding, and PoMW verification APIs. |
 | Typed domain contract | TypeScript interfaces | `src/api/contracts.ts` | Mirrors OpenAPI key objects: `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`. |
 | Collaboration workflow | Git + GitHub Issues + AGENTS guidance | `AGENTS.md`, `docs/issues/PHASE1_ISSUES.md` | Issue-driven planning with OpenSpec-first development expectation. |
-| Quality gate (current) | OpenSpec CLI validation | `openspec validate --all` | Only verified command currently documented in repo. |
-| Runtime service baseline | Node.js built-in HTTP server + `node:test` | `src/runtime/`, `package.json` | Provides `/healthz`, `/readyz`, runtime summary, runnable publish/match/commit/reveal/verify/award handlers, audit/event readback routes, structured request logging, deterministic in-memory IDs, and `npm run smoke:dispatch` for local end-to-end verification. |
+| Quality gate (current) | OpenSpec CLI validation + local runtime smoke | `openspec validate --all`, `npm run smoke:bootstrap`, `npm run smoke:dispatch` | Spec consistency plus executable bootstrap and full dispatch verification paths for local runtime checks. |
+| Runtime service baseline | Node.js built-in HTTP server + `node:test` | `src/runtime/`, `package.json` | Provides `/healthz`, `/readyz`, runtime summary, runnable publish/match/commit/reveal/verify/award handlers, audit/event readback routes, structured request logging, deterministic in-memory IDs, and smoke commands for both bootstrap and full dispatch verification. |
 
 ## API/Domain Model Stack (Current)
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -171,4 +171,5 @@ MVP control plane 采用“单仓多模块”边界，而不是在 Phase 1 立�
    - 在 contract-only 阶段之后，先交付单进程本地 control plane 骨架，而不是等待完整微服务拆分。
    - 首个可运行基线暴露 `/healthz`、`/readyz` 与至少一个 `/v1/*` namespaced route，并为 task/bid/proof/award/audit 建立确定性 ID 的存储抽象。
    - 本地 readback 路径至少覆盖 persisted task 与 task 级 audit timeline，确保 smoke check 可以直接观察状态写入结果。
+   - 仓库需要提供一个单命令 bootstrap smoke 路径，自动启动本地服务并探测 health/readiness/summary/task/audit readback，减少下游 QA/FE 手工拼接 curl 的门槛。
    - Phase 1 早期允许以内存存储启动，只要 contract、OpenSpec 与后续 vertical slice 可以在相同边界上继续演进。

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -239,6 +239,11 @@
 - **AND** 至少一个 runtime route 支持把已持久化实体重新读回，便于 smoke check 与后续 vertical slice 接续
 - **AND** runtime 提供 task 级别 audit readback，便于本地验证状态写入与事件时间线
 
+#### Scenario: Repository exposes one-command bootstrap smoke verification
+- **WHEN** 开发者执行仓库约定的本地 smoke 命令
+- **THEN** 命令自动启动 runtime baseline 并串行探测 `/healthz`、`/readyz` 与一个 `/v1/*` 写读回路径
+- **AND** 命令输出 task/audit readback 的结果摘要，便于 FE/QA 复用同一条本地验证路径
+
 #### Scenario: Runtime storage abstractions cover core lifecycle entities
 - **WHEN** 本地 control-plane 初始化存储层
 - **THEN** 平台为 `task`、`bid`、`proof`、`award` 与 `audit` 建立明确的存储抽象

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node src/runtime/server.js",
     "dev": "node --watch src/runtime/server.js",
     "smoke:dispatch": "node src/runtime/dispatch-smoke.js",
+    "smoke:bootstrap": "node src/runtime/bootstrap-smoke.js",
     "test": "node --test"
   },
   "engines": {

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -8,6 +8,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke path: `npm run smoke:dispatch`
 - Run the built-in runtime tests: `npm test`
+- Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
 ## Boot and probe
 
@@ -23,10 +24,7 @@ Then verify the bootstrap probes and one namespaced task route from another term
 curl -s http://127.0.0.1:3000/healthz
 curl -s http://127.0.0.1:3000/readyz
 curl -s http://127.0.0.1:3000/v1/runtime/summary
-curl -s -X POST http://127.0.0.1:3000/v1/tasks \
-  -H 'content-type: application/json' \
-  -H 'x-workspace-id: workspace-kestrel' \
-  -d '{
+curl -s -X POST http://127.0.0.1:3000/v1/tasks   -H 'content-type: application/json'   -H 'x-workspace-id: workspace-kestrel'   -d '{
     "task": {
       "title": "Bootstrap runtime smoke",
       "description": "Persist one task through the local control plane",
@@ -54,6 +52,14 @@ npm run smoke:dispatch
 ```
 
 The smoke command boots the runtime on an ephemeral port, publishes a task, materializes candidates, commits and reveals a bid, resolves proof policy, checks award readiness, awards the task with the contract-shaped idempotent payload, and confirms the task/bid audit timelines before printing the resulting ids as JSON.
+
+Or run the bootstrap path end-to-end with one command:
+
+```bash
+npm run smoke:bootstrap
+```
+
+That command starts the runtime on an ephemeral port, checks `/healthz`, `/readyz`, `/v1/runtime/summary`, `POST /v1/tasks`, `GET /v1/tasks/{taskId}`, and `GET /v1/tasks/{taskId}/audit-events`, then prints a final JSON summary.
 
 ## Current endpoints
 

--- a/src/runtime/bootstrap-smoke.js
+++ b/src/runtime/bootstrap-smoke.js
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { createApp } from "./app.js";
+
+function buildBootstrapTask() {
+  return {
+    title: "Bootstrap runtime smoke",
+    description: "Verify the local control-plane bootstrap path end-to-end",
+    budget: {
+      currency: "USD",
+      minAmount: 100,
+      maxAmount: 250
+    },
+    sla: {
+      deadlineAt: "2026-03-20T00:00:00Z",
+      maxLatencyMs: 5000
+    },
+    constraints: {
+      identityTierMin: "T1",
+      requiredSkills: ["backend", "api"]
+    },
+    risk: {
+      level: "LOW",
+      valueScore: 0.2
+    },
+    powmPolicy: {
+      mode: "AUTO_TIERED",
+      baseDifficulty: 2
+    },
+    biddingWindow: {
+      commitDeadline: "2026-03-19T00:00:00Z",
+      revealDeadline: "2026-03-20T00:00:00Z"
+    }
+  };
+}
+
+async function expectJson(response, expectedStatus) {
+  assert.equal(response.status, expectedStatus);
+  return response.json();
+}
+
+export async function runBootstrapSmoke({
+  host = "127.0.0.1",
+  serviceName = "agent-indeed-control-plane-smoke",
+  log = (message) => console.log(message)
+} = {}) {
+  const app = createApp({
+    config: { serviceName },
+    logger: () => {}
+  });
+  const server = createServer(app);
+
+  let listening = false;
+
+  try {
+    server.listen(0, host);
+    await once(server, "listening");
+    listening = true;
+
+    const address = server.address();
+    const baseUrl = `http://${host}:${address.port}`;
+
+    log(`bootstrap smoke listening on ${baseUrl}`);
+
+    const health = await expectJson(await fetch(`${baseUrl}/healthz`), 200);
+    log(`PASS /healthz -> ${health.status}`);
+
+    const readiness = await expectJson(await fetch(`${baseUrl}/readyz`), 200);
+    assert.equal(readiness.status, "ready");
+    log(`PASS /readyz -> ${readiness.status}`);
+
+    const initialSummary = await expectJson(
+      await fetch(`${baseUrl}/v1/runtime/summary`),
+      200
+    );
+    assert.equal(initialSummary.storage.tasks, 0);
+    log(`PASS /v1/runtime/summary -> tasks=${initialSummary.storage.tasks}`);
+
+    const created = await expectJson(
+      await fetch(`${baseUrl}/v1/tasks`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-workspace-id": "workspace-kestrel"
+        },
+        body: JSON.stringify({
+          task: buildBootstrapTask()
+        })
+      }),
+      201
+    );
+    assert.match(created.taskId, /^task_/);
+    log(`PASS POST /v1/tasks -> ${created.taskId}`);
+
+    const task = await expectJson(
+      await fetch(`${baseUrl}/v1/tasks/${created.taskId}`),
+      200
+    );
+    assert.equal(task.task.title, "Bootstrap runtime smoke");
+    log(`PASS GET /v1/tasks/${created.taskId}`);
+
+    const auditEvents = await expectJson(
+      await fetch(`${baseUrl}/v1/tasks/${created.taskId}/audit-events`),
+      200
+    );
+    assert.equal(auditEvents.count, 1);
+    assert.equal(auditEvents.events[0].eventType, "TASK_CREATED");
+    log(`PASS GET /v1/tasks/${created.taskId}/audit-events -> ${auditEvents.count} event`);
+
+    const summary = await expectJson(await fetch(`${baseUrl}/v1/runtime/summary`), 200);
+    assert.equal(summary.storage.tasks, 1);
+    assert.equal(summary.storage.auditEvents, 1);
+    log(
+      `PASS final summary -> tasks=${summary.storage.tasks}, auditEvents=${summary.storage.auditEvents}`
+    );
+
+    return {
+      serviceName,
+      baseUrl,
+      taskId: created.taskId,
+      auditEventCount: auditEvents.count,
+      storage: summary.storage
+    };
+  } finally {
+    if (listening) {
+      server.close();
+      await once(server, "close");
+    }
+  }
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  runBootstrapSmoke()
+    .then((result) => {
+      console.log(JSON.stringify({ status: "ok", ...result }, null, 2));
+    })
+    .catch((error) => {
+      console.error("bootstrap smoke failed");
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/test/runtime/bootstrap-smoke.test.js
+++ b/test/runtime/bootstrap-smoke.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runBootstrapSmoke } from "../../src/runtime/bootstrap-smoke.js";
+
+test("bootstrap smoke command exercises the local runtime bootstrap path", async () => {
+  const lines = [];
+  const result = await runBootstrapSmoke({
+    serviceName: "test-bootstrap-smoke",
+    log: (message) => lines.push(message)
+  });
+
+  assert.match(result.taskId, /^task_/);
+  assert.equal(result.auditEventCount, 1);
+  assert.equal(result.storage.tasks, 1);
+  assert.equal(result.storage.auditEvents, 1);
+  assert.ok(lines.some((line) => line.includes("PASS /healthz")));
+  assert.ok(lines.some((line) => line.includes("PASS POST /v1/tasks")));
+});


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #115
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/feature`
- Scope: add a one-command runtime bootstrap smoke path for the control-plane tranche

## What Changed

- added `npm run smoke:bootstrap` in `package.json` so the bootstrap runtime path is executable from one command alongside the existing dispatch smoke path
- added `src/runtime/bootstrap-smoke.js` to start the local control plane on an ephemeral port, probe `/healthz`, `/readyz`, `/v1/runtime/summary`, create a task, and read task/audit state back
- added `test/runtime/bootstrap-smoke.test.js` to keep the smoke flow covered in `npm test`
- updated `src/runtime/README.md`, `README.md`, `docs/TECH_STACK.md`, and the OpenSpec runtime bootstrap sections to document the smoke command as the shared FE/QA verification path while staying aligned with the newer dispatch vertical-slice docs on `main`
- rebased the PR onto current `main` so the branch now contains the merged runtime skeleton and dispatch baseline without merge conflicts

## Why

- issue #115 asks for a runtime bootstrap tranche that downstream QA/frontend can hit immediately without manually stitching together curl steps
- now that the runtime skeleton and dispatch slice are merged to `main`, this PR keeps a focused bootstrap verification command on top of the latest baseline instead of remaining a stale stacked diff
- keeping the repo docs and OpenSpec runtime requirement in sync preserves the OpenSpec-first flow while turning the bootstrap path into an executable command

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| A documented command starts the service locally and returns healthy responses from `/healthz` and `/readyz`. | `npm run smoke:bootstrap` starts the runtime baseline in-process and asserts the health/readiness probes before continuing. | `package.json`, `src/runtime/bootstrap-smoke.js`, `test/runtime/bootstrap-smoke.test.js` |
| At least one namespaced API route responds against the same runtime process. | The smoke flow probes `/v1/runtime/summary`, `POST /v1/tasks`, `GET /v1/tasks/{taskId}`, and `GET /v1/tasks/{taskId}/audit-events` against the booted process. | `src/runtime/bootstrap-smoke.js`, `src/runtime/README.md` |
| Core persistence interfaces for task/bid/proof/award/audit are present and wired for repeatable local runs. | The smoke path exercises the existing deterministic task/audit store boundary from `main` and documents it as the repeatable local runtime check for the tranche. | `src/runtime/bootstrap-smoke.js`, `src/runtime/README.md`, `docs/TECH_STACK.md` |
| Progress and evidence are linked back to issue #115. | The branch, PR metadata, and OpenSpec/runtime docs all point back to the bootstrap tranche issue and keep the command scoped to that work item. | PR metadata, `openspec/changes/agent-dispatch-platform/design.md`, `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md` |

## QA Plan

### Preconditions

- Node.js 20.11+ is available locally.
- Branch `codex/p1-115-bootstrap-smoke` is rebased on current `origin/main`.
- OpenSpec CLI is available in the workspace.

### Steps

1. Run `npm test`.
2. Run `npm run smoke:bootstrap`.
3. Run `openspec validate --changes`.
4. Run `openspec validate --all`.
5. Run `git diff --check`.
6. Run `bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent`.

### Expected Results

- Runtime unit tests pass, including the new bootstrap smoke test.
- The smoke command prints PASS lines for health/readiness/runtime summary/task create/task readback/audit readback and exits with a final JSON payload.
- OpenSpec validations pass with the updated runtime bootstrap requirement text.
- Diff and pre-push checks pass cleanly.

### Validation Output

```text
$ npm test
> test
> node --test

✔ healthz and readyz return runtime status (22.553875ms)
✔ POST /v1/tasks persists a task and updates runtime summary (12.137334ms)
✔ POST /v1/tasks rejects requests without a workspace header (2.61825ms)
✔ GET /v1/tasks/:taskId returns the persisted task payload (2.865584ms)
✔ GET /v1/tasks/:taskId returns 404 for unknown ids (1.911334ms)
✔ dispatch vertical slice publishes, matches, bids, verifies, awards, and exposes audit trails (28.457583ms)
✔ reveal without a commit and failed verification return stable errors (6.414375ms)
✔ unknown routes are logged as 404s (0.818042ms)
✔ GET /v1/bids/:bidId/events rejects bid ids shorter than the published contract (0.68075ms)
✔ bid/proof status routes return 404 when the task-scoped projection does not exist (1.435667ms)
✔ bootstrap smoke command exercises the local runtime bootstrap path (29.939708ms)
✔ loadRuntimeConfig applies defaults for local runtime bootstrap (1.853125ms)
✔ loadRuntimeConfig rejects invalid ports (0.236958ms)
✔ loadRuntimeConfig rejects blank host and service names (0.089125ms)
✔ runDispatchSmoke executes the publish to award flow (55.20325ms)
✔ store assigns deterministic ids across the dispatch lifecycle (3.076625ms)
ℹ tests 16
ℹ suites 0
ℹ pass 16
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 251.982209

$ npm run smoke:bootstrap
> smoke:bootstrap
> node src/runtime/bootstrap-smoke.js

bootstrap smoke listening on http://127.0.0.1:58100
PASS /healthz -> ok
PASS /readyz -> ready
PASS /v1/runtime/summary -> tasks=0
PASS POST /v1/tasks -> task_00000001
PASS GET /v1/tasks/task_00000001
PASS GET /v1/tasks/task_00000001/audit-events -> 1 event
PASS final summary -> tasks=1, auditEvents=1
{
  "status": "ok",
  "serviceName": "agent-indeed-control-plane-smoke",
  "baseUrl": "http://127.0.0.1:58100",
  "taskId": "task_00000001",
  "auditEventCount": 1,
  "storage": {
    "tasks": 1,
    "bids": 0,
    "proofs": 0,
    "awards": 0,
    "auditEvents": 1,
    "latestTaskId": "task_00000001",
    "latestAuditId": "audit_00000001"
  }
}

$ openspec validate --changes
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ git diff --check
(no output)

$ bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent
[ok] Branch 'codex/p1-115-bootstrap-smoke' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (kestrel-dev-agent).
[ok] git user.email matches expected account (kestrel-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - This is still an in-memory bootstrap verifier, so it proves the local service path but not durable persistence or multi-process behavior.
  - The command partially overlaps the richer dispatch smoke path on `main`, so follow-on reviews should keep the two entrypoints aligned.
- Rollback:
  - Revert commit `b42c207` to remove the bootstrap smoke command and docs updates.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--kestrel`
