### PR TITLE
docs: codify planning reference rules

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,7 @@ Thanks for contributing. This repository is currently API/spec-first, so most ch
   - `docs/PHASE1_GOALS.md`
   - `docs/ROADMAP.md`
   - `docs/issues/PHASE1_ISSUES.md`
+  - `docs/PLANNING_REFERENCE_RULES.md`
   - Prefer GitHub issue links or milestone queries over copying live issue/PR status into repo docs.
 
 ## Branch and PR Flow
@@ -51,6 +52,7 @@ When planning-owner PRs or cross-lane dependency PRs pile up:
 2. Merge only the clean tranche first, in dependency-aware order.
 3. For dirty PRs, leave a signed blocker/rebase note on the PR thread instead of copying transient state into repo docs.
 4. Keep `docs/issues/PHASE1_ISSUES.md` and `docs/PHASE1_CHECKPOINT_BOARD.md` focused on durable links/structure, not day-to-day queue status.
+5. When a blocker thread closes but leaves behind a durable artifact, cite the surviving repo artifact path instead of continuing to describe the closed issue as active work.
 
 ## Multi-Agent Commit Identity Isolation
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Agent dispatch platform prototype.
 - Multi-agent git commit identity playbook: `docs/AGENT_IDENTITY.md`
 - Tech stack baseline: `docs/TECH_STACK.md`
 - MVP roadmap: `docs/ROADMAP.md`
+- Planning reference rules: `docs/PLANNING_REFERENCE_RULES.md`
 - Organization and member profiles: `docs/ORGANIZATION.md`
 - Architecture gap assessment: `docs/ARCHITECTURE_GAPS.md`
 - Error-code + retry baseline: `docs/ERROR_CODE_RETRY_POLICY.md`

--- a/docs/PLANNING_REFERENCE_RULES.md
+++ b/docs/PLANNING_REFERENCE_RULES.md
@@ -1,0 +1,55 @@
+# Planning Reference Rules
+
+Use this guide when updating roadmap, checkpoint, epic, merge-train, or QA handoff docs.
+
+## Goal
+
+Keep durable planning docs stable while GitHub issues, PRs, and review queues keep moving.
+
+## Source hierarchy
+
+1. Open issues and PRs are the source of truth for live execution state.
+2. Milestone, label, and owner queries are the source of truth for same-day queue views.
+3. Dated repo artifacts can preserve a closed review or QA snapshot when reviewers still need a stable baseline.
+4. Roadmaps, checkpoint guides, and epic rollups should summarize durable state only.
+
+## What counts as a live reference
+
+Use these for active blockers, ready-next work, and merge sequencing:
+
+- open issue links
+- open PR links
+- milestone queries
+- owner/label queries
+- current validation commands posted in a live PR or issue thread
+
+## What counts as a closed baseline
+
+Closed issues and merged PRs can still be cited, but only as one of these:
+
+- merged baseline
+- closed historical context
+- original delivery thread for a durable artifact that still exists in-repo
+
+When a closed thread leaves behind a durable artifact, prefer the artifact path over the closed issue number in ongoing planning docs.
+
+Examples:
+
+- cite `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` as the retained contract snapshot after the originating QA sweep issue closes
+- cite closed runtime implementation issues as merged baselines, not as active blockers
+
+## Repo doc rules
+
+- `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_EPIC_STATUS.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` should point to active work plus stable merged baselines.
+- `docs/MERGE_TRAIN_PLAYBOOK.md` should point queue state to GitHub sweeps and queries, not a closed umbrella issue.
+- `docs/issues/PHASE1_ISSUES.md` should catalog durable issue links and stable ownership structure, not same-day queue commentary.
+- Review-blocker details belong in PR comments, with signed replies and pasted validation output.
+
+## Quick check before commit
+
+Before you push a planning-doc change, confirm:
+
+- every issue or PR named as active work is still open
+- every closed issue is labeled as historical or merged baseline context
+- every dated repo artifact cited as current still exists on `main`
+- volatile queue sequencing stays in GitHub threads instead of repo docs


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: codify how planning docs should cite live work, closed baselines, and durable dated artifacts

## What Changed

- added `docs/PLANNING_REFERENCE_RULES.md` with a source hierarchy for live issues/PRs, milestone queries, and dated repo artifacts
- updated `CONTRIBUTING.md` so planning-doc edits explicitly review the new reference rules and stop treating closed blocker threads as active work
- linked the new playbook from `README.md` so planning contributors can find it from the project doc index

## Why

- recent planning PR review cycles repeatedly regressed on the same problem: closed issues were still described as active blockers, while durable dated artifacts and live GitHub queries were the real sources of truth
- a small repo-level rulebook reduces repeat review churn on epic #2 without touching product/API scope

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Planning docs use durable sources instead of stale queue snapshots | adds a dedicated rulebook that defines live references, closed baselines, and dated artifact usage | `docs/PLANNING_REFERENCE_RULES.md` |
| Contributors can apply the rule during routine doc updates | wires the rulebook into the contribution workflow and project doc index | `CONTRIBUTING.md`, `README.md` |

## QA Plan

### Preconditions

- repo is on the pushed branch `codex/issue-2-planning-reference-rules`

### Steps

1. Open `docs/PLANNING_REFERENCE_RULES.md` and verify the source hierarchy distinguishes live issues/PRs from closed baselines.
2. Open `CONTRIBUTING.md` and confirm planning-doc updates now review the new rulebook.
3. Run the validation commands listed below.

### Expected Results

- contributors have one durable document that explains when to cite open threads, GitHub queries, or dated repo artifacts
- contribution guidance points to that rulebook before planning-doc edits are pushed
- validation passes without OpenSpec drift or whitespace errors

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user jckhang`
```text
[ok] Branch 'codex/issue-2-planning-reference-rules' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (jckhang).
[ok] git user.email matches expected account (jckhang@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - contributors may treat the new doc as optional unless review comments reinforce it during planning PRs
- Rollback:
  - revert this PR to remove the new rulebook and the two index references

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
