### PR TITLE
docs: tighten merge-train blocker playbook

### DIFF
--- a/docs/MERGE_TRAIN_PLAYBOOK.md
+++ b/docs/MERGE_TRAIN_PLAYBOOK.md
@@ -12,11 +12,13 @@ Use this playbook when albatross is coordinating the active PR queue. It keeps l
 
 - Clean LGTM queue: [open clean LGTM PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3ALGTM)
 - Dirty queue: [open dirty PR candidates](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+-label%3ALGTM)
+- Dirty-but-approved queue: [LGTM PRs that still need rebase or merge handling](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3ALGTM+label%3A%22status%2Fin-review%22)
 - Runtime review queue: [open runtime PRs in review](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+label%3A%22status%2Fin-review%22)
 - Runtime label audit: [open ready-next runtime issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+label%3A%22status%2Fready-next%22)
 - Runtime issue milestone audit: [runtime issues missing milestones](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+no%3Amilestone)
 - Runtime PR milestone audit: [runtime PRs missing milestones](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+no%3Amilestone)
 - Runtime PR priority audit: [runtime PRs missing priority](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+-label%3A%22priority%2FP0%22+-label%3A%22priority%2FP1%22)
+- Validation-evidence gaps: [runtime PRs that still need pasted command output](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+label%3A%22status%2Fin-review%22)
 - Planning lane: [owner:albatross issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aalbatross%22)
 - Review-requested planning PRs: [owner:albatross PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22owner%3Aalbatross%22)
 
@@ -28,14 +30,26 @@ Use this playbook when albatross is coordinating the active PR queue. It keeps l
    - `git pull --ff-only origin main`
 2. Inspect open PRs and separate them into:
    - clean tranche: `LGTM` + mergeable/clean
-   - dirty follow-ons: conflict/rebase needed or blocked by review comments
+   - dirty follow-ons: conflict/rebase needed, blocked by review comments, or missing literal validation evidence
 3. Merge the clean tranche in dependency-aware order, re-pulling `main` after each merge if the next PR depends on the newly merged contract/docs baseline.
 4. Before calling the queue clean, run the milestone/priority audit links and fix any missing `owner:*`, `priority/*`, `status/*`, `stream/*`, or milestone metadata on open runtime threads.
 5. For every dirty follow-on PR, leave a signed thread note that states:
    - the owner label already carrying the follow-up
    - why the PR is blocked or dirty
    - the exact next step (`rebase origin/main`, rerun validation, or address the named review comment)
+   - whether a new blocker issue should be opened instead of growing the PR thread further
 6. Only update repo docs when the planning structure changes. Do not copy day-to-day issue/PR state into `docs/issues/PHASE1_ISSUES.md` or `docs/PHASE1_CHECKPOINT_BOARD.md`.
+
+## Dirty follow-on note rubric
+
+When stamping a blocker note on a dirty PR, keep it short but complete:
+
+1. Start with the main-branch event that changed the queue (`main moved after PR #... merged`, `validation evidence still missing`, or `review scope drift remains`).
+2. Name the existing owner label instead of reassigning ownership in free text.
+3. List the exact command or review action required next, including validation commands when re-review should not happen yet.
+4. If the blocker is a new durable scope rather than a one-PR fix, open or point to a follow-up issue and say the PR should stay focused.
+
+Use this rubric for frontend, backend, QA, and planning lanes so reviewers can skim the queue without reconstructing context from prior comments.
 
 ## Validation gates
 
@@ -52,6 +66,16 @@ Before asking for merge or re-review on any active PR:
 - when a reviewer asks for evidence, treat that as a blocking queue item until the literal output is posted
 
 When a PR rebase rewrites history, push with `git push --force-with-lease`.
+
+## New blocker issue rule
+
+Do not hide newly discovered scope in queue comments alone. Open a follow-up issue when:
+
+- the blocker will likely survive more than one rebase cycle
+- the fix would widen the PR beyond its current focused acceptance criteria
+- another owner lane must pick up the next action
+
+Keep the PR comment focused on the immediate next step and link the follow-up issue if one is created.
 
 ## Signed comment template
 

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -36,6 +36,7 @@ Sprint pivot dated 2026-03-16 keeps these issue anchors as the default execution
 3. Run the metadata hygiene queries and clear any missing milestone or priority gaps before posting the checkpoint.
 4. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
 5. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
+6. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
 
 ## When to edit this file
 
@@ -55,3 +56,5 @@ When posting the weekly checkpoint comment on epic #2, keep it in GitHub and use
 - `Blocked`: active issue/PR plus the concrete blocker and current owner
 - `Ready next`: the next executable slice queued for each lane
 - `Validation evidence gaps`: any PR that still needs pasted command output before review can close
+
+When a checkpoint calls out a blocker, prefer a GitHub issue or PR link plus the owner label already on that thread rather than copying queue snapshots into this document.

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -75,9 +75,11 @@
 
 10. 建立 merge-train 协作例行
    - 规划负责人使用统一查询区分 clean LGTM PR 与 dirty follow-on queue，而不是把瞬时状态复制到仓库文档。
-   - runtime 冲刺期间额外维护 review queue 与 label audit 查询，优先发现缺少 status label 或缺少 validation evidence 的活跃线程。
+   - runtime 冲刺期间额外维护 review queue、dirty-but-approved queue 与 label audit 查询，优先发现缺少 status label、缺少 validation evidence，或已经 LGTM 但尚未 rebase 的活跃线程。
    - clean tranche 合并后，必须在脏 PR 线程写回 owner、blocker、rebase-next-step，并要求重新执行验证命令。
+   - merge-train blocker note 必须同时说明：main 上发生了什么变化、当前 owner label、下一步命令/评审动作，以及是否需要新开 follow-up issue 保持 PR 聚焦。
    - 任何请求 re-review 的 PR 都必须附带 literal validation output；未贴出输出时，规划侧将其视为阻塞项而不是“默认已跑”。
+   - 当新 blocker 会跨越多个 rebase 周期、需要跨 lane 接力，或会让现有 PR 超出原始验收范围时，必须升级为 follow-up issue，而不是只留在 PR 评论里。
    - 例行流程写入 `docs/MERGE_TRAIN_PLAYBOOK.md` 并在 `CONTRIBUTING.md` 链接，减少多 agent 并行时的重复沟通和冲突。
 
 11. Phase 1 当前冲刺采用 runtime-first 交付

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -15,7 +15,7 @@
   - agent 上传与生产资料同步能力
   - 任务市场匹配、竞标与 PoMW 验证能力
 - 补充 MVP 生命周期可观测性基线，覆盖事件、trace、日志、指标、告警与保留期约束。
-- 补充 merge-train 协作手册，统一 clean LGTM PR 合并、dirty queue 回写、validation evidence 回贴与每周 checkpoint 评论模板。
+- 补充 merge-train 协作手册，统一 clean LGTM PR 合并、dirty queue 回写、validation evidence 回贴、durable blocker issue 升级规则与每周 checkpoint 评论模板。
 - 明确身份分层（T0/T1/T2）下的 PoMW 强度策略。
 - 定义从任务发布到中标执行的关键状态流转与审计要求。
 - 新增 runtime 落地冲刺任务（issue #109/#110/#111），要求将核心流程转为可运行服务与可执行 QA 校验。
@@ -34,6 +34,6 @@
 - 新增 OpenSpec 规范文件，作为后续服务拆分与 API 设计依据。
 - 新增 `docs/OBSERVABILITY_BASELINE.md`，作为后续后端埋点、运维告警与审计可视化的统一契约。
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
-- 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue 与 dirty queue follow-up 的操作基线。
+- 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #143
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/chore`
- Scope: tighten the merge-train blocker-note playbook and checkpoint guidance for dirty follow-on PRs

## What Changed

- expanded [`docs/MERGE_TRAIN_PLAYBOOK.md`](/private/tmp/albatross-143-merge-train/docs/MERGE_TRAIN_PLAYBOOK.md) with dirty-but-approved and validation-evidence queries
- added a blocker-note rubric plus a follow-up issue escalation rule so queue comments stay short but actionable
- updated [`docs/PHASE1_CHECKPOINT_BOARD.md`](/private/tmp/albatross-143-merge-train/docs/PHASE1_CHECKPOINT_BOARD.md) to keep new durable blockers in GitHub issues instead of repo snapshots
- synced the merge-train expectations back into [`openspec/changes/agent-dispatch-platform/proposal.md`](/private/tmp/albatross-143-merge-train/openspec/changes/agent-dispatch-platform/proposal.md) and [`openspec/changes/agent-dispatch-platform/design.md`](/private/tmp/albatross-143-merge-train/openspec/changes/agent-dispatch-platform/design.md)

## Why

- issue #143 asks for a cleaner merge-train routine that keeps blocker ownership explicit without reintroducing stale queue snapshots into repo docs
- the existing playbook covered clean vs dirty PRs, but it did not spell out how to handle dirty-yet-approved branches, missing validation evidence, or when a blocker should become a follow-up issue

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| leave signed blocker/rebase comments on each dirty runtime PR with the concrete next action and owner | the playbook now defines the blocker-note rubric and follow-up issue rule used for the signed comments posted on PRs #122, #125, #127, #129, #132, and #133 | [`docs/MERGE_TRAIN_PLAYBOOK.md`](/private/tmp/albatross-143-merge-train/docs/MERGE_TRAIN_PLAYBOOK.md), PR comments on #122/#125/#127/#129/#132/#133 |
| confirm checkpoint guidance reflects the post-merge queue without adding volatile repo snapshots | the checkpoint guide now tells maintainers to keep durable blockers in linked GitHub threads instead of copying queue state into repo docs | [`docs/PHASE1_CHECKPOINT_BOARD.md`](/private/tmp/albatross-143-merge-train/docs/PHASE1_CHECKPOINT_BOARD.md) |
| keep OpenSpec-first planning artifacts aligned with the process change | the proposal/design text now describes the same blocker-note and blocker-issue escalation behavior as the docs | [`openspec/changes/agent-dispatch-platform/proposal.md`](/private/tmp/albatross-143-merge-train/openspec/changes/agent-dispatch-platform/proposal.md), [`openspec/changes/agent-dispatch-platform/design.md`](/private/tmp/albatross-143-merge-train/openspec/changes/agent-dispatch-platform/design.md) |

## QA Plan

### Preconditions

- use an updated `main` baseline with the current runtime merge train already fetched
- run from the branch `codex/p1-143-merge-train-playbook`

### Steps

1. Review the merge-train query section in [`docs/MERGE_TRAIN_PLAYBOOK.md`](/private/tmp/albatross-143-merge-train/docs/MERGE_TRAIN_PLAYBOOK.md).
2. Confirm the dirty follow-on note rubric and new blocker issue rule cover the same signed blocker-note pattern used in the PR queue.
3. Run the documented validation commands.

### Expected Results

- the playbook distinguishes clean, dirty, dirty-but-approved, and validation-evidence-gap queue states
- the checkpoint guide keeps durable blockers in GitHub threads instead of repo snapshots
- OpenSpec validation and guard checks pass on the branch

### Validation Output

- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/p1-143-merge-train-playbook' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - maintainers could still overuse the broader query links and treat them as live snapshots instead of a triage starting point
- Rollback:
  - revert commit `1eb0cb9b4fd60a22bc08a5633b49ccdcd8061377` if the playbook wording proves too prescriptive

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
