### PR TITLE
[P1-11] Add QA packet snippets for issue #11

### DIFF
--- a/docs/BACKEND_API_EXAMPLE_PACKET.md
+++ b/docs/BACKEND_API_EXAMPLE_PACKET.md
@@ -9,11 +9,14 @@ backend-owned request/response reference for QA, beta consumers, and issue
 - Runtime command: `npm run smoke:dispatch`
 - Runtime implementation: `src/runtime/dispatch-smoke.js`
 - API contracts: `src/api/openapi.yaml`, `src/api/contracts.ts`
+- Final issue-evidence handoff: `npm run --silent smoke:issue11 -- --signature <agent-name>`
 - Final E2E aggregation thread: issue [#11](https://github.com/jckhang/agent-indeed/issues/11)
 
 The examples below use the deterministic IDs and payload shapes exercised by the local
 runtime smoke flow. They are meant to be copied as canonical examples, not treated as
-new contract definitions.
+new contract definitions. The `smoke:issue11` formatter remains the single runnable
+evidence command; this packet only covers request/response and minimal Node `fetch`
+usage that the evidence output references.
 
 ## Happy path packet
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: align the issue #11 QA packet doc with the canonical `smoke:issue11` evidence flow without changing runtime behavior or published API contracts

## What Changed

- updated `docs/BACKEND_API_EXAMPLE_PACKET.md` to add the canonical `npm run --silent smoke:issue11 -- --signature <agent-name>` handoff entry alongside the existing runtime/API source-of-truth links
- clarified that the packet remains a request/response and minimal `fetch` reference, while `smoke:issue11` is the single runnable evidence command reviewers should post back to issue #11
- kept the packet explicitly scoped to merged `main` behavior so downstream consumers do not treat it as a new contract surface

## Why

- the open blocker on this PR was accurate: the current diff is doc-only, but the prior PR body/QA section still described earlier runtime/test work that is no longer on the branch
- narrowing the PR narrative to the live diff makes review auditable again and keeps issue #11 consumers pointed at one canonical evidence command

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| QA/beta consumers can find the canonical runnable evidence path | the packet now links the final `smoke:issue11` handoff directly from the source-of-truth section | `docs/BACKEND_API_EXAMPLE_PACKET.md` |
| The packet stays contract-safe and does not imply new API/runtime behavior | the doc now states that `smoke:issue11` is the runnable evidence path and the packet is only a request/response + `fetch` reference on top of merged `main` behavior | `docs/BACKEND_API_EXAMPLE_PACKET.md` |

## QA Plan

### Preconditions

- repo checked out on `codex/p1-11-qa-api-packet`

### Steps

1. Open `docs/BACKEND_API_EXAMPLE_PACKET.md`.
2. Confirm the source-of-truth section now lists `npm run --silent smoke:issue11 -- --signature <agent-name>`.
3. Confirm the intro text says the packet is a reference for payloads / `fetch` usage and not the runnable evidence command.

### Expected Results

- reviewers can see one canonical runnable evidence command for issue #11
- the PR description matches the actual docs-only diff on this branch

### Validation Output

- `git diff --check origin/main..HEAD -- docs/BACKEND_API_EXAMPLE_PACKET.md`
```text
<no output>
```

## Risks and Rollback

- Risk:
  - the packet could drift again if future PRs update the evidence handoff without updating this source-of-truth note in the same change
- Rollback:
  - revert this PR to restore the previous packet wording

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
