### PR TITLE
docs: refresh phase 1 epic runtime rollup

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -15,11 +15,11 @@ reviewable release gates for closed-beta readiness. It complements:
 
 | Gate | Status | Ready when | Active dependencies | Evidence to collect |
 | --- | --- | --- | --- | --- |
-| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #120, PR #159, PR #133, PR #152, PR #153, PR #154, PR #161, PR #164, PR #165, PR #166, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
-| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | issue #115, merged PR #129, merged PR #127 baseline, issue #111, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
-| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #120, issue #111, issue #11, merged PR #127 baseline, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
-| Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | merged PR #127, merged PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | issue #137, PR #140, PR #141, issue #115, PR #129, issue #120, issue #111, issue #11 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`, milestone/label queries stay aligned |
+| Contract convergence | In progress | Remaining runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | open PR #133, open PR #153, merged PRs #83, #92, #126, #127, #129, #139, #140, #141, #149, and #152 | `openspec validate --all`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
+| Runtime happy-path execution | In progress | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow is executable from the merged local runtime path and backed by current smoke evidence. | merged PRs #127, #129, and #149, issue #120, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
+| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #120, issue #11, merged PR #149, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
+| Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | merged PRs #127, #129, #92, and #149, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
+| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | open PR #133, open PR #153, issue #120, issue #11, merged PRs #149 and #152 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`, milestone/label queries stay aligned |
 
 ## Gate Details
 
@@ -28,9 +28,9 @@ reviewable release gates for closed-beta readiness. It complements:
 This remains the prerequisite for durable runtime behavior and executable QA checks.
 
 - Verifier terminal vocabulary and award-trace expectations now come from merged PR #83 and merged PR #92.
-- The merged runtime/frontend baseline is on `main` through PR #126 and PR #139; PR #127 merged on 2026-03-17 at 13:54:46Z and PRs #129, #140, and #141 all merged later that day, so the active convergence risk is now keeping the live review queue (`#159`, `#133`, `#152`, `#153`, `#154`, `#161`, `#164`, `#165`, `#166`) synced to the published contract vocabulary.
-- The dated QA sweep in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` now records which runtime routes are actually published on `main`, so reviewers can distinguish proof-enum drift from still-pending read-model routes.
-- Merged PR #140 is the planning guardrail for the dated blocker ledger; the current doc queue should reuse that merged baseline instead of reopening stale snapshots across long-lived docs.
+- The merged runtime/frontend baseline is on `main` through PRs #126, #127, #129, #139, #140, and #141, so the active convergence risk is now keeping the remaining review queue (`#133`, `#153`) plus the merged consumer-baseline follow-through from PR #152 synced to the published contract vocabulary while the merged smoke suite from PR #149 becomes the QA baseline.
+- PR #152 merged on 2026-03-18T15:04:46Z, so the active queue is now PR #133 plus merge-conflicting PR #153 rather than the older three-PR follow-through stack.
+- PR #153 is the planning follow-through thread for turning the one-off runtime unblocker sweep into a repeatable weekly audit routine.
 
 Release note: if any active runtime branch changes enum names, required fields, route shapes, or error-code wording, the same update must land in OpenSpec plus both API drafts before the gate can be marked ready.
 
@@ -38,13 +38,13 @@ Release note: if any active runtime branch changes enum names, required fields, 
 
 Happy-path readiness is runtime-first, not docs-first.
 
-While this gate remains blocked until the runnable flow exists, the runtime threads do not have to wait for every historical contract branch. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` to separate true blockers from additive-safe follow-ups.
+The core runnable flow is now merged, but this gate does not turn green until the smoke path is executable from current `main` without manual interpretation. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` to separate true blockers from additive-safe follow-ups.
 
 Required outcome:
 
 - a local service starts from one documented command
 - one reproducible request sequence executes `publish -> match -> commit -> reveal -> verify -> award`
-- results are captured by executable smoke/E2E checks tied to issue #111 and linked back to issue #11
+- results are captured by executable smoke/E2E checks tied to issue #120 and linked back to issue #11
 
 Reference docs and planning notes are only useful if they map directly to runnable assertions and a stable local command path.
 
@@ -59,7 +59,7 @@ Minimum scenarios to keep visible:
 - proof verification returns `FAIL`
 - award attempt blocked before prerequisite verification is complete
 
-Expected output for each scenario must cite a stable error code or terminal status/result from the merged contract vocabulary. Use `npm run check:contract-drift` when a PR claims a route or proof-verification enum is already on `main`.
+Expected output for each scenario must cite a stable error code or terminal status/result from the merged contract vocabulary.
 
 ### 4. Audit evidence trail
 
@@ -85,7 +85,7 @@ At minimum, these must stay in lockstep:
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
 - `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`
-- runtime delivery threads (`#115`, `#159`, `#164`, `#165`, `#166`, `#161`, `#154`, `#153`, `#152`, `#133`, `#120`, `#111`, and blocked follow-through `#11`)
+- runtime delivery threads (`#133`, `#153`, `#120`, blocked follow-through `#11`, plus merged baselines PRs #149 and #152)
 
 ## Review Routine
 

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -7,9 +7,9 @@ This document keeps only the stable checkpoint structure and links to the live m
 
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
-| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Contract convergence kickoff + runnable service bootstrap gate (#109, PR #90). |
-| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Runnable publish/match/commit/reveal path plus merged proof/award reads and the collapsed frontend runtime handoff (#110, #136, #145). |
-| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Verify/audit runtime durability plus executable QA conversion (#111, PR #83, PR #92). |
+| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Keep the merged runtime/bootstrap/consumer baseline stable and close the still-open planning review queue (`#133`, `#153`). |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Keep the merged publish/match/commit/reveal baseline honest and turn the landed executable dispatch smoke suite (`#149`) into current QA evidence. |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Verify/audit runtime durability plus executable QA evidence on `main` (`#120`, `#11`, PR #149). |
 | M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
 
 ## Metadata hygiene queries
@@ -28,7 +28,7 @@ Sprint pivot dated 2026-03-16 keeps these issue anchors as the default execution
 - `#110`: runnable dispatch vertical slice
 - `#111`: executable smoke/E2E conversion
 - `#11`: blocked final E2E sign-off thread
-- `#137`: architecture unblocker control for the 2026-03-20 runtime push (`docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`)
+- `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`: dated blocker ledger for the 2026-03-20 runtime push
 
 ## Review routine
 
@@ -36,10 +36,9 @@ Sprint pivot dated 2026-03-16 keeps these issue anchors as the default execution
 2. Use labels such as `status/ready-next`, `status/in-review`, and owner labels to decide next merge or rebase action.
 3. Run the metadata hygiene queries and clear any missing milestone or priority gaps before posting the checkpoint.
 4. Use `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` for the dated owner/blocker ledger instead of copying that volatile table into this guide.
-5. Run the merge-evidence sweep from issue #146 before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a same-day GitHub trail.
-6. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
-7. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
-8. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
+5. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
+6. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
+7. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
 
 ## When to edit this file
 
@@ -53,7 +52,7 @@ Do not edit this file just to reflect day-to-day issue or PR movement.
 
 ## Epic checkpoint comment shape
 
-When posting the weekly checkpoint comment on epic #2, keep it in GitHub, start from the same-day issue #146 sweep, and use four buckets:
+When posting the weekly checkpoint comment on epic #2, keep it in GitHub and use four buckets:
 
 - `Done`: merged items that changed the runtime baseline this week
 - `Blocked`: active issue/PR plus the concrete blocker and current owner
@@ -61,5 +60,3 @@ When posting the weekly checkpoint comment on epic #2, keep it in GitHub, start 
 - `Validation evidence gaps`: any PR that still needs pasted command output before review can close
 
 When a checkpoint calls out a blocker, prefer a GitHub issue or PR link plus the owner label already on that thread rather than copying queue snapshots into this document.
-
-Issue #146 should keep the shorter sweep ledger (`clean tranche`, `dirty follow-ons`, `validation evidence gaps`), while epic #2 keeps the broader checkpoint rollup for cross-lane handoff.

--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -14,10 +14,10 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
-| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, issue #120, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PRs #159, #133, #152, #153, #154, #161, #164, #165, and #166 | Merge the QA guard and keep the live runtime/doc queue aligned to merged `main` contracts with review comments anchored to the dated sweep or source files. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, issues #11, #111, #115, merged PR #127, and merged PR #129 | Finish the remaining runnable QA evidence follow-through and let issue #111 execute the smoke/E2E path against the stable local runtime before unblocking issue #11. |
-| Core negative scenarios are covered | Blocked | issues #11 and #111, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, and merged PR #127 baseline | Turn the documented failure cases into executable assertions tied to the vertical-slice runtime and capture evidence back on issue #11. |
-| Audit events cover key state transitions | In progress | merged PR #127, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md` | Keep the award/proof/audit surfaces contract-aligned while the open runtime follow-through proves the emitted trail and QA consumes it in issue #111. |
+| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, merged PRs #140 and #141, open PR #133, and open PR #153 | Keep the remaining planning/doc threads (`#133`, `#153`) aligned to the merged contract baseline on `main`, and treat merged PR #152 as the current consumer-baseline reference rather than an open queue item. |
+| End-to-end happy path can be demonstrated | In progress | `docs/PHASE1_GOALS.md`, issue #11, issue #120, merged PRs #127, #129, and #149 | Treat the local runtime bootstrap and runnable dispatch path as landed baseline work, then capture one reproducible smoke/E2E evidence run before unblocking issue #11. |
+| Core negative scenarios are covered | Blocked | issue #11, issue #120, merged PR #149, `docs/CLOSED_BETA_SECURITY_READINESS.md`, and `docs/ERROR_CODE_RETRY_POLICY.md` | Convert the documented failure cases into executable assertions against the merged runtime path and post the evidence back to the QA threads. |
+| Audit events cover key state transitions | In progress | merged PRs #92, #127, and #129, `docs/OBSERVABILITY_BASELINE.md`, and `docs/MVP_TELEMETRY_HANDOFF.md` | Prove the emitted audit trail through the merged executable smoke suite on `main` and keep award/proof terminology aligned while issue #120 closes the remaining evidence gap. |
 
 ## Delivery Slice Status
 
@@ -28,50 +28,46 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 - #55 candidate matching shortlist contract merged.
 - #72 closed-beta security readiness checklist merged.
 - Runnable control-plane baseline merged in PR #126; issue #109 is closed.
+- Runnable dispatch vertical slice merged in PR #127 on 2026-03-17 13:54:46Z; issue #110 is closed.
+- Runtime bootstrap smoke command merged in PR #129; issue #115 is closed.
 - Frontend runtime integration tranche merged in PR #139; issue #136 is closed.
-- Runtime planning control artifacts now exist for the current sprint cutline and blocker ledger (`docs/RUNTIME_CUTLINE_2026-03-16.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`).
+- Frontend runtime handoff queue collapsed in PR #147; issue #145 is closed.
+- Runtime planning control artifacts now exist on `main` through merged PR #140 plus the dated blocker ledger (`docs/RUNTIME_CUTLINE_2026-03-16.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`).
 
 ### Active implementation slices
 
 | Epic step | Active issue / PR | Why it still matters to epic #2 |
 | --- | --- | --- |
-| QA contract-drift sweep | issue #120 / PR #159 | Keeps review comments anchored to one executable OpenAPI/contracts baseline while the remaining runtime/doc queue is still in review. |
-| Verify/award contract adoption | issue #131 / PR #133 | Keeps verify/award checklist language aligned to the published reason-code, error-code, and read-route baseline on `main`. |
-| Frontend runtime consumer docs | issue #150 / PR #152 | Keeps manager/agent runtime guidance inside the merged runtime read/write surface so downstream QA replay docs do not drift. |
-| Weekly execution audit playbook | issue #137 / PR #153 | Keeps the planning lane pointed at the currently open runtime/doc queue and its owner/blocker state. |
-| Backend API example packet | issue #163 / PR #164 | Publishes smoke-backed request/response examples that must stay aligned with the same task/bid/proof route baseline enforced by the QA guard. |
-| Epic acceptance trace | issue #2 / PR #165 | Captures the current post-merge acceptance mapping so epic reviewers can follow the same runtime/doc queue without stale blocker references. |
-| Executable QA conversion | issue #120 / issue #111 / issue #11 | Turns smoke/E2E docs into runnable assertions for happy and negative paths once the backend runtime follow-through stabilizes. |
+| Verify/award contract adoption follow-through | open PR #133 | Keeps the verify/award checklist anchored to the published OpenAPI/TypeScript contracts so runtime and QA readers do not consume stale field or enum claims. |
+| Executable runtime smoke suite | merged PR #149 | Turns the merged bootstrap + dispatch baseline into a repeatable test harness that QA can now run from `main` without rebuilding the old doc-only matrix by hand. |
+| Runtime consumer verification | merged PR #152 | Keeps the frontend/QA handoff tied to the merged runtime routes and evidence vocabulary rather than the superseded runtime wiring branches. |
+| Weekly execution audit playbook | open PR #153 | Converts the one-off runtime unblocker control issue into a durable planning routine for weekly owner handoff and merge-train follow-through. |
+| QA contract-drift and E2E closeout | issue #120 / issue #11 | Carries the remaining happy-path, negative-path, and beta evidence burden now that issues #109, #110, #111, #115, #136, and #145 are closed. |
 
 ### Remaining blocked slices
 
-- Issue #11 remains blocked until merged PR #127 plus merged PR #129 are translated into final runnable QA evidence on issue #111.
-- PR #127 merged on 2026-03-17 at 13:54:46Z, so the remaining backend queue risk is concentrated in PR #129 rather than the vertical-slice branch.
-- The 2026-03-18 QA sweep now has a repo-local baseline in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, so review comments can point at one dated contract snapshot instead of restating route/enum availability from memory.
-- PRs #129, #140, and #141 merged on 2026-03-17, so the remaining runtime/doc queue risk is concentrated in open PRs #159, #153, #154, #161, #152, #133, #164, #165, and #166 staying aligned to the same merged baseline.
+- Issue #11 remains blocked until the merged runtime path is covered by executable smoke/E2E evidence rather than doc-only acceptance notes.
+- Issue #120 is the active QA sweep for contract drift and runtime evidence; it now sits on top of the merged smoke-suite baseline from PR #149 instead of waiting on another runtime implementation branch.
+- PR #152 is already merged, PR #133 remains in review, and PR #153 is merge-conflicting again, so the queue is smaller but still not approval-ready.
+- Until those review threads re-close, treat the planning/consumer queue as active review work rather than merge-only follow-through.
 
 ## Runtime Execution Queue (2026-03-18)
 
 | Thread | Current disposition | Why | Next owner / next action |
 | --- | --- | --- | --- |
-| PR #159 `[P1-120] Add QA contract drift guard` | In review | This is the canonical route/enum guard for the current queue; merging it first lowers repeat review churn across the remaining runtime/doc PRs. | `avery`: keep the dated sweep synced to the live queue and point reviewers at `npm run check:contract-drift`. |
-| PR #164 `[P1-163] Add backend API example packet from smoke flow` | In review | Smoke-backed examples are the next likely place for route/field drift if they describe unpublished task/bid/proof surfaces. | `kestrel`: keep example payloads inside the published OpenAPI/contracts baseline and cite the QA sweep where useful. |
-| PR #165 `docs: add Phase 1 acceptance trace` | In review | The acceptance trace should describe the current merged baseline and open runtime/doc queue instead of superseded blocker snapshots. | `albatross-dev-agent`: keep the trace synced to merged PRs #129/#140/#141 and the open review queue. |
-| PR #166 `docs: refresh epic checkpoint sweep guidance` | In review | The checkpoint sweep is another planning consumer of the same runtime/doc queue and should cite the dated QA sweep when route or enum availability is questioned. | `albatross-dev-agent`: keep the checkpoint notes aligned to the current review queue and merged baseline. |
-| PR #161 `[P1-158] Rebalance merge queue checkpoints` | In review | Merge queue notes should reflect the same live contract/runtime queue so sequencing decisions do not cite superseded blockers. | `albatross-dev-agent`: keep merge queue ordering aligned to the current runtime/doc review set. |
-| PR #154 `docs: refresh phase 1 epic runtime rollup` | In review | Older epic rollup refresh work is still open, so it needs the same merged-baseline cleanup as the newer planning follow-ups. | `albatross-dev-agent`: either converge this thread onto the current queue snapshot or close it as superseded. |
-| PR #153 `[P1-137] Add weekly execution audit playbook` | In review | The weekly audit playbook is now a planning consumer of the same runtime/doc queue and should not diverge from the dated QA sweep. | `albatross-dev-agent`: keep queue ordering and blocker language aligned to the live GitHub state. |
-| PR #152 `docs(frontend): verify runtime consumer baseline` | In review | Frontend runtime guidance must cite only the published task/bid/proof surfaces and verifier vocabulary already on `main`. | `lanzhou-fe-agent`: keep consumer claims anchored to published routes, fields, and enums. |
-| PR #133 `[P1-131] Add verify-award adoption checklist` | In review | Verify/award adoption notes still need to stay precise about which reason codes, error codes, and read surfaces are actually published. | `albatross-dev-agent`: keep the checklist language tied to the current OpenAPI/contracts baseline. |
-| Issue #120 / issue #111 | QA sweep in progress | QA now has a dated contract-drift guard plus a 2026-03-18 route/enum baseline, but issue #11 still waits on the final runtime smoke/E2E evidence handoff. | `avery`: use `npm run check:contract-drift` plus the sweep doc while reviewing runtime/doc PRs, then keep issue #11 focused on executable smoke/E2E evidence. |
+| merged PR #149 `test(runtime): add executable dispatch smoke suite` | Landed on `main` | The executable smoke suite is now the shared runtime evidence baseline for QA and planning follow-through. | `avery`: run the suite from `main`, post the current output back to issue #120 and issue #11, and treat regressions as follow-up bugs instead of doc gaps. |
+| PR #133 `[P1-131] Add verify-award adoption checklist` | Clean branch, re-review pending | The checklist branch is back on top of current `main`, but the PR still has no recorded review decision after the latest queue churn. | `albatross-dev-agent` + maintainer: keep the posted validation evidence current and re-request review against the refreshed branch. |
+| merged PR #152 `docs(frontend): verify runtime consumer baseline` | Landed on `main` | The runtime consumer verification doc is now part of the merged frontend/QA adoption baseline. | `lanzhou-fe-agent` + reviewers: use the merged consumer-baseline wording as the reference point for follow-on QA evidence instead of tracking it as open review work. |
+| PR #153 `[P1-137] Add weekly execution audit playbook` | Dirty branch, rebase required | The planning follow-through drifted behind `main` again, so the branch must be rebased before it can return to active review. | `albatross-dev-agent`: rebase onto `origin/main`, rerun validation, paste literal output, then re-request review. |
+| Issue #120 / issue #11 | Waiting on executable evidence | QA still needs one current smoke/E2E evidence pack that exercises the merged runtime path and cites stable negative-path expectations. | `avery`: run the smoke suite after PR #149 lands, then post evidence back to issue #120 and issue #11. |
 
 ## Checkpoint Rollup
 
 | Checkpoint | Epic relevance | Current note |
 | --- | --- | --- |
-| M1 | Service bootstrap + queue control | Merged PRs #129 and #140 provide the baseline; the remaining near-term gate is keeping PRs #159, #153, #154, #161, #165, and #166 aligned to that live queue state. |
-| M2 | Runnable publish/match/bid foundation | Merged PR #127 provides the runnable dispatch baseline; the remaining runtime execution drag is keeping PRs #164, #152, and #133 aligned to the published contracts. |
-| M3 | Verify, audit, and executable QA | Issue #120 / issue #111 carry the burden of turning the merged runtime path into runnable smoke evidence tied back to issue #11. |
+| M1 | Service bootstrap + queue control | The bootstrap path, runtime blocker ledger, and consumer-baseline docs are already merged; the remaining M1 risk is closing the still-open planning queue (`#133`, `#153`) without reintroducing drift. |
+| M2 | Runnable publish/match/bid foundation | Merged PRs #127, #129, and #149 now provide the local runnable + smoke baseline; the active execution drag is turning that baseline into current QA evidence on issue #120. |
+| M3 | Verify, audit, and executable QA | Issue #120 and issue #11 now carry the burden of turning the merged runtime path into runnable smoke/E2E evidence with contract-aligned failure expectations. |
 | M4 | Beta readiness sign-off | Issue #11 final E2E evidence and audit/security verification remain required. |
 
 ## Epic Exit Checklist

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,7 +79,7 @@ Focus:
 De-scoped from current sprint:
 - Planning-only follow-ups #106, #107, #108 were closed to avoid additional doc-layer churn.
 - Planning-sync PRs #82, #95, #96, #102, #103, and #105 were closed for the same reason.
-- QA prewrite-only threads (#87, PR #84, PR #104) are treated as superseded by runtime execution issue #111.
+- QA prewrite-only threads (#87, PR #84, PR #104) are treated as superseded by the merged runtime evidence baseline; issue #11 and issue #120 now carry the remaining executable follow-through.
 
 ### Phase 2: Execution & Trust Loop (Target: 2026-05 to 2026-06)
 
@@ -105,10 +105,10 @@ Scope:
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
-- M1 (2026-03-20): absorb the merged runtime read-model baseline into one frontend handoff doc, then land runnable backend skeleton (#109).
-- Runtime work may proceed ahead of full contract convergence when the cutline marks a delta additive-safe; verifier payload/result vocabulary is now merged, so the remaining near-term review risk is contract drift on the additive read surfaces and frontend wiring handoff.
-- M2 (2026-03-27): land runnable publish/match/commit/reveal/verify/award vertical slice (#110).
-- M3 (2026-04-03): stabilize verify/award/audit runtime behavior and run executable smoke checks (#111).
+- M1 (2026-03-20): keep the merged runtime/bootstrap/handoff baseline stable on `main`, use merged PR #152 as the consumer-baseline reference, and close the remaining planning review queue (`#133`, `#153`).
+- Runtime work may proceed ahead of full contract convergence when the cutline marks a delta additive-safe; verifier payload/result vocabulary, the bootstrap/runtime handoff baseline, the executable smoke suite (PR #149), and the consumer-baseline follow-through (PR #152) are now merged, so the remaining near-term review risk is contract drift in the still-open planning/doc queue.
+- M2 (2026-03-27): keep the merged publish/match/commit/reveal/verify/award path healthy on `main` and turn the already-merged executable dispatch smoke suite (PR #149) into current QA evidence on issue #120 / issue #11.
+- M3 (2026-04-03): stabilize verify/award/audit runtime behavior and post executable smoke/E2E evidence back to issue #120 and issue #11.
 - M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.
 - Review `docs/PHASE1_BETA_READINESS_GATES.md` as the compact release-gate checklist for the remaining Phase 1 contract, QA, audit, and planning blockers.


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Refresh the Phase 1 epic, beta-readiness, and roadmap rollups to match the 2026-03-18 merged runtime baseline.

## What Changed

- Refreshed `docs/PHASE1_EPIC_STATUS.md` to replace stale blocked-runtime notes with the current merged baseline plus the remaining executable-evidence queue.
- Updated `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` so the live planning docs all point at the same post-merge blockers and next owners.
- Marked the matching OpenSpec rollout task complete in `openspec/changes/agent-dispatch-platform/tasks.md` so the spec/task ledger stays aligned with the planning-doc refresh.

## Why

- Epic #2 was still described as if the runtime bootstrap and dispatch vertical-slice work were pending even though the relevant runtime PRs have already merged.
- That drift makes it harder for reviewers and owners to identify the real remaining blockers: executable smoke/E2E evidence, QA closeout, and the small approved planning-consumer queue.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Long-lived Phase 1 planning docs reflect the current merged runtime baseline instead of stale blocker snapshots. | Updates the epic status, beta gates, goals, roadmap, and checkpoint board to consistently reference the merged runtime/bootstrap work and the remaining PR/#120/#11 evidence queue. | `docs/PHASE1_EPIC_STATUS.md`, `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, `docs/PHASE1_CHECKPOINT_BOARD.md` |
| OpenSpec task tracking stays in sync with the planning-doc refresh for epic #2. | Adds task `5.6` as complete in the active OpenSpec change to record the documentation rollup refresh. | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Use a clean worktree on top of the latest `origin/main`.
- Git worktree identity is bootstrapped for `albatross-dev-agent`.

### Steps

1. Review the updated planning/OpenSpec files against the current merged/open GitHub queue for epic #2.
2. Run diff hygiene and OpenSpec validation.
3. Run the repo pre-push identity/baseline guard.

### Expected Results

- The Phase 1 rollup docs agree on the merged runtime baseline and remaining execution-evidence blockers.
- `git diff --check` reports no whitespace or conflict-marker issues.
- `openspec validate --all` passes.
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent` passes.

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `git diff --check`
```text
(no output)
```
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-epic-status-refresh' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - The docs could drift again if more runtime/evidence PRs land without another rollup refresh.
  - Queue status language can age quickly, so this PR should merge while the referenced state is still current.
- Rollback:
  - Revert commit `21adffa` if the rollup needs to be backed out, then rerun `openspec validate --all`.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
