### PR TITLE
docs: add Phase 1 acceptance trace

### DIFF
--- a/docs/PHASE1_ACCEPTANCE_TRACE.md
+++ b/docs/PHASE1_ACCEPTANCE_TRACE.md
@@ -1,0 +1,58 @@
+# Phase 1 Acceptance Trace
+
+Last updated: 2026-03-18
+
+This document is the durable acceptance-to-evidence map for epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`).
+Use it to decide whether a milestone, issue, or PR comment is actually moving Phase 1 toward a shippable closed-beta baseline.
+
+Keep volatile queue state in GitHub. This file should only answer three stable questions:
+- which epic acceptance area is being advanced
+- which issue or milestone owns the next executable step
+- which evidence must exist before the acceptance area can be treated as satisfied
+
+## Acceptance map
+
+| Epic acceptance area | Stable source of truth | Delivery threads | Required evidence before we call it done | Review notes |
+| --- | --- | --- | --- | --- |
+| OpenSpec artifacts, OpenAPI draft, and implementation stay aligned | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts` | issue #109, issue #110, issue #111, issue #11 | `openspec validate --all` passes on the merge-ready branch; any runtime/API diff that changes contract scope updates OpenSpec and both API drafts in the same change | Treat this as a release-wide invariant, not a one-time milestone gate |
+| Happy-path dispatch flow is runnable end to end | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, runtime milestone queries in `docs/PHASE1_CHECKPOINT_BOARD.md` | issue #109, issue #110 | A local command path exercises `publish -> match -> commit -> reveal -> verify -> award` and records the evidence bundle expected by `docs/RUNTIME_EXECUTION_HANDOFF.md` | Do not accept doc-only claims for this area |
+| Core negative scenarios are covered by executable checks | `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/PHASE1_BETA_READINESS_GATES.md`, QA milestone queries in `docs/PHASE1_CHECKPOINT_BOARD.md` | issue #111, issue #11 | Automated checks cover the blocked reveal, signature failure, and insufficient-proof paths; rerun evidence is linked back into issue #11 | If the check is manual-only, the acceptance area is still open |
+| Audit trail covers key state transitions | `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/PHASE1_BETA_READINESS_GATES.md` | issue #110, issue #111, issue #11 | Runtime evidence shows audit output for task creation, bid commit, bid reveal, proof verification, and award; the emitted fields remain traceable to the published contracts | Audit docs without runtime evidence are preparatory, not sufficient |
+
+## Milestone handoff rules
+
+### M1: runnable baseline
+
+Use M1 review to answer:
+- is the backend skeleton from issue #109 runnable on a clean branch from `main`
+- are contract changes still passing `openspec validate --all`
+- does the runtime handoff packet name one local command path that later milestones can reuse
+
+### M2: dispatch loop execution
+
+Use M2 review to answer:
+- does issue #110 exercise the full happy-path loop instead of only documenting it
+- do merged runtime-facing docs still stay inside the published API baseline
+- is the evidence output concrete enough for QA to replay without inventing missing steps
+
+### M3: verify, audit, and smoke durability
+
+Use M3 review to answer:
+- does issue #111 convert the smoke matrix into runnable checks
+- do verify and audit outputs show up in the same evidence packet as the happy-path run
+- is issue #11 receiving the replayable command output needed for final sign-off
+
+### M4: beta readiness closure
+
+Use M4 review to answer:
+- does issue #11 contain the final evidence chain for happy path plus key negatives
+- are the audit, telemetry, and security readiness documents still aligned to the executable baseline
+- is there any remaining acceptance area whose proof still depends on a docs-only claim
+
+## Review routine
+
+1. Start from the milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
+2. Check `docs/RUNTIME_EXECUTION_HANDOFF.md` for the command contract and evidence bundle shape.
+3. Confirm the branch or PR under review updates OpenSpec and the API drafts whenever scope changes.
+4. Post weekly epic #2 checkpoints with `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so each update uses the same Done, Blocked, Ready next, and Validation evidence gaps structure.
+5. If evidence is missing, keep the acceptance area open and push the gap back into the relevant GitHub issue or PR instead of copying transient status into repo docs.

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -7,7 +7,7 @@ This document keeps only the stable checkpoint structure and links to the live m
 
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
-| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus verify/award contract adoption (#167, PR #174, PR #176, PR #133). |
+| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus verify/award contract adoption (planning review-burndown queue, PR #174, PR #133). |
 | M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend publishes canonical smoke formatting and evidence (#177, PR #175). |
 | M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Formatter-backed smoke pass, QA packet updates, and final issue #11 evidence handoff (#178, PR #172, issue #11). |
 | M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
@@ -26,7 +26,7 @@ Use these GitHub queries before a checkpoint comment so milestone views and runt
 Sprint pivot dated 2026-03-16 now uses these anchors by default:
 
 - Closed runtime baseline: `#109`, `#110`, `#111`
-- Live planning refresh: `#167`
+- Live planning refresh: `owner:albatross` + `stream/review-burndown` query
 - Live backend formatter handoff: `#177`
 - Live QA smoke handoff: `#178`
 - Final evidence gate: `#11`
@@ -38,7 +38,7 @@ Sprint pivot dated 2026-03-16 now uses these anchors by default:
 3. Use `docs/PHASE1_ACCEPTANCE_TRACE.md` to map the checkpoint back to the epic acceptance area and evidence expectation it is meant to close.
 4. Run the metadata hygiene queries and clear any missing milestone or priority gaps before posting the checkpoint.
 5. Use `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, and `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` for dated runtime evidence context instead of copying those volatile notes into this guide.
-6. Run the same-day planning sweep from issue #167 or the `owner:albatross` + `stream/review-burndown` query before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a live GitHub trail.
+6. Run the same-day planning sweep from the `owner:albatross` + `stream/review-burndown` query before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a live GitHub trail.
 7. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
 8. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
 9. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -8,8 +8,8 @@ This document keeps only the stable checkpoint structure and links to the live m
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
 | M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus verify/award contract adoption (planning review-burndown queue, PR #174, PR #133). |
-| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend publishes canonical smoke formatting and evidence (#177, PR #175). |
-| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Formatter-backed smoke pass, QA packet updates, and final issue #11 evidence handoff (#178, PR #172, issue #11). |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while reviewers reuse the canonical backend evidence block from merged PR #175 and keep new smoke output flowing into issue #11. |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | QA packet updates, active smoke-command follow-through on PR #172, and final issue #11 evidence handoff. |
 | M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
 
 ## Metadata hygiene queries
@@ -27,8 +27,8 @@ Sprint pivot dated 2026-03-16 now uses these anchors by default:
 
 - Closed runtime baseline: `#109`, `#110`, `#111`
 - Live planning refresh: `owner:albatross` + `stream/review-burndown` query
-- Live backend formatter handoff: `#177`
-- Live QA smoke handoff: `#178`
+- Merged backend evidence baseline: `PR #175`
+- Live smoke-command handoff: `PR #172`
 - Final evidence gate: `#11`
 
 ## Review routine

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -35,12 +35,13 @@ Sprint pivot dated 2026-03-16 now uses these anchors by default:
 
 1. Open milestone issue and PR links instead of editing status snapshots in-repo.
 2. Use labels such as `status/ready-next`, `status/in-review`, and owner labels to decide next merge or rebase action.
-3. Run the metadata hygiene queries and clear any missing milestone or priority gaps before posting the checkpoint.
-4. Use `docs/RUNTIME_EXECUTION_HANDOFF.md` and `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` for dated runtime evidence context instead of copying those volatile notes into this guide.
-5. Run the same-day planning sweep from issue #167 or the owner:`albatross` + `stream/review-burndown` query before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a live GitHub trail.
-6. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
-7. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
-8. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
+3. Use `docs/PHASE1_ACCEPTANCE_TRACE.md` to map the checkpoint back to the epic acceptance area and evidence expectation it is meant to close.
+4. Run the metadata hygiene queries and clear any missing milestone or priority gaps before posting the checkpoint.
+5. Use `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, and `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` for dated runtime evidence context instead of copying those volatile notes into this guide.
+6. Run the same-day planning sweep from issue #167 or the `owner:albatross` + `stream/review-burndown` query before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a live GitHub trail.
+7. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
+8. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
+9. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
 
 ## When to edit this file
 

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -93,6 +93,7 @@ Ship the first usable agent dispatch loop for closed beta:
 
 ## Definition of Done
 
+- `docs/PHASE1_ACCEPTANCE_TRACE.md` remains the canonical acceptance-to-evidence map for epic #2 and milestone reviews.
 - OpenSpec change remains valid and synchronized with implementation.
 - API draft and TypeScript contracts are consistent for `AgentBundle`, `TaskSpec`, `Bid`, `ProofPack`.
 - Implementation-scoped issues are closed only when runtime code or executable test coverage is merged.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -58,6 +58,7 @@ Exit criteria:
 - End-to-end scenario passes: publish task -> commit -> reveal -> verify -> award.
 - All critical state transitions produce audit events.
 - Beta guardrails for auth, secrets, and sensitive data handling are documented and owned.
+- Epic acceptance reviews use `docs/PHASE1_ACCEPTANCE_TRACE.md` so each milestone closes against executable evidence instead of doc-only status claims.
 
 ## Current Sprint Pivot (2026-03-16 to 2026-03-27)
 
@@ -114,6 +115,7 @@ Scope:
 
 Checkpoint status board:
 - Review `docs/PHASE1_CHECKPOINT_BOARD.md` for milestone links, target owners, and checkpoint review prompts.
+- Use `docs/PHASE1_ACCEPTANCE_TRACE.md` to decide which acceptance area the current milestone evidence is supposed to satisfy.
 - Use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` when posting the weekly epic #2 checkpoint so the comment keeps the same Done/Blocked/Ready next/Validation evidence gaps shape plus owner handoff table.
 
 ## Phase 1 KPIs

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -9,6 +9,7 @@
 - [x] 0.7 收敛 `docs/issues/PHASE1_ISSUES.md` 与 `docs/PHASE1_CHECKPOINT_BOARD.md` 为稳定索引，改用 GitHub 查询承载高频 issue / PR 状态。
 - [x] 0.8 输出 `docs/MVP_STATE_MODEL.md`，冻结 MVP 状态机与关键写入时序约束。
 - [x] 0.9 输出 `docs/MERGE_TRAIN_PLAYBOOK.md`，统一 clean LGTM merge train、dirty queue 回写与 rebase 协作流程。
+- [x] 0.10 输出 `docs/PHASE1_ACCEPTANCE_TRACE.md`，把 epic #2 的验收项、里程碑 handoff 与证据要求收敛为稳定索引，避免把高频队列状态写回仓库文档。
 
 ## 1. OpenSpec 基础落地
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: add one durable Phase 1 acceptance-to-evidence trace for epic #2 and checkpoint reviews

## What Changed

- added `docs/PHASE1_ACCEPTANCE_TRACE.md` to map the Phase 1 epic acceptance areas to stable source docs, owner issues, milestone handoff questions, and required evidence
- linked the new acceptance trace from `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` so milestone reviews reuse one evidence contract instead of drifting into status snapshots
- updated `openspec/changes/agent-dispatch-platform/tasks.md` to record the new planning baseline artifact in the OpenSpec task ledger

## Why

- epic #2 still needs one durable place that says what evidence actually closes each acceptance area
- the roadmap/checkpoint docs already point reviewers toward milestone links and evidence handoff docs, but they did not have one shared acceptance map tying those pieces back to the epic exit criteria
- this keeps planning reviews focused on executable evidence and reduces the temptation to copy volatile queue state back into repo docs

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Epic acceptance reviews stay grounded in stable docs instead of volatile PR snapshots | `docs/PHASE1_ACCEPTANCE_TRACE.md` now maps each acceptance area to stable docs, delivery issues, and required evidence | `docs/PHASE1_ACCEPTANCE_TRACE.md` |
| Phase 1 milestone/checkpoint reviews use one reusable evidence contract | `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` now point reviewers at the same acceptance trace during milestone and checkpoint reviews | `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, `docs/PHASE1_CHECKPOINT_BOARD.md` |
| OpenSpec planning artifacts stay synchronized with the new planning baseline | the OpenSpec task list records the new acceptance-trace artifact as completed planning baseline work | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- clean worktree on `codex/issue-2-epic-acceptance-trace`
- git identity bootstrapped for `albatross-dev-agent`

### Steps

1. Review the new acceptance trace document for epic acceptance areas, delivery threads, and evidence expectations.
2. Verify the roadmap/goals/checkpoint docs now reference that same trace during milestone reviews.
3. Run the OpenSpec validation and repo diff/pre-push checks.

### Expected Results

- the repo has one durable acceptance-to-evidence map for epic #2
- milestone/checkpoint docs point to the same acceptance trace instead of requiring status duplication
- OpenSpec validation and pre-push checks pass on the branch

### Validation Output

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ git diff --check
<no output>

$ bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent
[ok] Branch 'codex/issue-2-epic-acceptance-trace' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - reviewers may want a different split between stable acceptance guidance and the weekly checkpoint template
- Rollback:
  - revert commit `0e5d00e` to remove the acceptance trace and linked references

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
