### PR TITLE
[P1-163] Add backend API example packet from smoke flow

### DIFF
--- a/docs/BACKEND_API_EXAMPLE_PACKET.md
+++ b/docs/BACKEND_API_EXAMPLE_PACKET.md
@@ -1,0 +1,601 @@
+# Backend API example packet
+
+This packet turns the merged `npm run smoke:dispatch` runtime path on `main` into one
+backend-owned request/response reference for QA, beta consumers, and issue
+[#11](https://github.com/jckhang/agent-indeed/issues/11).
+
+## Source of truth
+
+- Runtime command: `npm run smoke:dispatch`
+- Runtime implementation: `src/runtime/dispatch-smoke.js`
+- API contracts: `src/api/openapi.yaml`, `src/api/contracts.ts`
+- Final E2E aggregation thread: issue [#11](https://github.com/jckhang/agent-indeed/issues/11)
+
+The examples below use the deterministic IDs and payload shapes exercised by the local
+runtime smoke flow. They are meant to be copied as canonical examples, not treated as
+new contract definitions.
+
+## Happy path packet
+
+### 1. Publish task
+
+Route/type links:
+- `POST /v1/tasks`
+- `CreateTaskRequest`, `CreateTaskResponse`
+
+Request:
+```json
+{
+  "task": {
+    "title": "Dispatch smoke task",
+    "description": "Exercise the runtime publish to award flow in one command",
+    "budget": {
+      "currency": "USD",
+      "minAmount": 100,
+      "maxAmount": 300
+    },
+    "sla": {
+      "deadlineAt": "2026-03-20T00:00:00Z",
+      "maxLatencyMs": 5000
+    },
+    "constraints": {
+      "identityTierMin": "T1",
+      "requiredSkills": ["backend", "api"],
+      "complianceTags": ["soc2"]
+    },
+    "risk": {
+      "level": "LOW",
+      "valueScore": 0.2
+    },
+    "powmPolicy": {
+      "mode": "AUTO_TIERED",
+      "baseDifficulty": 2
+    },
+    "biddingWindow": {
+      "commitDeadline": "2026-03-19T00:00:00Z",
+      "revealDeadline": "2026-03-20T00:00:00Z"
+    }
+  }
+}
+```
+
+Response `201 Created`:
+```json
+{
+  "taskId": "task_00000001",
+  "status": "OPEN_FOR_MATCHING",
+  "commitDeadline": "2026-03-19T00:00:00Z",
+  "revealDeadline": "2026-03-20T00:00:00Z"
+}
+```
+
+### 2. Match candidates
+
+Route/type links:
+- `GET /v1/tasks/{taskId}/candidates`
+- shortlist response types in `src/api/contracts.ts`
+
+First read can return the stable retry signal:
+
+Response `409 Conflict`:
+```json
+{
+  "code": "TASK_MATCH_NOT_READY",
+  "category": "MATCHING",
+  "message": "candidate matching snapshot is not ready for task task_00000001",
+  "auditId": "audit_task_match_not_ready",
+  "retryable": true,
+  "retryAfterSeconds": 1
+}
+```
+
+Retry response `200 OK`:
+```json
+{
+  "taskId": "task_00000001",
+  "status": "MATCHED",
+  "generatedAt": "2026-03-18T09:06:09.694Z",
+  "candidates": [
+    {
+      "agentId": "agent_kestrel_alpha",
+      "identityTier": "T1",
+      "matchedSkills": ["backend", "api"],
+      "complianceStatus": "PASSED",
+      "eligibilityChecks": [
+        { "gate": "IDENTITY_TIER", "status": "PASSED" },
+        { "gate": "REQUIRED_SKILL", "status": "PASSED" },
+        { "gate": "COMPLIANCE", "status": "PASSED" }
+      ],
+      "eligible": true,
+      "rank": 1,
+      "matchingTraceId": "matchtrace_00000001"
+    },
+    {
+      "agentId": "agent_kestrel_beta",
+      "identityTier": "T0",
+      "matchedSkills": ["backend", "api"],
+      "complianceStatus": "PASSED",
+      "eligibilityChecks": [
+        { "gate": "IDENTITY_TIER", "status": "PASSED" },
+        { "gate": "REQUIRED_SKILL", "status": "PASSED" },
+        { "gate": "COMPLIANCE", "status": "PASSED" }
+      ],
+      "eligible": true,
+      "rank": 2,
+      "matchingTraceId": "matchtrace_00000001"
+    },
+    {
+      "agentId": "agent_kestrel_gamma",
+      "identityTier": "T2",
+      "matchedSkills": ["backend", "api"],
+      "complianceStatus": "FAILED",
+      "eligibilityChecks": [
+        {
+          "gate": "IDENTITY_TIER",
+          "status": "FAILED",
+          "detail": "requires minimum T1"
+        },
+        { "gate": "REQUIRED_SKILL", "status": "PASSED" },
+        {
+          "gate": "COMPLIANCE",
+          "status": "FAILED",
+          "detail": "missing soc2"
+        }
+      ],
+      "eligible": false,
+      "matchingTraceId": "matchtrace_00000001"
+    }
+  ]
+}
+```
+
+### 3. Commit bid
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/bids/commit`
+- bid write/response contracts in `src/api/contracts.ts`
+
+Request:
+```json
+{
+  "idempotencyKey": "idem-commit-smoke-001",
+  "commit": {
+    "bidId": "bid_00000001",
+    "taskId": "task_00000001",
+    "agentId": "agent_kestrel_alpha",
+    "bidHash": "sha256:45de640566a262fd4f293ae58837cb37900190c7492ee2c2ddfb11df6fefc2bd",
+    "committedAt": "2026-03-16T00:10:00.000Z"
+  }
+}
+```
+
+Response `202 Accepted`:
+```json
+{
+  "bidId": "bid_00000001",
+  "taskId": "task_00000001",
+  "agentId": "agent_kestrel_alpha",
+  "phase": "COMMIT",
+  "status": "COMMITTED",
+  "result": "COMMITTED",
+  "commit": {
+    "bidId": "bid_00000001",
+    "taskId": "task_00000001",
+    "agentId": "agent_kestrel_alpha",
+    "bidHash": "sha256:45de640566a262fd4f293ae58837cb37900190c7492ee2c2ddfb11df6fefc2bd",
+    "committedAt": "2026-03-16T00:10:00.000Z"
+  },
+  "window": {
+    "currentPhase": "COMMIT_OPEN",
+    "commitDeadline": "2026-03-19T00:00:00Z",
+    "revealDeadline": "2026-03-20T00:00:00Z",
+    "serverTime": "2026-03-16T00:00:00.000Z",
+    "nextAction": "WAIT_FOR_REVEAL_WINDOW"
+  }
+}
+```
+
+### 4. Issue proof policy
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/proof-policy`
+- policy response types in `src/api/contracts.ts`
+
+Request:
+```json
+{
+  "agentId": "agent_kestrel_alpha",
+  "identityTier": "T1",
+  "trustScore": 0.84
+}
+```
+
+Response `200 OK`:
+```json
+{
+  "taskId": "task_00000001",
+  "agentId": "agent_kestrel_alpha",
+  "requiredProofStrength": "LOW",
+  "challengeProfile": "SAMPLE_EXECUTION",
+  "verifierParams": {
+    "minSampleCount": 1,
+    "minQualityScore": 0.383,
+    "maxRuntimeMs": 180000
+  },
+  "inputSnapshot": {
+    "taskRiskLevel": "LOW",
+    "taskValueScore": 0.2,
+    "identityTier": "T1",
+    "trustScore": 0.84
+  },
+  "rationale": [
+    "task risk LOW drives the base verifier threshold",
+    "identity tier T1 adjusts the challenge profile",
+    "trust score 0.84 reduces repeated manual review for proven agents"
+  ],
+  "persistedAt": "2026-03-16T00:00:00.000Z",
+  "policyTraceId": "policytrace_00000001"
+}
+```
+
+### 5. Reveal bid
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/bids/reveal`
+- reveal/proof contracts in `src/api/contracts.ts`
+
+Request:
+```json
+{
+  "idempotencyKey": "idem-reveal-smoke-001",
+  "reveal": {
+    "bidId": "bid_00000001",
+    "taskId": "task_00000001",
+    "agentId": "agent_kestrel_alpha",
+    "nonce": "nonce-001",
+    "price": {
+      "currency": "USD",
+      "amount": 180
+    },
+    "executionPlan": {
+      "summary": "Execute with cached backend workflow",
+      "etaSeconds": 240,
+      "requiredTools": ["node", "openssl"]
+    },
+    "proof": {
+      "proofSchemaVersion": "1.0",
+      "proofId": "proof_00000001",
+      "taskId": "task_00000001",
+      "agentId": "agent_kestrel_alpha",
+      "capturedAt": "2026-03-19T00:30:00Z",
+      "identityProof": {
+        "credentialLevel": "T1",
+        "signerDid": "did:key:agent_kestrel_alpha",
+        "signature": "sig-proof-001"
+      },
+      "sampleWork": {
+        "sampleTaskDigest": "sha256:sample-task-001",
+        "outputDigest": "sha256:sample-output-001",
+        "qualityScore": 0.9,
+        "runtimeMs": 1200
+      },
+      "executionTrace": {
+        "traceHash": "sha256:trace-001",
+        "traceUri": "s3://proofs/trace-001.json",
+        "traceSignature": "sig-trace-001",
+        "toolCallCount": 4
+      }
+    }
+  }
+}
+```
+
+Response `200 OK`:
+```json
+{
+  "bidId": "bid_00000001",
+  "taskId": "task_00000001",
+  "agentId": "agent_kestrel_alpha",
+  "phase": "REVEAL",
+  "status": "REVEALED",
+  "result": "REVEALED",
+  "rankingScore": 0.881,
+  "decisionTraceHash": "sha256:6033d33c9b1936c7ee3f0bbdaf85bdedf734488e62f72f788ae7a9dcc37d8843",
+  "revealAcceptedAt": "2026-03-18T09:06:09.699Z",
+  "proofSubmission": {
+    "proofId": "proof_00000001",
+    "verificationStatus": "PENDING_VERIFY"
+  },
+  "window": {
+    "currentPhase": "REVEAL_OPEN",
+    "commitDeadline": "2026-03-19T00:00:00Z",
+    "revealDeadline": "2026-03-20T00:00:00Z",
+    "serverTime": "2026-03-19T00:10:00.000Z",
+    "nextAction": "TRACK_PROOF_VERIFICATION"
+  }
+}
+```
+
+### 6. Verify proof
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/proofs/verify`
+- `VerifyProofPackRequest`, `ProofVerificationResponse`
+
+Request:
+```json
+{
+  "policyTraceId": "policytrace_00000001",
+  "proof": {
+    "proofSchemaVersion": "1.0",
+    "proofId": "proof_00000001",
+    "taskId": "task_00000001",
+    "agentId": "agent_kestrel_alpha",
+    "capturedAt": "2026-03-19T00:30:00Z",
+    "identityProof": {
+      "credentialLevel": "T1",
+      "signerDid": "did:key:agent_kestrel_alpha",
+      "signature": "sig-proof-001"
+    },
+    "sampleWork": {
+      "sampleTaskDigest": "sha256:sample-task-001",
+      "outputDigest": "sha256:sample-output-001",
+      "qualityScore": 0.9,
+      "runtimeMs": 1200
+    },
+    "executionTrace": {
+      "traceHash": "sha256:trace-001",
+      "traceUri": "s3://proofs/trace-001.json",
+      "traceSignature": "sig-trace-001",
+      "toolCallCount": 4
+    }
+  }
+}
+```
+
+Response `200 OK`:
+```json
+{
+  "proofId": "proof_00000001",
+  "result": "PASS",
+  "policyTraceId": "policytrace_00000001",
+  "requiredPolicy": {
+    "taskId": "task_00000001",
+    "agentId": "agent_kestrel_alpha",
+    "requiredProofStrength": "LOW",
+    "challengeProfile": "SAMPLE_EXECUTION",
+    "verifierParams": {
+      "minSampleCount": 1,
+      "minQualityScore": 0.383,
+      "maxRuntimeMs": 180000
+    },
+    "inputSnapshot": {
+      "taskRiskLevel": "LOW",
+      "taskValueScore": 0.2,
+      "identityTier": "T1",
+      "trustScore": 0.84
+    },
+    "rationale": [
+      "task risk LOW drives the base verifier threshold",
+      "identity tier T1 adjusts the challenge profile",
+      "trust score 0.84 reduces repeated manual review for proven agents"
+    ],
+    "persistedAt": "2026-03-16T00:00:00.000Z",
+    "policyTraceId": "policytrace_00000001"
+  },
+  "requiredDifficulty": 0.383,
+  "achievedDifficulty": 0.9,
+  "decisionTraceHash": "sha256:24620d1afadc305678befd30f34b754893ca11c0db48d902211163873460ba49",
+  "reasonCodes": [],
+  "verifiedAt": "2026-03-19T00:10:00.000Z",
+  "bidId": "bid_00000001"
+}
+```
+
+### 7. Award readiness read
+
+Route/type links:
+- `GET /v1/tasks/{taskId}/award`
+- award read contracts in `src/api/contracts.ts`
+
+Response `200 OK`:
+```json
+{
+  "taskId": "task_00000001",
+  "status": "READY_TO_AWARD",
+  "statusMessage": "Proof passed and shortlist evidence is complete.",
+  "shortlistedBidId": "bid_00000001",
+  "awardedAgentId": "agent_kestrel_alpha",
+  "shortlistAuditId": "audit_00000003",
+  "proofAuditId": "audit_00000004",
+  "proofSummary": {
+    "proofId": "proof_00000001",
+    "result": "PASS",
+    "reasonCodes": [],
+    "requiredDifficulty": 0.383,
+    "achievedDifficulty": 0.9,
+    "verifiedAt": "2026-03-19T00:10:00.000Z",
+    "auditId": "audit_00000004"
+  },
+  "decisionTraceHash": "sha256:24620d1afadc305678befd30f34b754893ca11c0db48d902211163873460ba49",
+  "handoff": {
+    "status": "READY",
+    "handoffChannel": "API",
+    "checklist": ["publish award event", "notify winner"]
+  },
+  "reviewedAt": "2026-03-19T00:10:00.000Z"
+}
+```
+
+### 8. Award write
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/award`
+- award write/response contracts in `src/api/contracts.ts`
+
+Request:
+```json
+{
+  "idempotencyKey": "idem-award-smoke-001",
+  "award": {
+    "bidId": "bid_00000001",
+    "awardReason": "Best verified fit for the backend vertical slice.",
+    "shortlistAuditId": "audit_00000003",
+    "proofAuditId": "audit_00000004"
+  }
+}
+```
+
+Response `200 OK`:
+```json
+{
+  "taskId": "task_00000001",
+  "status": "AWARDED",
+  "statusMessage": "Award confirmed and ready for downstream handoff.",
+  "shortlistedBidId": "bid_00000001",
+  "awardedBidId": "bid_00000001",
+  "awardedAgentId": "agent_kestrel_alpha",
+  "awardReason": "Best verified fit for the backend vertical slice.",
+  "shortlistAuditId": "audit_00000003",
+  "proofAuditId": "audit_00000004",
+  "proofSummary": {
+    "proofId": "proof_00000001",
+    "result": "PASS",
+    "reasonCodes": [],
+    "requiredDifficulty": 0.383,
+    "achievedDifficulty": 0.9,
+    "verifiedAt": "2026-03-19T00:10:00.000Z",
+    "auditId": "audit_00000004"
+  },
+  "decisionTraceHash": "sha256:24620d1afadc305678befd30f34b754893ca11c0db48d902211163873460ba49",
+  "auditEventId": "audit_00000005",
+  "handoff": {
+    "status": "READY",
+    "handoffChannel": "API",
+    "checklist": ["publish award event", "notify winner"]
+  },
+  "reviewedAt": "2026-03-19T00:10:00.000Z",
+  "awardedAt": "2026-03-19T00:10:00.000Z"
+}
+```
+
+### Audit replay identifiers
+
+For issue [#11](https://github.com/jckhang/agent-indeed/issues/11), the happy-path run yields:
+
+- `taskId`: `task_00000001`
+- `bidId`: `bid_00000001`
+- `proofId`: `proof_00000001`
+- `policyTraceId`: `policytrace_00000001`
+- `decisionTraceHash`: `sha256:24620d1afadc305678befd30f34b754893ca11c0db48d902211163873460ba49`
+- final `auditEventId`: `audit_00000005`
+- task event sequence: `TASK_CREATED`, `BID_COMMITTED`, `BID_REVEALED`, `POMW_VERIFIED`, `TASK_AWARDED`
+
+## Negative-path packet
+
+### Reveal without commit
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/bids/reveal`
+- bid error contracts in `src/api/openapi.yaml`
+
+Response `400 Bad Request`:
+```json
+{
+  "code": "BID_REVEAL_COMMIT_NOT_FOUND",
+  "category": "PRECONDITION",
+  "message": "no prior commit exists for bid bid_00000077",
+  "auditId": "audit_bid_reveal_commit_not_found",
+  "retryable": false,
+  "details": {
+    "bidId": "bid_00000077",
+    "taskId": "task_00000002"
+  }
+}
+```
+
+### Proof FAIL
+
+Route/type links:
+- `POST /v1/tasks/{taskId}/proofs/verify`
+- `ProofVerificationResponse` and verify error contracts
+
+Response `422 Unprocessable Entity`:
+```json
+{
+  "code": "PROOF_VERIFY_FAILED",
+  "category": "POLICY",
+  "message": "proof difficulty 0.4 is below required threshold 0.876",
+  "auditId": "audit_proof_verify_failed",
+  "retryable": false,
+  "details": {
+    "proofId": "proof_00000002",
+    "taskId": "task_00000002",
+    "policyTraceId": "policytrace_00000002",
+    "requiredDifficulty": 0.876,
+    "achievedDifficulty": 0.4,
+    "decisionTraceHash": "sha256:e1a09d2dcdffebda3c16feab17abb064901893e7699e012009e81ab105dd8ca0",
+    "reasonCodes": [
+      "QUALITY_SCORE_BELOW_MINIMUM",
+      "HASHCASH_BITS_BELOW_MINIMUM"
+    ]
+  }
+}
+```
+
+### Award blocked after failed proof
+
+Read response `200 OK` from `GET /v1/tasks/{taskId}/award`:
+```json
+{
+  "taskId": "task_00000002",
+  "status": "BLOCKED",
+  "statusMessage": "Bid bid_00000002 is not awardable because proof result is FAIL.",
+  "shortlistedBidId": "bid_00000002",
+  "awardedAgentId": "agent_kestrel_gamma",
+  "shortlistAuditId": "audit_00000008",
+  "proofAuditId": "audit_00000009",
+  "proofSummary": {
+    "proofId": "proof_00000002",
+    "result": "FAIL",
+    "reasonCodes": [
+      "QUALITY_SCORE_BELOW_MINIMUM",
+      "HASHCASH_BITS_BELOW_MINIMUM"
+    ],
+    "requiredDifficulty": 0.876,
+    "achievedDifficulty": 0.4,
+    "verifiedAt": "2026-03-19T00:10:00.000Z",
+    "auditId": "audit_00000009"
+  },
+  "decisionTraceHash": "sha256:e1a09d2dcdffebda3c16feab17abb064901893e7699e012009e81ab105dd8ca0",
+  "handoff": {
+    "status": "PENDING",
+    "checklist": ["wait for proof verification", "refresh award readiness"]
+  },
+  "reviewedAt": "2026-03-19T00:10:00.000Z"
+}
+```
+
+Write response `422 Unprocessable Entity` from `POST /v1/tasks/{taskId}/award`:
+```json
+{
+  "code": "TASK_AWARD_PRECONDITION_FAILED",
+  "category": "PRECONDITION",
+  "message": "bid bid_00000002 is not awardable because proof result is FAIL",
+  "auditId": "audit_task_award_precondition_failed",
+  "retryable": false,
+  "details": {
+    "bidId": "bid_00000002",
+    "taskId": "task_00000002",
+    "proofId": "proof_00000002",
+    "proofResult": "FAIL"
+  }
+}
+```
+
+## How QA and beta consumers should use this packet
+
+1. Treat `docs/BACKEND_API_EXAMPLE_PACKET.md` as the reusable API packet for issue
+   [#11](https://github.com/jckhang/agent-indeed/issues/11) instead of rebuilding payloads from review comments.
+2. Treat `src/api/openapi.yaml` and `src/api/contracts.ts` as the contract source of truth; if this packet and those files diverge, update the packet in the same PR that changed the contract.
+3. Use `npm run smoke:dispatch` as the executable proof that these examples still match the merged runtime behavior.

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -72,6 +72,10 @@ Issue #11 remains the aggregation point for final beta-readiness evidence. Runti
 should link their evidence there rather than duplicating large transcripts across multiple
 planning docs.
 
+The backend-owned reusable API packet for that final handoff lives in
+`docs/BACKEND_API_EXAMPLE_PACKET.md`; issue #11 and future QA runs should point at that
+doc instead of reconstructing payloads from PR review threads.
+
 ## Ownership handshake
 
 | Lane | Required handoff output | Consumes from |

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -87,6 +87,7 @@ review history, and linked PRs, open the GitHub issue directly.
 - P1-39 Execute runtime smoke/E2E checks from QA matrices: [#111](https://github.com/jckhang/agent-indeed/issues/111)
 - P1-40 Frontend runtime integration tranche: [#136](https://github.com/jckhang/agent-indeed/issues/136)
 - P1-41 Frontend runtime mainline sync tranche: [#145](https://github.com/jckhang/agent-indeed/issues/145)
+- P1-42 Backend API example packet from merged smoke flow: [#163](https://github.com/jckhang/agent-indeed/issues/163)
 
 ## Working rule
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -88,6 +88,7 @@
    - 当前冲刺以 issue #109（服务骨架）、#110（端到端垂直切片）、#111（可执行 QA 校验）为主线。
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
+   - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -21,6 +21,7 @@
 - 新增 runtime 落地冲刺任务（issue #109/#110/#111），要求将核心流程转为可运行服务与可执行 QA 校验。
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求 issue #146 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
+- 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
 
 ## Capabilities
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -47,3 +47,4 @@
 - [x] 5.8 完成前端 runtime consumer verification pass（issue #150），校准 task composer、shortlist/award、bid workspace、verification timeline 对当前 `main` runtime 字段与 fallback 语义的引用。
 - [x] 5.9 跟进前端 consumer contract claim trim（issue #157），把 shortlist/award/bid/proof 读路径的 `main` 基线解释收敛到 OpenAPI/TS draft anchors，避免把 runtime 数据缺口误写成 contract 缺口。
 - [x] 5.10 补充前端 consumer contract reviewer quick-check 锚点，给出 `origin/main` 的行号与 grep 校验命令，减少对已发布读路径的重复误判。
+- [x] 5.11 输出 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged `smoke:dispatch` 路径固化为 issue #11 / QA / beta consumer 可复用的请求响应示例包。

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -7,4 +7,5 @@
 - `GET /v1/tasks/{taskId}/candidates` is the canonical shortlist read path; downstream manager-review work should extend that response additively, keep `limit` as the shared query parameter, and use additive toggles such as `includeScoreBreakdown` instead of a parallel shortlist path/shape.
 - Ranked candidates always carry `rank`; filtered-out candidates stay visible with `eligible=false` and no synthetic rank. `scoreBreakdown` remains optional behind `includeScoreBreakdown`.
 - Bid/proof status polling contracts now include typed read projections for async verification refresh.
+- `docs/BACKEND_API_EXAMPLE_PACKET.md`: canonical `publish -> match -> commit -> reveal -> verify -> award` request/response packet plus negative-path examples for issue #11 handoff.
 - `docs/ONBOARDING_PIPELINE.md`: deterministic onboarding pipeline, skill indexing contract, and retry guidance for bundle upload.


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #163
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/docs`
- Scope: publish one backend-owned API example packet from the merged `smoke:dispatch` flow for QA and issue #11 handoff

## What Changed

- added `docs/BACKEND_API_EXAMPLE_PACKET.md` with canonical request/response examples for the merged `publish -> match -> commit -> reveal -> verify -> award` flow plus the required negative-path examples (`reveal without commit`, `proof FAIL`, and `award precondition failed`)
- linked the packet from `src/api/README.md` and `docs/RUNTIME_EXECUTION_HANDOFF.md` so QA and beta consumers have one durable backend-owned handoff target for issue #11
- updated the stable issue/spec indexes in `docs/issues/PHASE1_ISSUES.md` and `openspec/changes/agent-dispatch-platform/{proposal,design,tasks}.md` so the new example-packet work stays visible in the OpenSpec-first flow

## Why

- issue #163 asks for one reusable backend packet that turns the merged runtime smoke path into canonical API payloads instead of forcing QA and beta consumers to reconstruct examples from review comments
- issue #11 is still the final E2E aggregation thread, so this packet gives that thread a durable handoff artifact tied directly to the merged runtime and published contracts

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| One focused artifact or doc links each example to the merged runtime smoke path on `main`. | `docs/BACKEND_API_EXAMPLE_PACKET.md` records the happy-path and negative-path examples and names `npm run smoke:dispatch` plus the runtime/API source files as the packet's origin. | `docs/BACKEND_API_EXAMPLE_PACKET.md` |
| Example payloads stay aligned with the published OpenAPI/TypeScript contracts and do not invent fields not present on `main`. | The packet is framed as a contract-backed example layer and is linked from `src/api/README.md`; I also re-ran `npm run smoke:dispatch` against the merged runtime baseline while preparing the packet. | `docs/BACKEND_API_EXAMPLE_PACKET.md`, `src/api/README.md`, `npm run smoke:dispatch` output below |
| Issue #11 can reference this packet directly instead of keeping backend example work bundled inside the QA closure thread. | `docs/RUNTIME_EXECUTION_HANDOFF.md` now points issue #11 and future QA runs at the packet, and the stable issue index includes issue #163 for follow-up lookup. | `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/issues/PHASE1_ISSUES.md` |

## QA Plan

### Preconditions

- Use the latest `origin/main` baseline in a clean kestrel worktree.
- Node.js and the local repo scripts are available.

### Steps

1. Open `docs/BACKEND_API_EXAMPLE_PACKET.md` and confirm it covers the full happy path plus the required negative paths from issue #163.
2. Run `npm run smoke:dispatch` and confirm the runtime still exercises the same bounded flow and error vocabulary referenced by the packet.
3. Run the repo validation commands below.

### Expected Results

- QA and beta consumers can copy one backend-owned packet instead of reconstructing payloads from PR comments.
- The packet stays tied to the merged runtime smoke path and the published API contract files.
- OpenSpec validation, diff hygiene, and the pre-push guard all pass on the branch.

### Validation Output

- `npm run smoke:dispatch`
```text
> smoke:dispatch
> node src/runtime/dispatch-smoke.js

[happy-path] PASS task-created :: task_00000001
[happy-path] PASS first-match-blocked :: TASK_MATCH_NOT_READY
[happy-path] PASS candidates-ranked :: 3 candidates
[happy-path] PASS bid-committed :: COMMITTED
[happy-path] PASS proof-policy-issued :: policytrace_00000001
[happy-path] PASS bid-revealed :: PENDING_VERIFY
[happy-path] PASS proof-verified :: PASS
[happy-path] PASS award-ready :: bid_00000001
[happy-path] PASS task-awarded :: audit_00000005
[happy-path] PASS task-audit-timeline :: 5 events
[happy-path] PASS bid-audit-timeline :: 4 events
[invalid-signature] PASS invalid-signature-rejected :: PROOF_VERIFY_FAILED
[negative-paths] PASS reveal-without-commit-rejected :: BID_REVEAL_COMMIT_NOT_FOUND
[negative-paths] PASS proof-fail-rejected :: PROOF_VERIFY_FAILED
[negative-paths] PASS award-blocked :: BLOCKED
{
  "status": "ok",
  "command": "npm run smoke:dispatch",
  "scenarios": [
    {
      "name": "happy-path",
      "status": "PASS",
      "verificationResult": "PASS",
      "taskId": "task_00000001",
      "bidId": "bid_00000001"
    },
    {
      "name": "invalid-signature",
      "status": "PASS",
      "result": "PROOF_VERIFY_FAILED",
      "reasonCodes": [
        "TRACE_SIGNATURE_INVALID"
      ],
      "taskId": "task_00000001",
      "proofId": "proof_00000011"
    },
    {
      "name": "negative-paths",
      "status": "PASS",
      "revealWithoutCommit": "BID_REVEAL_COMMIT_NOT_FOUND",
      "proofFail": "PROOF_VERIFY_FAILED",
      "awardBlocked": "TASK_AWARD_PRECONDITION_FAILED",
      "taskId": "task_00000001"
    }
  ]
}
```
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user kestrel-dev-agent`
```text
[ok] Branch 'codex/p1-163-api-example-packet' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (kestrel-dev-agent).
[ok] git user.email matches expected account (kestrel-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - the example packet can drift if later contract/runtime PRs change payloads without updating the packet in the same branch
  - the packet intentionally uses deterministic smoke IDs from the local runtime, so consumers should reuse the shapes and vocabulary rather than expect literal IDs in production
- Rollback:
  - revert commit `6a74301` to remove the packet and its index links

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--kestrel`
