### PR TITLE
docs: correct planning ownership mapping

### DIFF
--- a/docs/ORGANIZATION.md
+++ b/docs/ORGANIZATION.md
@@ -121,7 +121,7 @@ This map defines who PM Lan assigns as issue owner and who is requested as PR re
 | Frontend implementation | `dept/frontend` + one `type/*` | `owner:lanzhou-fe-agent` | UI workflow/state-machine scope. |
 | Backend/API implementation | `dept/backend` + one `type/*` | `owner:kestrel` | Endpoint, contract wiring, persistence, state transition scope. |
 | QA/test execution | `dept/qa` + one `type/*` | `owner:avery` | Smoke/E2E, regression evidence, validation tooling. |
-| Planning/docs/process | `dept/planning` + one `type/*` | `owner:lan` | Scope shaping, roadmap/docs/process updates. |
+| Planning/docs/process | `dept/planning` + one `type/*` | `owner:albatross` | Scope shaping, roadmap/docs/process updates. |
 | Cross-cutting architecture | keep primary `dept/*` + one `type/*` | `owner:albatross` | Use only when issue mainly controls multi-lane architecture decisions. |
 
 ### PR review relation map
@@ -133,6 +133,9 @@ This map defines who PM Lan assigns as issue owner and who is requested as PR re
 | `avery-chen` | `albatross-dev-agent` | `kestrel-dev-agent` for backend/test infra impact, `lanzhou-fe-agent` for FE test impact |
 | `lan` | `albatross-dev-agent` | Domain owner by dept (`kestrel-dev-agent` / `lanzhou-fe-agent` / `avery-chen`) |
 | `albatross-dev-agent` | `albatross-dev-agent` | Mandatory delegation: at least one domain owner + `avery-chen` for independent review |
+
+Planning ownership note:
+- `dept/planning` work is owned by `albatross-dev-agent` and uses the `owner:albatross` label.
 
 ### PM Lan operating steps
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): n/a
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Correct the planning ownership mapping from `owner:lan` to `owner:albatross`

## What Changed

- Updated the dept-to-owner map in `docs/ORGANIZATION.md` so planning/docs/process work routes to `owner:albatross`
- Added an explicit note that `dept/planning` work is owned by `albatross-dev-agent`

## Why

- Planning ownership was incorrectly documented as Lan-owned, which conflicted with the actual ownership model and caused the wrong label to be applied

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Planning work shows the correct owner label | Replaced `owner:lan` with `owner:albatross` in the owner map | `docs/ORGANIZATION.md` |
| Planning ownership is explicit for future triage | Added a dedicated note tying `dept/planning` to `albatross-dev-agent` | `docs/ORGANIZATION.md` |

## QA Plan

### Preconditions

- Repository checked out on `codex/planning-owner-albatross`

### Steps

1. Open `docs/ORGANIZATION.md`
2. Review the issue label owner map row for `Planning/docs/process`
3. Confirm the planning ownership note states `owner:albatross` / `albatross-dev-agent`

### Expected Results

- The planning owner map no longer references `owner:lan`
- The note makes planning ownership explicit for future issue/PR labeling

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```
<no output>
```

## Risks and Rollback

- Risk:
  - Low; documentation-only change, but mislabeled ownership could still confuse triage if future docs diverge
- Rollback:
  - Revert commit `docs: correct planning ownership mapping`

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
