### PR TITLE
docs: define runtime execution handoff

### DIFF
--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -17,6 +17,7 @@ Ship the first usable agent dispatch loop for closed beta:
 
 - Current sprint focus moves from planning-doc expansion to runnable implementation slices.
 - Runtime cutline decisions for open contract PRs live in `docs/RUNTIME_CUTLINE_2026-03-16.md`; use that table to decide which deltas block runtime merge versus which are additive-safe follow-ups.
+- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when issue #109, issue #110, issue #111, or issue #11 claims executable progress.
 - Architecture coordination for the 2026-03-17 to 2026-03-20 unblocker window lives in `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` and issue #137.
 - Active implementation issues for this pivot:
   - #109 backend runtime skeleton
@@ -95,6 +96,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Implementation-scoped issues are closed only when runtime code or executable test coverage is merged.
 - End-to-end happy path + key negative paths are covered by automated tests.
 - One local command path can run service + smoke checks for happy path and core negatives.
+- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Weekly epic #2 checkpoints use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so owner handoffs and validation-evidence gaps stay consistent across review weeks.

--- a/docs/RUNTIME_CUTLINE_2026-03-16.md
+++ b/docs/RUNTIME_CUTLINE_2026-03-16.md
@@ -6,6 +6,7 @@ Primary runtime threads:
 
 - issue #109: runnable control-plane backend skeleton
 - issue #110: runnable `publish -> match -> commit -> reveal -> verify -> award` vertical slice
+- issue #111: executable smoke/E2E conversion using the command/evidence contract in `docs/RUNTIME_EXECUTION_HANDOFF.md`
 
 Reference contract threads:
 
@@ -34,6 +35,7 @@ Go now:
 - create service entrypoint, config loading, request logging, and `/healthz`
 - add persistence abstractions for task, bid, proof, award, and audit records
 - add one namespaced API route plus a documented local run command
+- publish the exact service/reset/smoke command path once the skeleton becomes runnable
 
 Do not block #109 on:
 
@@ -65,6 +67,7 @@ Safe to defer from the first #110 merge:
 - bid/proof polling reads from PR #66
 - shortlist and award detail read surfaces from PR #68
 - audit timeline query endpoints from PR #92
+- final issue #11 evidence aggregation, as long as the branch already exposes the command path and trace identifiers required by `docs/RUNTIME_EXECUTION_HANDOFF.md`
 
 ## Beta-readiness wording
 
@@ -72,4 +75,5 @@ Contract convergence still matters for M1/M4 readiness, but the runtime sprint i
 
 - M1 runtime progress may continue while additive-safe contract PRs remain open.
 - M1 cannot declare the verify/award path stable until PR #83 is merged or an equivalent verifier contract lands.
+- M1/M4 checkpoints should treat `docs/RUNTIME_EXECUTION_HANDOFF.md` as the source of truth for what counts as an executable local run claim.
 - M4 beta sign-off still requires the full contract stack to converge, including the additive-safe read surfaces deferred from the first runtime merge.

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -1,0 +1,105 @@
+# Runtime Execution Handoff
+
+This document defines the planning-side handoff contract for the runtime-first sprint.
+It keeps issue #109, issue #110, issue #111, and the blocked final E2E thread in issue
+#11 aligned on one executable delivery path instead of four separate definitions of
+"done."
+
+## Scope
+
+- issue #109: land a runnable control-plane skeleton with one documented local service
+  command
+- issue #110: wire the `publish -> match -> commit -> reveal -> verify -> award`
+  vertical slice against persisted state
+- issue #111: convert the existing smoke/E2E matrices into executable assertions
+- issue #11: collect the final happy-path plus negative-path evidence needed for beta
+  sign-off
+
+This handoff does not replace implementation docs inside runtime PRs. It defines the
+minimum evidence and command contract those PRs must publish before the sprint can claim
+an executable path.
+
+## Required command contract
+
+Before issue #109, issue #110, or issue #111 can be closed, the owning PR set must
+publish one reproducible local command path with the exact commands, required env vars,
+and fixture/reset assumptions.
+
+The command path must include:
+
+1. `service command`
+   - Starts the control-plane service on a clean local checkout.
+   - Includes any required config/bootstrap step.
+2. `reset or seed command`
+   - Produces a deterministic local state for reruns.
+   - May be a script, make target, or documented curl/sqlite bootstrap step.
+3. `smoke command`
+   - Executes the happy path plus the core negative-path assertions.
+   - Exits non-zero on failure so QA and CI can consume it without manual log reading.
+
+The exact command names are intentionally not frozen in this planning doc. Runtime owners
+may choose the final script names, but they must surface one canonical command path in
+their PR body and linked issue comments.
+
+## Evidence package
+
+Every PR or issue update claiming runtime progress must include enough evidence for a
+different lane to rerun the flow without guessing.
+
+Minimum evidence:
+
+- literal output for the validation commands already required by repo policy
+- the exact runtime command path used for the demonstration
+- request/response evidence for each write step in the happy path:
+  - publish
+  - match
+  - commit
+  - reveal
+  - verify
+  - award
+- identifiers that let QA or operators correlate the run:
+  - `task_id`
+  - `bid_id`
+  - `proof_id`
+  - `audit_id` or `decisionTraceHash`
+- negative-path evidence for the first closure pass:
+  - reveal without commit
+  - invalid signature or upload/auth failure
+  - proof verification fail
+  - award blocked after failed proof or missing prerequisite
+
+Issue #11 remains the aggregation point for final beta-readiness evidence. Runtime PRs
+should link their evidence there rather than duplicating large transcripts across multiple
+planning docs.
+
+## Ownership handshake
+
+| Lane | Required handoff output | Consumes from |
+| --- | --- | --- |
+| Planning (`owner:albatross`) | keeps this command/evidence contract current; checks that epic docs only claim executable progress when a real command path exists | issue #109, issue #110, issue #111 PR bodies and comments |
+| Backend/runtime | publishes the service/reset/smoke commands and request/response fixtures | merged contracts, `docs/RUNTIME_CUTLINE_2026-03-16.md` |
+| QA | converts the published command path into repeatable smoke/E2E execution and posts the signed evidence back to issue #11 | backend PR outputs, `docs/ERROR_CODE_RETRY_POLICY.md`, security readiness docs |
+
+If a runtime PR can only show partial write-path progress, it should say exactly which
+segment is runnable and which segment is still blocked by contract or implementation gaps.
+Planning docs must not compress partial evidence into "E2E ready."
+
+## Scenario matrix for the first executable tranche
+
+| Scenario | Primary owner | Minimum proof before calling it done |
+| --- | --- | --- |
+| Happy path | issue #109 + issue #110 owners | One local run reaches `TASK_AWARDED` and emits the canonical audit events |
+| Reveal without commit | issue #110 owner | Command/assertion shows the stable rejection and error code |
+| Invalid signature or auth failure | issue #109 owner | Command/assertion shows write rejection before state mutation |
+| Proof FAIL path | issue #110 + issue #111 owners | Verify step returns the published terminal failure vocabulary and award remains blocked |
+| Audit evidence replay | issue #111 owner | Smoke run captures the event trail or trace identifiers needed for issue #11 evidence |
+
+## Review rule
+
+When planning or QA reviewers ask for "validation output" on runtime threads, the reply
+must include both:
+
+- repo policy validation (`openspec validate --all`, `git diff --check`, pre-push guard)
+- runtime execution evidence from the canonical service/reset/smoke path
+
+Passing spec validation alone is not enough for runtime implementation issues.

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -86,6 +86,7 @@
    - 2026-03-16 起，交付节奏从“持续追加规划文档”切换为“优先交付可运行实现”。
    - 当前冲刺以 issue #109（服务骨架）、#110（端到端垂直切片）、#111（可执行 QA 校验）为主线。
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
+   - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -19,6 +19,7 @@
 - 明确身份分层（T0/T1/T2）下的 PoMW 强度策略。
 - 定义从任务发布到中标执行的关键状态流转与审计要求。
 - 新增 runtime 落地冲刺任务（issue #109/#110/#111），要求将核心流程转为可运行服务与可执行 QA 校验。
+- 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 
 ## Capabilities
 
@@ -35,5 +36,6 @@
 - 新增 `docs/OBSERVABILITY_BASELINE.md`，作为后续后端埋点、运维告警与审计可视化的统一契约。
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
+- 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -42,3 +42,4 @@
 - [ ] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。
+- [x] 5.6 输出 `docs/RUNTIME_EXECUTION_HANDOFF.md`，统一 runtime sprint 的本地命令契约、证据包与 issue #11 回写规则。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Define the runtime execution handoff contract so issue #109, issue #110, issue #111, and issue #11 use one shared command/evidence definition.

## What Changed

- Added `docs/RUNTIME_EXECUTION_HANDOFF.md` to define the required local command path (`service`, `reset/seed`, `smoke`), the minimum runtime evidence package, and the ownership handshake across planning/backend/QA.
- Linked that handoff contract from `docs/PHASE1_GOALS.md` and `docs/RUNTIME_CUTLINE_2026-03-16.md` so the sprint goals and cutline now point at the same executable-proof standard.
- Synced the active OpenSpec change (`proposal.md`, `design.md`, `tasks.md`) so the runtime-first sprint explicitly includes the new handoff artifact.

## Why

- The runtime sprint currently spans issue #109, issue #110, issue #111, and the blocked final evidence thread in issue #11, but the repo did not yet define one durable handoff for what counts as a runnable local path.
- Without that shared contract, planning/QA reviews can accept spec validation while still missing the exact service/smoke commands or the trace identifiers needed to replay and aggregate evidence.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Runtime-first execution threads use one explicit command/evidence contract before claiming runnable progress. | Adds `docs/RUNTIME_EXECUTION_HANDOFF.md` with the canonical service/reset/smoke command expectations, evidence package, scenario matrix, and review rule. | `docs/RUNTIME_EXECUTION_HANDOFF.md` |
| The OpenSpec/runtime planning stack stays aligned with the new handoff rule. | Links the handoff doc from Phase 1 goals and the runtime cutline, and records the artifact in the active OpenSpec proposal/design/tasks. | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_CUTLINE_2026-03-16.md`, `openspec/changes/agent-dispatch-platform/proposal.md`, `openspec/changes/agent-dispatch-platform/design.md`, `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Use a clean worktree rebased onto the latest `origin/main`.
- Git worktree identity is bootstrapped for `albatross-dev-agent`.

### Steps

1. Read `docs/RUNTIME_EXECUTION_HANDOFF.md` and confirm the command contract/evidence package covers issue #109, issue #110, issue #111, and issue #11.
2. Verify the linked planning/OpenSpec files reference the same handoff doc and do not redefine a conflicting runtime closure rule.
3. Run OpenSpec validation, diff hygiene, and the repo pre-push guard.

### Expected Results

- Runtime implementation threads have one documented command/evidence contract for local reruns and issue #11 evidence aggregation.
- Phase 1 planning docs and the active OpenSpec change point at the same handoff artifact.
- `openspec validate --all`, `git diff --check`, and `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent` pass.

### Validation Output

- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
(no output)
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-runtime-execution-handoff' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - Runtime owners may still choose inconsistent command names unless future PRs actually follow this handoff contract.
  - The handoff doc can drift if the runtime path changes but the linked planning/OpenSpec references are not updated.
- Rollback:
  - Revert commit `0389cbf` and rerun `openspec validate --all` if the handoff contract needs to be backed out or reworked.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
