### PR TITLE
docs: add frontend runtime integration tranche

### DIFF
--- a/docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md
+++ b/docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md
@@ -1,12 +1,12 @@
 # Agent Bid Commit/Reveal Workspace (P1-21)
 
-Last updated: 2026-03-15
+Last updated: 2026-03-17
 
 ## Objective
 
 Define the focused frontend execution slice for issue #63 so an agent can move from bid commitment to reveal submission inside one workflow without carrying the full verification-timeline scope in the same delivery item.
 
-This slice builds on `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`: commit/reveal entry is implementable now against the current write contracts, while long-lived verification refresh remains an explicit backend follow-up through issue #59.
+This slice builds on `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`: commit/reveal entry is implementable now against the current write contracts, and the merged bid/proof status reads on `main` now provide the runtime-backed handoff target for issue #136.
 
 ## Scope
 
@@ -88,7 +88,7 @@ Failure rendering:
 
 Success state:
 - Show `status`, `result`, optional `rankingScore`, `decisionTraceHash`, and `proofSubmission.proofId` + `verificationStatus`.
-- If verification is still pending, hand off to the verification route with a clear note that the current repository lacks a durable read model for refresh-safe progress tracking.
+- If verification is still pending, hand off to the verification route with the returned `proofId` and use the merged bid/proof read routes for refresh-safe progress tracking.
 
 ## Cross-stage empty, loading, and blocked states
 
@@ -104,21 +104,21 @@ Success state:
 | Commit submit | `CommitBidRequest` | `POST /v1/tasks/{taskId}/bids/commit` | Ready | Current write contract already returns `window` snapshot and replay-safe result metadata |
 | Commit replay/closed handling | `CommitBidAcceptedResponse` + `CommitBidErrorResponse` | `POST /v1/tasks/{taskId}/bids/commit` response | Ready | Workspace should branch on stable reason codes instead of generic error copy |
 | Reveal submit | `RevealBidRequest` | `POST /v1/tasks/{taskId}/bids/reveal` | Ready | All required `ProofPack` sections can be represented now |
-| Reveal result handoff | `RevealBidAcceptedResponse` + `RevealBidErrorResponse` | `POST /v1/tasks/{taskId}/bids/reveal` response | Partial | Immediate post-submit handoff works, but refresh-safe reads still depend on issue #59 |
-| Verification follow-through | proof/bid read model | Proposed `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` | Pending backend contract | Needed to restore workspace state after browser refresh or cross-device resume |
+| Reveal result handoff | `RevealBidAcceptedResponse` + `RevealBidErrorResponse` | `POST /v1/tasks/{taskId}/bids/reveal` response | Ready | Immediate post-submit handoff can pass `proofSubmission.proofId` into the merged runtime read routes on `main` |
+| Verification follow-through | proof/bid read model | `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` | Ready on `main` | Needed to restore workspace state after browser refresh or cross-device resume; runtime persistence still depends on issue `#110` |
 
 ## Backend dependency feedback
 
 P1-21 keeps four follow-ups explicit instead of hiding them inside frontend-only assumptions:
 
-1. A bid workspace read model is still missing.
-   - Minimum payload: `bidId`, `taskId`, `agentId`, `phase`, `status`, accepted commit timestamp, optional reveal timestamp, latest `decisionTraceHash`, and current window snapshot.
-2. Proof verification still needs a read endpoint.
-   - Minimum payload: `proofId`, `verificationStatus`/`result`, required vs achieved difficulty, `reasonCodes`, `verifiedAt`, optional manual-review note.
-3. Window state should stay server-authored.
-   - Any future read model must echo the same `window` snapshot shape already returned by commit/reveal writes so frontend countdown and CTA logic do not drift.
-4. Required-vs-optional proof metadata needs to stay shared.
+1. Runtime persistence behind the merged bid/proof read endpoints still needs to stay stable.
+   - Minimum payload already exists on `main`; issue `#110` must keep `bidId`, phase/state fields, proof summary, audit refs, and refresh metadata populated for live runs.
+2. Window and refresh state should stay server-authored.
+   - The runtime implementation should preserve `window.nextAction` on writes and `refresh.*` on reads so countdown and polling logic do not drift.
+3. Required-vs-optional proof metadata needs to stay shared.
    - If `ProofPack` changes, this workspace spec, `src/api/openapi.yaml`, and `src/api/contracts.ts` must be updated together.
+4. The issue #136 runbook should remain the source of truth for local smoke evidence.
+   - Workspace validation is not complete until a local runtime run records bid/proof status projection behavior end to end.
 
 ## Acceptance criteria mapping
 
@@ -127,4 +127,4 @@ P1-21 keeps four follow-ups explicit instead of hiding them inside frontend-only
 | Agent can prepare a commit payload and reveal payload from one workflow with clear deadline/state feedback. | Single route, stage-aware shell, and `window.nextAction` guidance keep commit and reveal in one focused workspace. |
 | ProofPack entry/upload inputs align with the current contract and highlight missing required sections before submit. | Reveal stage maps every current required `ProofPack` section and distinguishes required vs optional evidence. |
 | UX states cover commit-window closed, reveal-without-commit, and payload validation failures. | Failure rendering and cross-stage blocked states define explicit handling for each requested case. |
-| Scope stays focused on commit/reveal interaction and does not absorb async verification timeline work. | Verification follow-through is limited to handoff notes; read-model and polling gaps stay tracked as dependencies on issue #59. |
+| Scope stays focused on commit/reveal interaction and does not absorb full verification-screen design work. | Verification follow-through stays limited to the runtime-backed handoff into issue `#136` and the dedicated verification baseline. |

--- a/docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md
+++ b/docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md
@@ -1,6 +1,6 @@
 # Agent Verification Timeline Baseline (P1-22)
 
-Last updated: 2026-03-14
+Last updated: 2026-03-17
 
 ## Objective
 
@@ -12,19 +12,19 @@ Define the agent-facing post-reveal timeline so an agent can understand whether 
 4. failed, or
 5. routed to manual review.
 
-This baseline stays honest about repository reality on `main`: commit/reveal write endpoints exist today, but the async bid/proof read contract is still pending backend follow-through in issue [#59](https://github.com/jckhang/agent-indeed/issues/59) and PR [#66](https://github.com/jckhang/agent-indeed/pull/66).
+This baseline stays honest about repository reality on `main`: commit/reveal write endpoints and bid/proof status read endpoints now exist, while local runtime persistence and smoke evidence still depend on implementation issues [#110](https://github.com/jckhang/agent-indeed/issues/110), [#115](https://github.com/jckhang/agent-indeed/issues/115), and [#136](https://github.com/jckhang/agent-indeed/issues/136).
 
 ## Scope
 
 - Closed-beta agent workflow only.
 - Verification timeline states, copy, and refresh expectations after reveal.
-- Explicit fallback behavior when the backend cannot yet expose async status reads.
+- Explicit fallback behavior when a local runtime has not yet populated the merged async status reads.
 
 Out of scope:
 
 - Rich visual design exploration.
 - Operator override tooling.
-- Event-stream transport; MVP is bounded to manual refresh today and polling once the read contract merges.
+- Event-stream transport; MVP stays bounded to polling plus manual refresh on the merged read endpoints.
 
 ## Agent workflow slice
 
@@ -32,7 +32,7 @@ Out of scope:
 | --- | --- | --- | --- |
 | 1 | Commit bid hash | `Commit workspace` | Ready now via `POST /v1/tasks/{taskId}/bids/commit` |
 | 2 | Reveal bid + proof | `Reveal workspace` | Ready now via `POST /v1/tasks/{taskId}/bids/reveal` |
-| 3 | Track verification progression | `Verification timeline` | Partial: terminal verify response exists, but no merged read endpoint exposes queued/verifying states yet |
+| 3 | Track verification progression | `Verification timeline` | Ready on `main`: `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` expose queued/verifying/terminal projections when the runtime serves them |
 
 ## Timeline model
 
@@ -46,8 +46,8 @@ Agent copy:
 - Supporting: `You do not need to resubmit your reveal. Check again for status updates.`
 
 Current contract reality:
-- The current API can only infer this immediately after reveal is accepted (`BidResponse.phase=REVEAL`, `BidResponse.status=REVEALED`).
-- No merged proof read endpoint exists on `main`, so the UI must present this as a pending state, not as a durable backend truth.
+- `GET /v1/tasks/{taskId}/proofs/{proofId}` now returns `verificationState=QUEUED` when the runtime has persisted the proof for verifier pickup.
+- If the running stack does not yet populate the projection, the UI should say the runtime status snapshot is unavailable rather than fabricating queued progress.
 
 ### 2. Verifying
 
@@ -59,8 +59,8 @@ Agent copy:
 - Supporting: `The verifier is evaluating your submission against the task policy.`
 
 Current contract reality:
-- This state is planned in the async read contract tracked by issue [#59](https://github.com/jckhang/agent-indeed/issues/59) and PR [#66](https://github.com/jckhang/agent-indeed/pull/66).
-- Until that contract merges, the UI must not render `Verifying` as if it were currently queryable.
+- `GET /v1/tasks/{taskId}/proofs/{proofId}` and `GET /v1/tasks/{taskId}/bids/{bidId}` now provide the verifier-in-progress projection on `main`.
+- The UI should treat `VERIFYING` as durable backend truth only when the runtime read model returns it, and otherwise fall back to an unavailable-projection message.
 
 ### 3. Passed
 
@@ -103,25 +103,26 @@ Current contract reality:
 
 ## Refresh strategy assumptions
 
-### Current fallback on `main`
+### Current runtime-backed behavior on `main`
 
 What the UI can promise now:
-- Reveal acceptance is synchronous and can move the timeline into a pending verification state.
-- Terminal proof outcomes can be shown only when the current session receives a `ProofVerificationResponse`.
+- Reveal acceptance is synchronous and can hand off `proofId` plus initial verification status into the read-model routes.
+- Queued, verifying, and terminal proof outcomes can be read through `GET /v1/tasks/{taskId}/proofs/{proofId}` when the runtime has persisted the projection.
+- Bid-level recovery after reload can use `GET /v1/tasks/{taskId}/bids/{bidId}` instead of caching browser-only state.
 
-What the UI cannot promise yet:
-- A durable read path for queued or verifying state.
-- Background auto-refresh that discovers a terminal result after the page is reloaded.
+What the UI still cannot promise without the running stack:
+- That every local environment already persists and serves the merged status projections.
+- Polling cadence beyond the backend-provided `refresh.pollAfterSeconds` metadata.
 
 Required product wording:
-- Show an explicit dependency callout: `Live verification refresh depends on the bid/proof status read contract (issue #59 / PR #66).`
-- Keep a manual `Refresh status` affordance visually secondary until the read endpoint is merged, so the UI does not imply current functionality that the backend cannot support.
+- If the projection is missing, say `Runtime verification status is not available from this environment yet.`
+- Keep a manual `Refresh status` affordance available even while polling so local smoke runs can prove refresh behavior explicitly.
 
-### MVP target once PR #66 lands
+### MVP polling behavior
 
 Recommended bounded behavior:
-- Poll `GET /v1/tasks/{taskId}/proofs/{proofId}` on a short interval (for example 10-15 seconds) while status is non-terminal.
-- Always keep a manual refresh action available.
+- Poll `GET /v1/tasks/{taskId}/proofs/{proofId}` on the backend-provided `refresh.pollAfterSeconds` cadence while state is non-terminal.
+- Also refresh `GET /v1/tasks/{taskId}/bids/{bidId}` when the screen needs award or bid-level state changes.
 - Stop polling immediately when a terminal state is returned.
 
 ### Optional later upgrade
@@ -134,15 +135,15 @@ Recommended bounded behavior:
 | --- | --- | --- | --- | --- |
 | Commit workspace submit | `CommitBidRequest` | `POST /v1/tasks/{taskId}/bids/commit` | Ready | Existing write response is enough for commit confirmation |
 | Reveal workspace submit | `RevealBidRequest` | `POST /v1/tasks/{taskId}/bids/reveal` | Ready | Existing write response is enough to confirm reveal acceptance |
-| Verification timeline pending states | proof status read model (`queued`, `verifying`) | Proposed backend read contract in issue #59 / PR #66 | Pending backend contract | Must stay labeled as pending until read endpoint merges |
-| Verification timeline terminal states | `ProofVerificationResponse` (`PASS`, `FAIL`, `MANUAL_REVIEW`) | `POST /v1/tasks/{taskId}/proofs/verify` | Partial | Works only when the current session receives the verify response |
-| Refresh controls | `RefreshPolicy`, `lastUpdatedAt`, `pollAfterSeconds` | Proposed backend read contract in issue #59 / PR #66 | Pending backend contract | Use dependency callout instead of pretending these fields already exist |
+| Verification timeline pending states | proof status read model (`QUEUED`, `VERIFYING`) | `GET /v1/tasks/{taskId}/proofs/{proofId}` | Ready on `main` | Runtime implementation must populate the projection for local runs; otherwise render unavailable-projection copy |
+| Verification timeline terminal states | `ProofStatusResponse` and `ProofVerificationResponse` (`PASS`, `FAIL`, `MANUAL_REVIEW`, `OVERRIDDEN`) | `GET /v1/tasks/{taskId}/proofs/{proofId}` plus `POST /v1/tasks/{taskId}/proofs/verify` | Ready | Read route is the primary agent-facing source; verify write remains verifier/operator-only |
+| Refresh controls | `RefreshPolicy`, `lastUpdatedAt`, `pollAfterSeconds` | `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` | Ready on `main` | Use backend refresh metadata as the only polling truth |
 
 ## Failure and empty-state guidance
 
 | Condition | Agent copy |
 | --- | --- |
-| Reveal accepted but no proof status read yet | `Verification updates are not live yet; check back after the status-read contract lands.` |
+| Reveal accepted but no proof status read yet | `Runtime verification status is not available from this environment yet.` |
 | Proof verification failed with reason codes | `Verification failed. Review the returned reason codes before retrying.` |
 | Proof routed to manual review | `Verification needs operator review before this bid can advance.` |
 | Proof status data missing optional timestamps or difficulty values | `Verification result received. Additional trace details are not available yet.` |
@@ -151,15 +152,15 @@ Recommended bounded behavior:
 
 P1-22 makes three concrete follow-ups explicit:
 
-1. The bid/proof status read contract remains a frontend blocker until PR [#66](https://github.com/jckhang/agent-indeed/pull/66) merges.
-2. `queued` and `verifying` should be explicit read-model states, not inferred forever from reveal success.
-3. Refresh policy metadata (`manualRefreshAllowed`, `pollAfterSeconds`, `lastUpdatedAt`) should be shared between agent and operator flows so timeline behavior stays testable.
+1. Runtime issue [#110](https://github.com/jckhang/agent-indeed/issues/110) must keep bid/proof status projections populated so the merged read routes are meaningful in local runs.
+2. `QUEUED` and `VERIFYING` should remain explicit read-model states, not re-inferred from reveal success in the client.
+3. Refresh policy metadata (`manualRefreshAllowed`, `pollAfterSeconds`, `lastUpdatedAt`) should stay shared between agent and operator flows so timeline behavior stays testable.
 
 ## Acceptance criteria mapping
 
 | Acceptance criterion | Baseline coverage |
 | --- | --- |
 | Verification timeline covers queued, verifying, passed, failed, and needs-review states with operator-friendly copy. | This document defines all five states, their user-facing copy, and when the UI may present them as current truth versus planned read-model behavior. |
-| Refresh strategy assumptions are explicit and bounded by the current backend contract. | `Current fallback on main`, `MVP target once PR #66 lands`, and `Optional later upgrade` separate present-day behavior from the proposed polling contract. |
-| UI does not treat unavailable bid/proof read fields as existing contract reality. | Every pending-state section marks queued/verifying reads and refresh metadata as dependency work, not merged API truth. |
-| Any missing async status contract is linked back to backend issue `#59` or a new follow-up issue. | The dependency is linked to both issue `#59` and active PR `#66` throughout this baseline. |
+| Refresh strategy assumptions are explicit and bounded by the current backend contract. | `Current runtime-backed behavior on main`, `MVP polling behavior`, and `Optional later upgrade` separate merged read-model truth from environment-specific runtime gaps. |
+| UI does not treat unavailable bid/proof runtime data as existing environment truth. | Every state section distinguishes merged API shape from a local runtime that may not yet serve the projection data. |
+| Any missing async status implementation is linked back to the runtime execution threads. | The dependency is linked to issues `#110`, `#115`, and `#136` throughout this baseline. |

--- a/docs/FRONTEND_MVP_SURFACE.md
+++ b/docs/FRONTEND_MVP_SURFACE.md
@@ -1,6 +1,6 @@
 # Frontend MVP Surface and API Wiring Matrix
 
-Last updated: 2026-03-15
+Last updated: 2026-03-17
 
 Related issue: [#33](https://github.com/jckhang/agent-indeed/issues/33)
 
@@ -63,8 +63,8 @@ Define the minimum manager, agent, and operator console surface needed to execut
 | Page | API endpoint | Required request fields from UI | Response fields required by UI | Contract status |
 | --- | --- | --- | --- | --- |
 | `/manager/tasks/new` | `POST /v1/tasks` | `task.title`, `task.description`, `task.budget.*`, `task.sla.*`, `task.constraints.*`, `task.risk.*`, `task.powmPolicy.*`, `task.biddingWindow.*` | `taskId`, `status`, `commitDeadline`, `revealDeadline` | Ready for a publish-only slice; explicit task-create idempotency is still a follow-up and should not be invented in UI |
-| `/manager/tasks/{taskId}/candidates` | `GET /v1/tasks/{taskId}/candidates` | Manager session + `task.write`; `taskId`, `limit`, optional `includeScoreBreakdown` | `agentId`, `eligible`, `matchingTraceId`, `identityTier`, `matchedSkills`, `missingRequiredSkills`, `complianceStatus`, `eligibilityChecks`, `rank` for eligible rows, optional `scoreBreakdown`, additive review context (`bidId`, `missingDataStates`, `proofReadiness`, `shortlistAuditId`, `decisionTraceHash`) | Ready on the shortlist-award contract branch; UI should handle `409 TASK_MATCH_NOT_READY` while snapshots are generating and render partial evidence without inventing fallback fields |
-| `/manager/tasks/{taskId}/award` | `POST /v1/tasks/{taskId}/award` + `GET /v1/tasks/{taskId}/award` | `taskId`, `idempotencyKey`, `award.bidId`, `award.awardReason`, `award.shortlistAuditId`, `award.proofAuditId`, optional `award.managerDecisionNote` | `taskId`, `status`, `statusMessage`, `shortlistedBidId`, `awardedBidId`, `awardedAt`, `proofSummary`, `handoff`, `decisionTraceHash`, `auditEventId` | Draft-ready on the shortlist-award contract branch; runtime wiring still depends on issue `#110` rather than missing contract shape |
+| `/manager/tasks/{taskId}/candidates` | `GET /v1/tasks/{taskId}/candidates` | Manager session + `task.write`; `taskId`, `limit`, optional `includeScoreBreakdown` | `agentId`, `eligible`, `matchingTraceId`, `identityTier`, `matchedSkills`, `missingRequiredSkills`, `complianceStatus`, `eligibilityChecks`, `rank` for eligible rows, optional `scoreBreakdown`, additive review context (`bidId`, `missingDataStates`, `proofReadiness`, `shortlistAuditId`, `decisionTraceHash`) | Ready on `main`; runtime handlers still need to stay aligned with issue `#110` while UI renders `409 TASK_MATCH_NOT_READY` as a retryable loading state |
+| `/manager/tasks/{taskId}/award` | `POST /v1/tasks/{taskId}/award` + `GET /v1/tasks/{taskId}/award` | `taskId`, `idempotencyKey`, `award.bidId`, `award.awardReason`, `award.shortlistAuditId`, `award.proofAuditId`, optional `award.managerDecisionNote` | `taskId`, `status`, `statusMessage`, `shortlistedBidId`, `awardedBidId`, `awardedAt`, `proofSummary`, `handoff`, `decisionTraceHash`, `auditEventId` | Contract-ready on `main`; runtime award execution still depends on issue `#110`, but award-readiness copy should come from the merged read model now |
 
 ### Agent pages
 
@@ -72,9 +72,9 @@ Define the minimum manager, agent, and operator console surface needed to execut
 | --- | --- | --- | --- | --- |
 | `/agent/onboarding` | `POST /v1/agents/bundles` | `idempotencyKey`, `bundle.schemaVersion`, `bundle.manifest.*`, `bundle.identity.*`, `bundle.skills[]`, `bundle.memoryRef.*`, `bundle.signature.*` | `agentId`, `version`, `status`, `result`, `indexedAt`; error `code`, `category`, `auditId`, `retryable`, `details`, `conflict` | Ready for create/replay/conflict/error paths in the current draft API, including explicit schema-version and signature payload-hash failures |
 | `/agent/tasks/{taskId}/bid-workspace` (commit stage) | `POST /v1/tasks/{taskId}/bids/commit` | `idempotencyKey`, `commit.bidId`, `commit.taskId`, `commit.agentId`, `commit.bidHash`, `commit.committedAt` | `bidId`, `taskId`, `agentId`, `phase`, `status`, `result`, `window.*` | Ready for the commit stage of the unified workspace; stable reason codes and server-authored window snapshot already exist |
-| `/agent/tasks/{taskId}/bid-workspace` (reveal stage) | `POST /v1/tasks/{taskId}/bids/reveal` | `idempotencyKey`, `reveal.bidId`, `reveal.taskId`, `reveal.agentId`, `reveal.nonce`, `reveal.price.*`, `reveal.executionPlan.*`, `reveal.proof.*` | `bidId`, `phase`, `status`, `result`, `rankingScore`, `decisionTraceHash`, `proofSubmission.*`, `window.*` | Ready for the reveal stage with typed failure paths; proof read endpoint is still needed to recover after refresh |
-| `/agent/tasks/{taskId}/verification` | `GET /v1/tasks/{taskId}/proofs/{proofId}` (proposed read endpoint) | `taskId`, `proofId` | `status`, `result` (`PASS`, `FAIL`, `MANUAL_REVIEW`), `requiredDifficulty`, `achievedDifficulty`, `reasonCodes`, `verifiedAt`, `lastUpdatedAt`, `refreshPolicy` | Missing on `main`; the bid workspace can hand off here after reveal, but queued/verifying reads still depend on issue `#59` / PR `#66` |
-| `/agent/tasks/{taskId}/status` | `GET /v1/tasks/{taskId}/bids/{bidId}` | `taskId`, `bidId` | `commitState`, `revealState`, `proofState`, `awardState`, `failureReasonCodes`, `proof.*`, `refresh.*` | Proposed in PR `#66`; intended shared status projection for agent timeline and retry UX |
+| `/agent/tasks/{taskId}/bid-workspace` (reveal stage) | `POST /v1/tasks/{taskId}/bids/reveal` | `idempotencyKey`, `reveal.bidId`, `reveal.taskId`, `reveal.agentId`, `reveal.nonce`, `reveal.price.*`, `reveal.executionPlan.*`, `reveal.proof.*` | `bidId`, `phase`, `status`, `result`, `rankingScore`, `decisionTraceHash`, `proofSubmission.*`, `window.*` | Ready for the reveal stage with typed failure paths; the returned `proofSubmission` should hand off directly into the merged status reads |
+| `/agent/tasks/{taskId}/verification` | `GET /v1/tasks/{taskId}/proofs/{proofId}` | `taskId`, `proofId` | `verificationState`, `requiredDifficulty`, `achievedDifficulty`, `reasonCodes`, `verifiedAt`, `decisionTraceHash`, `refresh.*` | Ready on `main`; runtime persistence from issue `#110` determines whether queued/verifying snapshots are populated for local runs |
+| `/agent/tasks/{taskId}/status` | `GET /v1/tasks/{taskId}/bids/{bidId}` | `taskId`, `bidId` | `commitState`, `revealState`, `proofState`, `awardState`, `failureReasonCodes`, `proof.*`, `refresh.*` | Ready on `main`; use this shared status projection for agent timeline recovery and retry-safe UX |
 
 ### Operator pages
 
@@ -99,7 +99,7 @@ Minimum frontend state model to avoid race conditions and dead-end UX:
 | --- | --- | --- |
 | Candidate snapshot may still be pending when task first opens | Manager can land on an empty or confusing shortlist state | Surface `TASK_MATCH_NOT_READY` as a retryable loading state and poll using the API delay hint |
 | Award APIs depend on runtime implementation | UI contract exists, but live manager actions still need backend handlers | Land issue `#110` on top of the merged award read/write contract without changing the API shape again |
-| Missing merged list/read endpoints for bids/proofs | UI cannot refresh queued/verifying state on `main` without guessing hidden fields | Merge PR `#66` or equivalent read endpoints for bid/proof status by `taskId`, `bidId`, `proofId` |
+| Runtime status projections may still be absent in a local environment even though the contracts are merged | UI can recover only when the running stack behind issue `#110` persists and serves bid/proof status snapshots | Keep runtime handlers and persistence aligned with the merged `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` contracts |
 | Proof queue and audit event list endpoints are still missing | Operator queue and full timeline screens cannot refresh without custom backend work | Add list/read endpoints beyond the bid/proof detail projections |
 | Generic `ErrorResponse` for commit/reveal/verify failures | User-facing reason code mapping is unstable | Publish stable error code catalog with category + retryability |
 | No idempotency support beyond bundle upload | Retry-safe UX cannot be guaranteed for task publish/award | Add idempotency key contract to task and award writes |
@@ -108,9 +108,9 @@ Minimum frontend state model to avoid race conditions and dead-end UX:
 
 ## Recommended Contract Follow-Ups
 
-1. Build agent verification UX on top of `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` instead of inferring async state from write responses.
+1. Build the runtime integration tranche in `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md` on top of `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}` instead of inferring async state from write responses.
 2. Standardize error shape (`code`, `category`, `message`, `retryable`, `details`, `auditId`) across all write endpoints.
-3. Add task-scoped bid/proof read endpoints that reuse the existing `window` snapshot shape so the unified bid workspace can recover state after refresh.
+3. Keep runtime handlers from issue `#110` aligned with the merged bid/proof read projections so refresh works after reload and cross-route handoff.
 4. Freeze state enums for task, bid, proof, and award in `openapi.yaml` and `contracts.ts` to reduce UI branching drift.
-5. Carry refresh metadata (`manualRefreshAllowed`, `pollAfterSeconds`, `lastUpdatedAt`) in the bid/proof read model so the verification timeline stays testable and honest.
-6. Add operator queue and audit event list APIs so the new polling contract can scale beyond single bid/proof detail pages.
+5. Carry refresh metadata (`manualRefreshAllowed`, `pollAfterSeconds`, `lastUpdatedAt`) end-to-end in the runtime implementation so the verification timeline stays testable and honest.
+6. Add operator queue and richer audit query APIs so the current polling/read contract can scale beyond single bid/proof detail pages.

--- a/docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md
+++ b/docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md
@@ -1,0 +1,187 @@
+# Frontend Runtime Integration Tranche (P1-40)
+
+Last updated: 2026-03-17
+
+Related issue: [#136](https://github.com/jckhang/agent-indeed/issues/136)
+
+## Objective
+
+Capture the first runtime-backed frontend handoff slice for this week's execution sprint so the MVP can be demonstrated through real manager and agent flows instead of static-fixture-only wiring.
+
+This tranche is intentionally grounded in the current `main` baseline:
+- manager publish uses `POST /v1/tasks`
+- manager shortlist and award-readiness use `GET /v1/tasks/{taskId}/candidates` and `GET /v1/tasks/{taskId}/award`
+- agent commit/reveal uses `POST /v1/tasks/{taskId}/bids/commit` and `POST /v1/tasks/{taskId}/bids/reveal`
+- agent verification/status refresh uses `GET /v1/tasks/{taskId}/bids/{bidId}` and `GET /v1/tasks/{taskId}/proofs/{proofId}`
+- proof verification remains verifier/operator-only through `POST /v1/tasks/{taskId}/proofs/verify`
+
+Execution dependencies remain explicit:
+- runtime service baseline: [#115](https://github.com/jckhang/agent-indeed/issues/115)
+- runnable vertical slice: [#110](https://github.com/jckhang/agent-indeed/issues/110)
+- QA runtime checks: [#111](https://github.com/jckhang/agent-indeed/issues/111)
+
+## Scope
+
+In scope:
+- one manager runtime path: publish -> shortlist review -> award-readiness review
+- one agent runtime path: commit -> reveal -> verification-status refresh
+- loading, empty, error, and retry-safe state expectations tied to the merged read/write contracts
+- one local runbook for exercising the path against the runtime stack
+
+Out of scope:
+- visual design or component-library expansion
+- operator queue/review implementation details beyond dependency notes
+- manual proof-override tooling
+- frontend-only mock payloads presented as primary integration truth
+
+## Runtime-backed route map
+
+| Route | Persona | Primary API dependency | Runtime expectation |
+| --- | --- | --- | --- |
+| `/manager/tasks/new` | Manager | `POST /v1/tasks` | Publish a task and transition into a created task summary with real deadlines/status |
+| `/manager/tasks/{taskId}/review` | Manager | `GET /v1/tasks/{taskId}/candidates`, `GET /v1/tasks/{taskId}/award` | Render shortlist freshness, candidate ranking, blockers, and award-readiness from runtime reads |
+| `/agent/tasks/{taskId}/bid-workspace` | Agent | `POST /v1/tasks/{taskId}/bids/commit`, `POST /v1/tasks/{taskId}/bids/reveal` | Preserve server-authored window state and hand off to verification without inventing hidden state |
+| `/agent/tasks/{taskId}/verification` | Agent | `GET /v1/tasks/{taskId}/bids/{bidId}`, `GET /v1/tasks/{taskId}/proofs/{proofId}` | Poll and manually refresh until proof reaches a terminal verification state |
+
+## Manager runtime flow
+
+### 1. Publish task
+
+Input source:
+- `TaskSpec` form groups from `docs/MANAGER_TASK_COMPOSER_UI_SLICE.md`
+
+Runtime contract:
+- `POST /v1/tasks`
+
+UI requirements:
+- disable duplicate submit while request is in flight
+- keep request payload aligned to current `TaskSpec` and `CreateTaskRequest`
+- on success, persist `taskId`, `status`, `commitDeadline`, and `revealDeadline` for the review handoff
+- on failure, reuse `ApiErrorResponse.code`, `retryable`, and `auditId` instead of generic fallback text
+
+### 2. Review shortlist
+
+Input source:
+- route `taskId`
+- manager session and workspace scope
+
+Runtime contract:
+- `GET /v1/tasks/{taskId}/candidates`
+
+UI requirements:
+- prefer runtime candidate rows over static fixture packs whenever the endpoint returns data
+- show shortlist freshness and candidate count from the response instead of synthesized placeholders
+- preserve partial candidate rows when score breakdown, proof readiness, or trace refs are missing
+- surface `TASK_MATCH_NOT_READY` or equivalent retryable loading state as `Shortlist still generating`, not as an empty result
+
+### 3. Review award readiness
+
+Runtime contract:
+- `GET /v1/tasks/{taskId}/award`
+
+UI requirements:
+- show `status`, `statusMessage`, shortlisted or awarded bid ids, proof summary, and handoff status directly from the read model
+- treat `BLOCKED` and `PENDING_REVIEW` as first-class review states with visible blocker copy
+- keep award action copy secondary when runtime handlers from #110 are not yet available in the running stack
+- do not substitute operator audit timeline data for manager award summary state
+
+## Agent runtime flow
+
+### 1. Commit bid
+
+Runtime contract:
+- `POST /v1/tasks/{taskId}/bids/commit`
+
+UI requirements:
+- preserve server-authored `window.currentPhase`, deadlines, and `nextAction`
+- treat `BID_COMMIT_DUPLICATE` as replay-safe recovery and restore the accepted commit snapshot
+- render terminal window-closed states without offering a false retry path
+
+### 2. Reveal bid and proof
+
+Runtime contract:
+- `POST /v1/tasks/{taskId}/bids/reveal`
+
+UI requirements:
+- require a successful commit or recovered replay result before enabling reveal
+- validate required `ProofPack` sections before submit
+- hand off `proofSubmission.proofId` and `verificationStatus` to the verification route after acceptance
+- keep `POST /v1/tasks/{taskId}/proofs/verify` out of the agent UI path; verification is observed through runtime reads, not triggered by the agent
+
+### 3. Refresh bid/proof status
+
+Runtime contracts:
+- `GET /v1/tasks/{taskId}/bids/{bidId}`
+- `GET /v1/tasks/{taskId}/proofs/{proofId}`
+
+UI requirements:
+- show queued/verifying/terminal proof states from the backend projection instead of inferring them forever from reveal success
+- use `refresh.pollAfterSeconds`, `refresh.manualRefreshAllowed`, and `refresh.lastUpdatedAt` as the only polling truth
+- map `failureReasonCodes` and `reasonCodes` into stable agent copy without inventing richer hidden backend detail
+- stop polling when proof state reaches `PASS`, `FAIL`, `MANUAL_REVIEW`, or `OVERRIDDEN`
+
+## Loading, empty, error, and retry-safe states
+
+| Surface | State | Required behavior |
+| --- | --- | --- |
+| Manager publish | submitting | Lock primary CTA, preserve draft, and show that duplicate publish is prevented locally only for the current session |
+| Manager shortlist | loading | Render task header plus shortlist skeleton; never fake ranked rows |
+| Manager shortlist | empty | Distinguish `no eligible candidates yet` from `matching still running` |
+| Manager shortlist | partial | Keep returned rows visible and badge missing score/proof fields |
+| Manager award-readiness | blocked | Render backend `statusMessage` plus dependency note when runtime award action is not yet wired |
+| Agent commit | duplicate replay | Reuse accepted commit result and move focus to reveal |
+| Agent reveal | hash mismatch | Explain immutable-payload requirement and return the user to reveal preparation |
+| Agent verification | queued/verifying | Poll using backend refresh metadata and keep manual refresh available |
+| Agent verification | terminal fail | Show returned reason codes and preserve trace/audit references when present |
+| Agent verification | missing projection | Explain that runtime status projection is not yet available for this proof instead of inventing state |
+
+## Local runtime runbook
+
+This runbook is the minimum reproducible handoff for issue #136. It assumes the runtime implementation issues [#115](https://github.com/jckhang/agent-indeed/issues/115) and [#110](https://github.com/jckhang/agent-indeed/issues/110) have produced a locally runnable service.
+
+### 1. Start the runtime
+
+- start the local control-plane service using the command/run instructions published by the runtime implementation PR
+- confirm the service exposes the merged `main` API surface from `src/api/openapi.yaml`
+- capture the base URL, manager auth header, agent auth header, and verifier/operator credential used for local smoke runs
+
+### 2. Exercise the manager path
+
+1. Publish a task with `POST /v1/tasks`
+   - record `taskId`, `status`, `commitDeadline`, and `revealDeadline`
+2. Open the manager review route for the created `taskId`
+   - confirm shortlist loading state is visible before data returns
+3. Read `GET /v1/tasks/{taskId}/candidates`
+   - confirm ranked rows or a retryable `not ready` state render without falling back to fixture-only content
+4. Read `GET /v1/tasks/{taskId}/award`
+   - confirm award-readiness copy uses backend `status` and `statusMessage`
+
+### 3. Exercise the agent path
+
+1. Commit a bid with `POST /v1/tasks/{taskId}/bids/commit`
+   - record `bidId`, `window.currentPhase`, and `window.nextAction`
+2. Reveal with `POST /v1/tasks/{taskId}/bids/reveal`
+   - record `proofSubmission.proofId` and initial verification status
+3. Refresh `GET /v1/tasks/{taskId}/bids/{bidId}`
+   - confirm bid, proof, and award state projections render without browser-only inference
+4. Refresh `GET /v1/tasks/{taskId}/proofs/{proofId}` until terminal
+   - confirm polling cadence follows `refresh.pollAfterSeconds`
+   - confirm terminal state and reason codes match the backend response
+
+### 4. Capture evidence
+
+Record the following in issue [#136](https://github.com/jckhang/agent-indeed/issues/136) and the linked PR:
+- runtime base commit or image/version under test
+- task id, bid id, and proof id used in the smoke path
+- whether manager shortlist and award-readiness reads returned runtime data
+- whether agent bid/proof status reads returned queued/verifying/terminal states correctly
+- any blockers from #110, #115, or #111 that prevented full execution
+
+## Acceptance criteria mapping
+
+| Acceptance criterion | How this tranche covers it |
+| --- | --- |
+| At least one manager flow and one agent flow execute against local runtime APIs end-to-end. | The runbook defines one concrete manager path and one concrete agent path against merged runtime endpoints on `main`. |
+| UI state transitions reflect runtime statuses and error reasons instead of placeholder-only states. | Loading/error/empty/retry-safe requirements and route-specific runtime expectations are tied to read/write response fields already present in `src/api/openapi.yaml` and `src/api/contracts.ts`. |
+| A reproducible local runbook and evidence links are posted back to this issue. | The local runtime runbook specifies the minimum evidence to post back to issue #136 and the linked PR. |
+| Progress references implementation threads #110 and #115. | Both dependencies are named in the objective, execution dependency list, and runbook. |

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -59,7 +59,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - `ProofPack` accepted and verified with T0/T1/T2 policy mapping.
 - Commit/reveal/verify/award transitions must persist and be queryable in runtime flow checks (issue #110).
 - Runtime implementers should treat `docs/RUNTIME_CUTLINE_2026-03-16.md` as the current go/no-go rule for open contract PR dependencies while the contract stack finishes converging.
-- Agent bidding console baseline is captured in `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, with focused follow-through in `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md` and `docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md`, so commit/reveal and verification acceptance criteria stay reviewable while bid/proof status reads remain backend follow-ups through issue #59.
+- Agent bidding console baseline is captured in `docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, with focused follow-through in `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, `docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md`, and `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md`, so commit/reveal and verification acceptance criteria stay tied to the merged bid/proof read contracts and the runtime integration tranche in issue #136.
 - Agent-facing verification status uses explicit queued/verifying/terminal terminology and does not invent backend fields that are not yet contractually available.
 
 ### G4. Audit and observability baseline

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,10 +52,11 @@ Scope:
 - Manager shortlist review slice (`docs/MANAGER_SHORTLIST_REVIEW_AWARD_READINESS_UI_SLICE.md`, issue #62) keeps shortlist fallback states and award blockers reviewable while shortlist/award contracts remain in flight.
 - Commit-reveal bidding workflow.
 - Agent bidding console baseline (`docs/AGENT_BIDDING_CONSOLE_BASELINE.md`, issue #44 / PR #56) keeps the broader commit/reveal + verification journey visible.
-- Dedicated bid workspace slice (`docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, issue #63 / PR #76) narrows the next frontend delivery item to one commit/reveal workflow while leaving async refresh on the backend follow-up track (#59).
+- Dedicated bid workspace slice (`docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, issue #63 / PR #76) narrows the frontend delivery item to one commit/reveal workflow while handing runtime status refresh to the merged bid/proof read routes.
+- Frontend runtime integration tranche (`docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md`, issue #136) defines the first manager + agent runtime-backed smoke path and the local evidence runbook tied to #110 and #115.
 - Audit visibility console baseline (`docs/AUDIT_VISIBILITY_CONSOLE_BASELINE.md`, issue #47) keeps task/bid timeline review, failure translation, and missing-field alert requirements visible while audit query and award-read contracts are still pending.
 - PoMW verification baseline with identity-tier policy.
-- Agent verification timeline/read-refresh baseline tied to the bid/proof status-read contract.
+- Agent verification timeline/read-refresh baseline tied to the merged bid/proof status reads and the runtime persistence work behind issue #136.
 - Auditable award events and minimal reputation writeback hook.
 - Lifecycle observability baseline for `upload -> match -> bid -> verify -> award`.
 - Operator audit timeline baseline (`docs/OPERATOR_AUDIT_TIMELINE_BASELINE.md`, issue #65 / PR #67) defines the first focused operator read surface and keeps audit-event completeness gaps visible before backend event reads are finalized.

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -77,6 +77,7 @@ review history, and linked PRs, open the GitHub issue directly.
 - P1-37 Bootstrap runnable control-plane backend skeleton: [#109](https://github.com/jckhang/agent-indeed/issues/109)
 - P1-38 Implement runnable MVP dispatch vertical slice: [#110](https://github.com/jckhang/agent-indeed/issues/110)
 - P1-39 Execute runtime smoke/E2E checks from QA matrices: [#111](https://github.com/jckhang/agent-indeed/issues/111)
+- P1-40 Frontend runtime integration tranche: [#136](https://github.com/jckhang/agent-indeed/issues/136)
 
 ## Working rule
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -40,3 +40,4 @@
 - [ ] 5.1 落地可运行 control-plane service skeleton（issue #109），包含健康检查、基础配置与最小持久化抽象。
 - [ ] 5.2 打通可执行的 MVP 垂直路径（issue #110）：`publish -> match -> commit -> reveal -> verify -> award`，并持久化关键状态转移。
 - [ ] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
+- [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #136
- Department label (pick one): `dept/frontend`
- Type label (pick one): `type/docs`
- Scope: Sync the frontend runtime integration tranche docs/OpenSpec tasks with the contracts that are already merged on `main`

## What Changed

- Added `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md` to define the manager + agent runtime-backed tranche for issue #136.
- Updated the frontend surface, bid/reveal workspace, and verification timeline docs to treat bid/proof status reads as merged-on-main contracts instead of pending PR #66 follow-ups.
- Synced planning artifacts in `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, `docs/issues/PHASE1_ISSUES.md`, and `openspec/changes/agent-dispatch-platform/tasks.md`.
- Added a reproducible local runtime runbook and explicit blockers for runtime persistence/handlers in #110 and #115.

## Why

- Frontend planning was stale after the bid/proof and shortlist/award read contracts merged on `main`.
- Issue #136 needs a current source of truth for what the UI can wire now versus what is still blocked on runtime execution work.
- The repo does not yet contain app code, so this tranche has to land as docs/spec guidance that unblocks the next implementation PRs.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| A reproducible local runbook and evidence links are posted back to this issue. | Adds a dedicated runtime integration tranche doc with manager publish/shortlist/award and agent commit/reveal/status refresh runbooks. | `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md` |
| Progress references implementation threads #110 and #115. | Calls out the runtime persistence/handler dependencies throughout the tranche, roadmap, and MVP surface docs. | `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md`, `docs/FRONTEND_MVP_SURFACE.md`, `docs/ROADMAP.md` |
| UI state transitions reflect runtime statuses and error reasons instead of placeholder-only states. | Updates the MVP surface and verification/bid baselines to rely on the merged bid/proof status projections and explicit retry/error behavior. | `docs/FRONTEND_MVP_SURFACE.md`, `docs/AGENT_BID_COMMIT_REVEAL_WORKSPACE.md`, `docs/AGENT_VERIFICATION_TIMELINE_BASELINE.md` |
| At least one manager flow and one agent flow execute against local runtime APIs end-to-end. | Defines the exact runtime-backed flows and environment blockers that the next implementation slice must satisfy; no app/runtime code exists in this repo yet, so this PR documents rather than claims completed execution. | `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md`, issue #136 blockers |

## QA Plan

### Preconditions

- Repo is on `codex/p1-136-frontend-runtime-integration` from current `origin/main`.
- OpenSpec CLI is available in the shell.

### Steps

1. Run `openspec validate --all`.
2. Run `git diff --check`.
3. Run `bash scripts/agent_prepush_check.sh --github-user lanzhou-fe-agent`.
4. Review the tranche doc and linked planning docs for references to merged-on-main bid/proof and shortlist/award reads.

### Expected Results

- OpenSpec validation passes.
- No diff whitespace errors are reported.
- Pre-push guard confirms branch prefix, baseline sync, and isolated Lanzhou identity.
- The touched docs consistently describe runtime blockers as implementation follow-ups in #110/#115 rather than missing API contracts.

### Validation Output

Reran on 2026-03-17 against the current PR head; literal command output is included below.

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

```text
$ git diff --check
(no output)
```

```text
$ bash scripts/agent_prepush_check.sh --github-user lanzhou-fe-agent
[ok] Branch 'codex/p1-136-frontend-runtime-integration' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (lanzhou-fe-agent).
[ok] git user.email matches expected account (lanzhou-fe-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - The docs could overstate runtime readiness if future API changes diverge from `main`.
  - Reviewers may expect executable UI code from issue #136 even though the repo currently only exposes docs/API artifacts.
- Rollback:
  - Revert this single docs commit if the tranche framing or dependency callouts need to be redone.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`


