### PR TITLE
docs: rename QA owner label to owner:avery

### DIFF
--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -1,6 +1,6 @@
 # Organization
 
-Last updated: 2026-03-16
+Last updated: 2026-03-17
 
 ## Purpose
 
@@ -120,7 +120,7 @@ This map defines who PM Lan assigns as issue owner and who is requested as PR re
 | --- | --- | --- | --- |
 | Frontend implementation | `dept/frontend` + one `type/*` | `owner:lanzhou-fe-agent` | UI workflow/state-machine scope. |
 | Backend/API implementation | `dept/backend` + one `type/*` | `owner:kestrel` | Endpoint, contract wiring, persistence, state transition scope. |
-| QA/test execution | `dept/qa` + one `type/*` | `owner:qa` | Smoke/E2E, regression evidence, validation tooling. |
+| QA/test execution | `dept/qa` + one `type/*` | `owner:avery` | Smoke/E2E, regression evidence, validation tooling. |
 | Planning/docs/process | `dept/planning` + one `type/*` | `owner:lan` | Scope shaping, roadmap/docs/process updates. |
 | Cross-cutting architecture | keep primary `dept/*` + one `type/*` | `owner:albatross` | Use only when issue mainly controls multi-lane architecture decisions. |
 

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -12,7 +12,7 @@ This file intentionally stays lightweight so we do not duplicate fast-changing i
 - [Planning lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aalbatross%22)
 - [Backend lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Akestrel%22)
 - [Frontend lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Alanzhou-fe-agent%22)
-- [QA lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aqa%22)
+- [QA lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aavery%22)
 
 ## Stable issue index
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): N/A (direct documentation sync request)
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Rename QA owner label references from `owner:qa` to `owner:avery` in organization/docs quick links

## What Changed

- Updated the issue owner map in `docs/ORGANIZATION.md` to set QA default owner label as `owner:avery`.
- Updated the QA lane quick-link in `docs/issues/PHASE1_ISSUES.md` to query `owner:avery`.
- Updated `Last updated` in `docs/ORGANIZATION.md` to reflect this edit date.

## Why

- QA ownership moved to Avery; docs and quick links must match live label taxonomy so dispatch and triage flows remain accurate.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| QA lane owner label uses `owner:avery` | Replaced `owner:qa` with `owner:avery` in owner map table | `docs/ORGANIZATION.md:123` |
| QA quick links point to current label | Updated issue query URL to `owner%3Aavery` | `docs/issues/PHASE1_ISSUES.md:15` |
| OpenSpec/doc consistency checks pass | Ran required OpenSpec validation command | `openspec validate --changes` output (pass) |

## QA Plan

### Preconditions

- Local branch checked out from latest `main`.
- GitHub label rename already applied (`owner:qa` -> `owner:avery`).

### Steps

1. Run `rg -n "owner:qa|owner%3Aqa" docs .github scripts`.
2. Open `docs/ORGANIZATION.md` and `docs/issues/PHASE1_ISSUES.md` to verify `owner:avery` references.
3. Run `openspec validate --changes`.

### Expected Results

- No `owner:qa` or `owner%3Aqa` matches remain in docs.
- QA owner map and lane query both reference `owner:avery`.
- OpenSpec validation passes.

### Validation Output

- `openspec validate --changes`

## Risks and Rollback

- Risk:
  - External automation or bookmarks may still reference `owner:qa` and need separate updates.
- Rollback:
  - Revert this commit and restore previous docs references.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
