### PR TITLE
docs: add Phase 1 epic checkpoint template

### DIFF
--- a/docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md
+++ b/docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md
@@ -1,0 +1,64 @@
+# Phase 1 Epic Checkpoint Template
+
+Use this template when posting the weekly checkpoint comment on epic
+[#2](https://github.com/jckhang/agent-indeed/issues/2). Keep the live status in
+GitHub issues and PRs; use this document only to make the checkpoint comment
+consistent, owner-specific, and reviewable.
+
+## Before posting
+
+- Open the milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
+- Run the metadata hygiene queries from `docs/PHASE1_CHECKPOINT_BOARD.md`.
+- Pull the current runtime blocker snapshot from the dated control doc when one
+  exists.
+- Verify every blocker references a live issue or PR and the owner label already
+  on that thread.
+
+## Comment template
+
+```md
+## Phase 1 checkpoint (YYYY-MM-DD)
+
+### Done
+- Merged [PR #](https://github.com/jckhang/agent-indeed/pull/) because it changed the runnable baseline by ...
+- Closed [issue #](https://github.com/jckhang/agent-indeed/issues/) after ...
+
+### Blocked
+- [issue/PR #](https://github.com/jckhang/agent-indeed/) - concrete blocker; current owner: `owner:*`; next unblock condition.
+- [issue/PR #](https://github.com/jckhang/agent-indeed/) - concrete blocker; current owner: `owner:*`; next unblock condition.
+
+### Ready next
+- Frontend: [issue/PR #](https://github.com/jckhang/agent-indeed/) - next executable slice.
+- Backend: [issue/PR #](https://github.com/jckhang/agent-indeed/) - next executable slice.
+- QA: [issue/PR #](https://github.com/jckhang/agent-indeed/) - next executable slice.
+- Planning: [issue/PR #](https://github.com/jckhang/agent-indeed/) - next executable slice.
+
+### Validation evidence gaps
+- [PR #](https://github.com/jckhang/agent-indeed/pull/) - missing literal output for `openspec validate --all` / diff check / pre-push guard.
+- [PR #](https://github.com/jckhang/agent-indeed/pull/) - missing smoke/test evidence in the PR body.
+
+### Owner handoff for next week
+| Lane | Owner | Must preserve | First next action |
+| --- | --- | --- | --- |
+| Frontend | `owner:lanzhou-fe-agent` | merged runtime/API baseline | ... |
+| Backend | `owner:kestrel-dev-agent` | one documented local command path | ... |
+| QA | `owner:avery` | executable happy/negative checks | ... |
+| Planning | `owner:albatross` | milestone + blocker ledger alignment | ... |
+```
+
+## Writing rules
+
+- Lead with merged or closed changes in `Done`; do not list work that is still in review.
+- Every `Blocked` bullet must name one blocker, one owner, and one concrete next unblock condition.
+- `Ready next` should describe executable slices only; defer design-only follow-ups unless they unblock the runtime path this week.
+- `Validation evidence gaps` should call out the exact missing command output so reviewers know what to ask for next.
+- The owner handoff table should stay short enough to scan in GitHub without expanding code blocks.
+
+## Minimum evidence checklist
+
+Before posting, confirm the comment names:
+
+- merged runtime slices that changed the baseline this week
+- the current blocker for each active lane
+- one next executable action for frontend, backend, QA, and planning
+- any open PR still missing pasted validation output

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -94,6 +94,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - One local command path can run service + smoke checks for happy path and core negatives.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
+- Weekly epic #2 checkpoints use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so owner handoffs and validation-evidence gaps stay consistent across review weeks.
 - P0 baseline issues that block collaboration quality are closed or explicitly waived.
 - FE/BE execution ownership and MVP hiring-critical roles are assigned or explicitly risk-accepted.
 - Closed-beta auth, auditability, and sensitive-data guardrails are documented or explicitly risk-accepted.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -114,6 +114,7 @@ Scope:
 
 Checkpoint status board:
 - Review `docs/PHASE1_CHECKPOINT_BOARD.md` for milestone links, target owners, and checkpoint review prompts.
+- Use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` when posting the weekly epic #2 checkpoint so the comment keeps the same Done/Blocked/Ready next/Validation evidence gaps shape plus owner handoff table.
 
 ## Phase 1 KPIs
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: add a durable Phase 1 epic checkpoint comment template and wire it into the planning docs

## What Changed

- added `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` with a ready-to-post GitHub comment shape for epic #2
- linked the new template from `docs/ROADMAP.md` so the roadmap points checkpoint owners at the durable comment structure
- extended `docs/PHASE1_GOALS.md` so weekly epic checkpoints explicitly preserve owner handoffs plus validation-evidence gaps

## Why

- issue #2 needs a stable weekly checkpoint shape that stays owner-specific and reproducible without copying volatile queue state into long-lived docs
- the repo already defines checkpoint buckets, but it did not give albatross a concrete comment template with owner handoffs and evidence-gap prompts
- this keeps the 2026-03-20 epic checkpoint easier to post consistently while staying aligned with the planning docs

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Epic #2 checkpoint has a dated structure with owner-by-owner next actions | Adds a durable checkpoint template with Done / Blocked / Ready next / Validation evidence gaps plus an owner handoff table | `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` |
| Planning docs point checkpoint owners at the same review shape | Links the template from the roadmap and Definition of Done notes | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md` |

## QA Plan

### Preconditions

- Repo is on `codex/issue-2-epic-checkpoint-template`

### Steps

1. Open `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md`.
2. Confirm the template includes the four required checkpoint buckets plus an owner handoff table.
3. Open `docs/ROADMAP.md` and `docs/PHASE1_GOALS.md` and verify both documents reference the checkpoint template.

### Expected Results

- The template is ready to paste into epic #2 as a weekly checkpoint comment.
- Roadmap and Phase 1 goals docs both point reviewers to the same checkpoint shape.

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-epic-checkpoint-template' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - Checkpoint owners may treat the template as a live status board instead of a comment scaffold.
- Rollback:
  - Revert this PR to remove the template and its roadmap/goals references if the workflow needs a different checkpoint shape.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
