### PR TITLE
docs: refresh runtime handoff baseline

### DIFF
--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -17,18 +17,20 @@ Ship the first usable agent dispatch loop for closed beta:
 
 - The runtime pivot delivered its baseline implementation threads and now moves into evidence and planning cleanup.
 - Runtime cutline decisions for open contract PRs live in `docs/RUNTIME_CUTLINE_2026-03-16.md`; use that table to decide which deltas block follow-through versus which are additive-safe.
-- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when issue #177, issue #178, or issue #11 claims executable progress.
+- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when PR #191, PR #182, PR #172, or issue #11 claims executable progress.
+- Architecture coordination for the 2026-03-17 to 2026-03-20 unblocker window lives in `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` and issue #137.
 - Closed baseline issues from the pivot:
   - #109 backend runtime skeleton
   - #110 runnable dispatch vertical slice
   - #111 executable QA smoke/E2E checks
 - Active follow-through threads for the pivot:
-  - #167 planning-doc refresh to the post-runtime baseline
-  - #177 canonical backend smoke formatter and evidence block
-  - #178 formatter-backed smoke pass that feeds issue #11
+  - `owner:albatross` + `stream/review-burndown` query for the planning/doc cleanup sweep
+  - PR #191 canonical backend evidence path for issue #11
+  - PR #182 smoke CLI coverage for the replayable command contract
+  - PR #172 QA packet snippets that reuse the same issue #11 evidence lane
 - Planning-only follow-ups (#106, #107, #108) were closed to keep sprint bandwidth on runtime delivery.
 - QA prewrite-only tracks (#87, PR #84, PR #104) remain superseded by the executable evidence path on issue #11.
-- Closed issue #120 is a dated QA sweep baseline, not an active blocker.
+- Closed issue #120 remains a dated QA sweep baseline documented in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, not an active blocker.
 
 ## In Scope
 
@@ -82,7 +84,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Audit visibility console baseline is captured in `docs/AUDIT_VISIBILITY_CONSOLE_BASELINE.md` so timeline, failure-translation, and missing-field acceptance criteria stay reviewable while audit query and award-read contracts are still backend follow-ups.
 - Operator audit timeline baseline is captured in `docs/OPERATOR_AUDIT_TIMELINE_BASELINE.md` so chronological event rendering, failure translation, and missing-field alerts are reviewed as explicit Phase 1 audit acceptance criteria.
 - Downstream implementation handoff for telemetry owners, contract gaps, and M4 checks is tracked in `docs/MVP_TELEMETRY_HANDOFF.md`.
-- Audit/verification outputs must be exercised by executable smoke assertions that ultimately feed issue #11.
+- Audit/verification outputs must be exercised by executable smoke assertions that ultimately feed issue #11, with `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` serving only as the dated QA baseline.
 
 ## Out of Scope (Phase 1)
 

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -17,7 +17,7 @@ Ship the first usable agent dispatch loop for closed beta:
 
 - The runtime pivot delivered its baseline implementation threads and now moves into evidence and planning cleanup.
 - Runtime cutline decisions for open contract PRs live in `docs/RUNTIME_CUTLINE_2026-03-16.md`; use that table to decide which deltas block follow-through versus which are additive-safe.
-- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when PR #191, PR #182, PR #172, or issue #11 claims executable progress.
+- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when PR #191, PR #182, PR #172, or issue #11 claims executable progress, with merged PR #175 as the backend evidence baseline.
 - Architecture coordination for the 2026-03-17 to 2026-03-20 unblocker window lives in `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` and issue #137.
 - Closed baseline issues from the pivot:
   - #109 backend runtime skeleton
@@ -25,9 +25,10 @@ Ship the first usable agent dispatch loop for closed beta:
   - #111 executable QA smoke/E2E checks
 - Active follow-through threads for the pivot:
   - `owner:albatross` + `stream/review-burndown` query for the planning/doc cleanup sweep
+  - merged PR #175 as the canonical backend evidence baseline
   - PR #191 canonical backend evidence path for issue #11
   - PR #182 smoke CLI coverage for the replayable command contract
-  - PR #172 QA packet snippets that reuse the same issue #11 evidence lane
+  - PR #172 plus issue #11 for the live smoke-command follow-through and signed evidence handoff
 - Planning-only follow-ups (#106, #107, #108) were closed to keep sprint bandwidth on runtime delivery.
 - QA prewrite-only tracks (#87, PR #84, PR #104) remain superseded by the executable evidence path on issue #11.
 - Closed issue #120 remains a dated QA sweep baseline documented in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, not an active blocker.
@@ -100,7 +101,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Implementation-scoped issues are closed only when runtime code or executable test coverage is merged.
 - End-to-end happy path + key negative paths are covered by automated tests.
 - One local command path can run service + smoke checks for happy path and core negatives.
-- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md` and the active formatter/smoke follow-through threads.
+- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`, with merged PR #175 as the baseline evidence format and PR #172 as the live QA handoff.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Weekly epic #2 checkpoints use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so owner handoffs and validation-evidence gaps stay consistent across review weeks.

--- a/docs/RUNTIME_CUTLINE_2026-03-16.md
+++ b/docs/RUNTIME_CUTLINE_2026-03-16.md
@@ -2,11 +2,11 @@
 
 This cutline defines which current contract-convergence deltas block runtime work now versus which ones are additive-safe follow-ups for the current execution pivot.
 
-Primary runtime threads:
+Primary runtime threads at the time of the pivot:
 
-- issue #109: runnable control-plane backend skeleton
-- issue #110: runnable `publish -> match -> commit -> reveal -> verify -> award` vertical slice
-- issue #111: executable smoke/E2E conversion using the command/evidence contract in `docs/RUNTIME_EXECUTION_HANDOFF.md`
+- issue #109: runnable control-plane backend skeleton (now merged baseline)
+- issue #110: runnable `publish -> match -> commit -> reveal -> verify -> award` vertical slice (now merged baseline)
+- issue #111: executable smoke/E2E conversion using the command/evidence contract in `docs/RUNTIME_EXECUTION_HANDOFF.md` (now handed off to issue #11, with `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` as the dated QA baseline)
 
 Reference contract threads:
 

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -1,29 +1,29 @@
 # Runtime Execution Handoff
 
 This document defines the planning-side handoff contract for the runtime-first sprint.
-It keeps issue #109, issue #110, issue #111, and the blocked final E2E thread in issue
-#11 aligned on one executable delivery path instead of four separate definitions of
-"done."
+It keeps the merged runtime baseline from issues #109/#110/#111 plus the live evidence
+thread in issue #11 plus the dated QA drift sweep baseline in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` aligned on one executable delivery path instead of
+splitting "done" across stale planning snapshots.
 
 ## Scope
 
-- issue #109: land a runnable control-plane skeleton with one documented local service
-  command
-- issue #110: wire the `publish -> match -> commit -> reveal -> verify -> award`
-  vertical slice against persisted state
-- issue #111: convert the existing smoke/E2E matrices into executable assertions
+- merged runtime baseline from issue #109: runnable control-plane skeleton with one
+  documented local service command
+- merged runtime baseline from issue #110: `publish -> match -> commit -> reveal ->`
+  `verify -> award` vertical slice against persisted state
+- merged QA baseline from issue #111: executable smoke/E2E contract expectations now
+  handed off to the live evidence queue
+- `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`: dated QA drift/smoke baseline for the merged runtime contract
 - issue #11: collect the final happy-path plus negative-path evidence needed for beta
   sign-off
 
 This handoff does not replace implementation docs inside runtime PRs. It defines the
-minimum evidence and command contract those PRs must publish before the sprint can claim
-an executable path.
+minimum evidence and command contract the live evidence threads must publish before the
+sprint can claim an executable path.
 
 ## Required command contract
 
-Before issue #109, issue #110, or issue #111 can be closed, the owning PR set must
-publish one reproducible local command path with the exact commands, required env vars,
-and fixture/reset assumptions.
+Before issue #11 or a runtime follow-up PR claims runnable progress, the owning PR or issue update must publish one reproducible local command path with the exact commands, required env vars, and fixture/reset assumptions.
 
 The command path must include:
 
@@ -73,9 +73,7 @@ Minimum evidence:
   - proof verification fail
   - award blocked after failed proof or missing prerequisite
 
-Issue #11 remains the aggregation point for final beta-readiness evidence. Runtime PRs
-should link their evidence there rather than duplicating large transcripts across multiple
-planning docs.
+Issue #11 remains the aggregation point for final beta-readiness evidence. `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` can anchor dated drift expectations, but live transcripts should stay on issue #11 rather than being duplicated across multiple planning docs.
 
 The backend-owned reusable API packet for that final handoff lives in
 `docs/BACKEND_API_EXAMPLE_PACKET.md`; issue #11 and future QA runs should point at that
@@ -85,7 +83,7 @@ doc instead of reconstructing payloads from PR review threads.
 
 | Lane | Required handoff output | Consumes from |
 | --- | --- | --- |
-| Planning (`owner:albatross`) | keeps this command/evidence contract current; checks that epic docs only claim executable progress when a real command path exists | issue #109, issue #110, issue #111 PR bodies and comments |
+| Planning (`owner:albatross`) | keeps this command/evidence contract current; checks that epic docs only claim executable progress when a real command path exists | merged runtime baseline docs, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, and issue #11 evidence comments |
 | Backend/runtime | publishes the service/reset/smoke commands and request/response fixtures | merged contracts, `docs/RUNTIME_CUTLINE_2026-03-16.md` |
 | QA | converts the published command path into repeatable smoke/E2E execution and posts the signed evidence back to issue #11 | backend PR outputs, `docs/ERROR_CODE_RETRY_POLICY.md`, security readiness docs |
 
@@ -93,15 +91,15 @@ If a runtime PR can only show partial write-path progress, it should say exactly
 segment is runnable and which segment is still blocked by contract or implementation gaps.
 Planning docs must not compress partial evidence into "E2E ready."
 
-## Scenario matrix for the first executable tranche
+## Scenario matrix for the live evidence tranche
 
 | Scenario | Primary owner | Minimum proof before calling it done |
 | --- | --- | --- |
-| Happy path | issue #109 + issue #110 owners | One local run reaches `TASK_AWARDED` and emits the canonical audit events |
-| Reveal without commit | issue #110 owner | Command/assertion shows the stable rejection and error code |
-| Invalid signature or auth failure | issue #109 owner | Command/assertion shows write rejection before state mutation |
-| Proof FAIL path | issue #110 + issue #111 owners | Verify step returns the published terminal failure vocabulary and award remains blocked |
-| Audit evidence replay | issue #111 owner | Smoke run captures the event trail or trace identifiers needed for issue #11 evidence |
+| Happy path | issue #11 owner + latest backend runtime PR | One local run reaches `TASK_AWARDED` and emits the canonical audit events |
+| Reveal without commit | latest runtime follow-up owner | Command/assertion shows the stable rejection and error code |
+| Invalid signature or auth failure | latest runtime follow-up owner | Command/assertion shows write rejection before state mutation |
+| Proof FAIL path | QA owner + latest runtime follow-up owner | Verify step returns the published terminal failure vocabulary and award remains blocked |
+| Audit evidence replay | QA owner | Smoke run captures the event trail or trace identifiers needed for issue #11 evidence |
 
 ## Review rule
 

--- a/docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md
+++ b/docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md
@@ -9,7 +9,7 @@ This dated control note is the architecture lane's working contract for the 2026
 - Prefer runnable output over new design-only expansion.
 - Treat review comments asking for literal validation output as blocking until the command output is posted in the PR thread or template.
 - Keep runtime behavior behind the published OpenSpec/OpenAPI/contracts baseline; if runtime moves first, the PR is dirty until the contract set catches up.
-- Leave superseded planning-only threads closed unless they unblock one of `#115`, `#127`, `#129`, or `#111`.
+- Leave superseded planning-only threads closed unless they unblock one of `#115`, `#127`, `#129`, or issue #11.
 
 ## Lane unblocker ledger
 
@@ -20,7 +20,7 @@ This dated control note is the architecture lane's working contract for the 2026
 | Backend | closed [#110](https://github.com/jckhang/agent-indeed/issues/110) follow-through | Land the publish -> match -> commit -> reveal -> verify -> award runtime path cleanly on top of merged `main` | [PR #127](https://github.com/jckhang/agent-indeed/pull/127) merged on 2026-03-17 at 13:54:46Z, so this lane is no longer a live blocker unless a new runtime regression appears | kestrel |
 | Backend contract sync | closed [#110](https://github.com/jckhang/agent-indeed/issues/110) follow-through | Keep runtime adoption notes aligned with merged verify/award contracts | [PR #133](https://github.com/jckhang/agent-indeed/pull/133) is mergeable again, but the verify/award checklist still needs one more doc alignment pass that points reviewers at the published reason-code and error-code enums before it can be treated as queue-ready | albatross-dev-agent |
 | Frontend | closed [#136](https://github.com/jckhang/agent-indeed/issues/136) follow-through | Keep frontend runtime docs scoped to the merged runtime/API baseline | [PR #139](https://github.com/jckhang/agent-indeed/pull/139) merged on 2026-03-17 at 08:40Z, so the frontend lane is no longer an active blocker until a new runtime follow-on opens | lanzhou-fe-agent |
-| QA | [#120](https://github.com/jckhang/agent-indeed/issues/120) / [#111](https://github.com/jckhang/agent-indeed/issues/111) | Turn smoke/E2E notes into executable checks against the real runtime | QA cannot close the weekly sweep until merged [PR #127](https://github.com/jckhang/agent-indeed/pull/127) is complemented by [PR #129](https://github.com/jckhang/agent-indeed/pull/129) and issue #111 turns the local command path into posted executable evidence | avery |
+| QA | closed [#120](https://github.com/jckhang/agent-indeed/issues/120) baseline + [#11](https://github.com/jckhang/agent-indeed/issues/11) | Turn smoke/E2E notes into executable checks against the merged runtime and post durable evidence | QA now treats `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` as the dated contract-drift baseline, while issue #11 carries the live signed command/evidence trail needed to close the weekly sweep | avery |
 
 ## Design-only and deferred queue control
 
@@ -40,6 +40,6 @@ This dated control note is the architecture lane's working contract for the 2026
 When posting the 2026-03-20 checkpoint on epic [#2](https://github.com/jckhang/agent-indeed/issues/2), cover these buckets:
 
 - Done: merged runtime/bootstrap/frontend slices that changed the executable baseline
-- Blocked: `#111`, `#133`, and any PR still carrying stale blocker snapshots or unresolved doc/contract drift
+- Blocked: issue #11 follow-through, `#133`, and any PR still carrying stale blocker snapshots or unresolved doc/contract drift
 - Ready next: one executable next step for frontend, backend, and QA
 - Validation evidence gaps: every open runtime PR whose review thread still asks for pasted command output (PR #129 is no longer in that bucket)

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -52,3 +52,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.15 刷新 runtime handoff / cutline / Phase 1 goal 文档，把已合并的 #109/#110/#111 归档为 merged baseline，并把后续可执行证据责任收敛到 issue #11 与 `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Refresh runtime handoff docs to treat #109/#110/#111 as merged baseline and point live evidence follow-through at #11/#120

## What Changed

- refreshed `docs/RUNTIME_EXECUTION_HANDOFF.md` so the runtime handoff contract now treats issues #109/#110/#111 as the merged baseline and moves live evidence ownership to issue #11 and issue #120
- updated `docs/RUNTIME_CUTLINE_2026-03-16.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`, and `docs/PHASE1_GOALS.md` so they stop describing closed runtime issues as active delivery threads
- added OpenSpec task ledger item `5.12` in `openspec/changes/agent-dispatch-platform/tasks.md` to keep the planning/spec record aligned with the docs refresh

## Why

- issue #2 review docs were still describing the closed runtime implementation issues as current execution threads, which made the Phase 1 rollout look like work was still pending in issues that already landed
- epic checkpointing and QA evidence now run through issue #11 and issue #120, so the planning docs need to anchor to that post-runtime baseline instead of the pre-merge queue snapshot

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Phase 1 runtime handoff docs reflect the current merged baseline instead of stale closed-issue status | Rewords the handoff, cutline, unblocker-control, and goals docs to treat #109/#110/#111 as merged baseline and route live executable evidence through issue #11 / issue #120 | `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/RUNTIME_CUTLINE_2026-03-16.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`, `docs/PHASE1_GOALS.md` |
| OpenSpec-first workflow stays in sync with the docs-only epic refresh | Adds task ledger item `5.12` recording the runtime-baseline refresh in the active change set | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Repo is on branch `codex/issue-2-runtime-handoff-baseline`
- OpenSpec CLI is available in the workspace

### Steps

1. Review the updated runtime handoff/cutline/goals docs for references to active runtime evidence threads.
2. Run `openspec validate --all`.
3. Run `git diff --check` and `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`.

### Expected Results

- The docs describe #109/#110/#111 as merged baseline work, not active delivery threads.
- Live evidence ownership points to issue #11 / issue #120.
- OpenSpec validation and pre-push checks pass cleanly.

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-runtime-handoff-baseline' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - These dated planning docs could drift again if later comments copy live queue state back into repo files instead of GitHub threads.
- Rollback:
  - Revert this PR to restore the prior wording, then re-open a narrower follow-up that only touches the specific stale doc section.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
