### PR TITLE
[Week 2026-03-19] Add formatter-backed QA smoke evidence export

### DIFF
--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -75,6 +75,10 @@ planning docs.
 The backend-owned reusable API packet for that final handoff lives in
 `docs/BACKEND_API_EXAMPLE_PACKET.md`; issue #11 and future QA runs should point at that
 doc instead of reconstructing payloads from PR review threads.
+When QA needs the bounded runtime smoke result in issue-comment form, use
+`npm run smoke:dispatch:issue11` so the posted block includes the true command string,
+happy-path ids, audit event list, and negative-path reason codes without manual
+reformatting.
 
 ## Ownership handshake
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -89,6 +89,7 @@
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
    - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
+   - QA / runtime 侧补充 `npm run smoke:dispatch:issue11`，把同一 smoke summary 转成 issue comment 友好的 Markdown 块，并保留 happy-path ids、审计事件和负面 reason codes。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,6 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求 issue #146 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
+- 增补 `smoke:dispatch:issue11` 证据导出命令，把当前 runtime smoke 结果格式化成 issue #11 可直接粘贴的 QA 回写块。
 
 ## Capabilities
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -40,6 +40,7 @@
 - [x] 5.1 落地可运行 control-plane service skeleton（issue #109），包含健康检查、基础配置与最小持久化抽象。
 - [x] 5.2 打通可执行的 MVP 垂直路径（issue #110）：`publish -> match -> commit -> reveal -> verify -> award`，并持久化关键状态转移。
 - [ ] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
+- [x] 5.3.b 补充 `npm run smoke:dispatch:issue11` 证据导出命令，生成 issue #11 可直接粘贴的 smoke Markdown block。
 - [x] 5.3.a 增加 QA contract-drift 回归校验（issue #120），自动比对 OpenAPI / TypeScript proof reason-code 与当前 runtime 路由基线，减少 review 期间的手工枚举漂移。
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node src/runtime/server.js",
     "dev": "node --watch src/runtime/server.js",
     "smoke:dispatch": "node src/runtime/dispatch-smoke.js",
+    "smoke:dispatch:issue11": "node src/runtime/dispatch-smoke.js --issue11-comment",
     "smoke:bootstrap": "node src/runtime/bootstrap-smoke.js",
     "check:contract-drift": "node scripts/check-runtime-contract-drift.js --assert",
     "test": "node --test"

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -7,6 +7,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start the service: `npm start`
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
+- Render the issue-ready smoke evidence block for issue `#11`: `npm run smoke:dispatch:issue11`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
@@ -52,6 +53,14 @@ npm run smoke:dispatch
 ```
 
 The smoke command boots the runtime on ephemeral ports and runs three bounded scenarios: the happy path (`publish -> match -> commit -> reveal -> verify -> award`), an invalid-signature verification failure, and the minimum negative-path regression checks for `reveal without commit`, `proof FAIL`, and `award blocked`. It prints prefixed PASS lines for human review and a final JSON summary that QA can link back to issue `#11`.
+
+To render the same smoke evidence as a paste-ready Markdown block for issue `#11`, run:
+
+```bash
+npm run smoke:dispatch:issue11
+```
+
+That formatter keeps the actual invoked command, happy-path ids (`taskId`, `bidId`, `proofId`, `policyTraceId`, `awardAuditId`), audit event list, and negative-path reason codes in one reproducible block for QA handoff comments.
 
 Or run the bootstrap path end-to-end with one command:
 

--- a/src/runtime/dispatch-smoke.js
+++ b/src/runtime/dispatch-smoke.js
@@ -336,6 +336,7 @@ export async function runDispatchSmoke({ log = console.log } = {}) {
     return {
       taskId: created.taskId,
       bidId: reveal.bidId,
+      proofId: proof.proofId,
       awardAuditId: awarded.auditEventId,
       policyTraceId: policy.policyTraceId,
       verificationResult: verified.result,
@@ -527,6 +528,9 @@ async function runNegativeScenarioSuite({ log = console.log } = {}) {
     return {
       scenario: "negative-paths",
       taskId: created.taskId,
+      bidId: failingReveal.bidId,
+      proofId: failingProof.proofId,
+      policyTraceId: policy.policyTraceId,
       revealWithoutCommit: missingCommitResponse.code,
       proofFail: verifyResponse.code,
       awardBlocked: awardResponse.code,
@@ -535,7 +539,10 @@ async function runNegativeScenarioSuite({ log = console.log } = {}) {
   });
 }
 
-export async function runDispatchSmokeSuite({ log = console.log } = {}) {
+export async function runDispatchSmokeSuite({
+  log = console.log,
+  command = "npm run smoke:dispatch"
+} = {}) {
   const happyPath = await runDispatchSmoke({
     log: (line) => log(`[happy-path] ${line}`)
   });
@@ -548,14 +555,18 @@ export async function runDispatchSmokeSuite({ log = console.log } = {}) {
 
   return {
     status: "ok",
-    command: "npm run smoke:dispatch",
+    command,
     scenarios: [
       {
         name: "happy-path",
         status: "PASS",
         verificationResult: happyPath.verificationResult,
         taskId: happyPath.taskId,
-        bidId: happyPath.bidId
+        bidId: happyPath.bidId,
+        proofId: happyPath.proofId,
+        policyTraceId: happyPath.policyTraceId,
+        awardAuditId: happyPath.awardAuditId,
+        eventTypes: happyPath.eventTypes
       },
       {
         name: "invalid-signature",
@@ -571,15 +582,58 @@ export async function runDispatchSmokeSuite({ log = console.log } = {}) {
         revealWithoutCommit: negativePaths.revealWithoutCommit,
         proofFail: negativePaths.proofFail,
         awardBlocked: negativePaths.awardBlocked,
-        taskId: negativePaths.taskId
+        taskId: negativePaths.taskId,
+        bidId: negativePaths.bidId,
+        proofId: negativePaths.proofId,
+        policyTraceId: negativePaths.policyTraceId,
+        proofFailReasonCodes: negativePaths.proofFailReasonCodes
       }
     ]
   };
 }
 
+
+export function formatIssue11Comment(summary) {
+  const happyPath = summary.scenarios.find((scenario) => scenario.name === "happy-path");
+  const invalidSignature = summary.scenarios.find((scenario) => scenario.name === "invalid-signature");
+  const negativePaths = summary.scenarios.find((scenario) => scenario.name === "negative-paths");
+
+  return [
+    "Issue #11 executable smoke evidence",
+    "",
+    "Validation command:",
+    `- \`${summary.command}\``,
+    "",
+    "| Scenario | Status | Key evidence |",
+    "| --- | --- | --- |",
+    `| happy path | ${happyPath.status} | task \`${happyPath.taskId}\`, bid \`${happyPath.bidId}\`, proof \`${happyPath.proofId}\`, policy \`${happyPath.policyTraceId}\`, award audit \`${happyPath.awardAuditId}\` |`,
+    `| invalid signature | ${invalidSignature.status} | proof \`${invalidSignature.proofId}\`, result \`${invalidSignature.result}\`, reason codes \`${invalidSignature.reasonCodes.join("`, `")}\` |`,
+    `| negative paths | ${negativePaths.status} | reveal \`${negativePaths.revealWithoutCommit}\`, proof \`${negativePaths.proofFail}\`, award \`${negativePaths.awardBlocked}\`, reason codes \`${negativePaths.proofFailReasonCodes.join("`, `")}\` |`,
+    "",
+    "Happy-path audit events:",
+    ...happyPath.eventTypes.map((eventType) => `- \`${eventType}\``),
+    "",
+    "JSON summary:",
+    "```json",
+    JSON.stringify(summary, null, 2),
+    "```"
+  ].join("\n");
+}
+
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  runDispatchSmokeSuite()
+  const emitIssue11Comment = process.argv.includes("--issue11-comment");
+  const command = emitIssue11Comment
+    ? "npm run smoke:dispatch:issue11"
+    : "npm run smoke:dispatch";
+  const log = emitIssue11Comment ? () => {} : console.log;
+
+  runDispatchSmokeSuite({ command, log })
     .then((result) => {
+      if (emitIssue11Comment) {
+        console.log(formatIssue11Comment(result));
+        return;
+      }
+
       console.log(JSON.stringify(result, null, 2));
     })
     .catch((error) => {

--- a/test/runtime/dispatch-smoke.test.js
+++ b/test/runtime/dispatch-smoke.test.js
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { runDispatchSmoke, runDispatchSmokeSuite } from "../../src/runtime/dispatch-smoke.js";
+import {
+  formatIssue11Comment,
+  runDispatchSmoke,
+  runDispatchSmokeSuite
+} from "../../src/runtime/dispatch-smoke.js";
 
 test("runDispatchSmoke executes the publish to award flow", async () => {
   const logLines = [];
@@ -12,6 +16,9 @@ test("runDispatchSmoke executes the publish to award flow", async () => {
 
   assert.equal(result.taskId, "task_00000001");
   assert.equal(result.bidId, "bid_00000001");
+  assert.equal(result.proofId, "proof_00000001");
+  assert.equal(result.policyTraceId, "policytrace_00000001");
+  assert.equal(result.awardAuditId, "audit_00000005");
   assert.equal(result.verificationResult, "PASS");
   assert.deepEqual(result.eventTypes, [
     "TASK_CREATED",
@@ -53,10 +60,20 @@ test("runDispatchSmokeSuite executes happy-path and negative smoke scenarios", a
     result.scenarios.map((scenario) => scenario.status),
     ["PASS", "PASS", "PASS"]
   );
+  assert.equal(result.scenarios[0].proofId, "proof_00000001");
+  assert.equal(result.scenarios[0].policyTraceId, "policytrace_00000001");
+  assert.equal(result.scenarios[0].awardAuditId, "audit_00000005");
   assert.deepEqual(result.scenarios[1].reasonCodes, ["TRACE_SIGNATURE_INVALID"]);
   assert.equal(result.scenarios[2].revealWithoutCommit, "BID_REVEAL_COMMIT_NOT_FOUND");
   assert.equal(result.scenarios[2].proofFail, "PROOF_VERIFY_FAILED");
   assert.equal(result.scenarios[2].awardBlocked, "TASK_AWARD_PRECONDITION_FAILED");
+  assert.equal(result.scenarios[2].bidId, "bid_00000002");
+  assert.equal(result.scenarios[2].proofId, "proof_00000002");
+  assert.equal(result.scenarios[2].policyTraceId, "policytrace_00000001");
+  assert.deepEqual(result.scenarios[2].proofFailReasonCodes, [
+    "QUALITY_SCORE_BELOW_MINIMUM",
+    "HASHCASH_BITS_BELOW_MINIMUM"
+  ]);
   assert.ok(logLines.some((line) => line.includes("[happy-path] PASS task-awarded")));
   assert.ok(
     logLines.some((line) => line.includes("[invalid-signature] PASS invalid-signature-rejected"))
@@ -64,4 +81,19 @@ test("runDispatchSmokeSuite executes happy-path and negative smoke scenarios", a
   assert.ok(
     logLines.some((line) => line.includes("[negative-paths] PASS reveal-without-commit-rejected"))
   );
+});
+
+test("formatIssue11Comment renders a markdown-ready summary for issue 11", async () => {
+  const summary = await runDispatchSmokeSuite({
+    command: "npm run smoke:dispatch:issue11",
+    log: () => {}
+  });
+
+  const comment = formatIssue11Comment(summary);
+
+  assert.match(comment, /Issue #11 executable smoke evidence/);
+  assert.match(comment, /`npm run smoke:dispatch:issue11`/);
+  assert.match(comment, /task `task_00000001`, bid `bid_00000001`, proof `proof_00000001`/);
+  assert.match(comment, /reason codes `QUALITY_SCORE_BELOW_MINIMUM`, `HASHCASH_BITS_BELOW_MINIMUM`/);
+  assert.match(comment, /"awardAuditId": "audit_00000005"/);
 });


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #178; refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: add one formatter-backed smoke evidence export so Avery can rerun the bounded runtime pass and paste the result into issue #11 without manual reformatting

## What Changed

- added `npm run smoke:dispatch:issue11`, which runs the bounded dispatch smoke suite and renders a Markdown-ready issue comment for issue #11
- extended `src/runtime/dispatch-smoke.js` to carry stable happy-path ids (`taskId`, `bidId`, `proofId`, `policyTraceId`, `awardAuditId`), negative-path reason codes, and audit event names in the smoke summary
- added regression coverage for the exported summary/formatter and documented the new handoff command in the runtime README plus runtime/OpenSpec handoff notes

## Why

- issue #178 asks QA to reuse the canonical smoke formatter output, run the bounded smoke pass against the merged runtime baseline, and post pass/fail evidence into issue #11
- `main` already had the runnable smoke suite, but QA still had to hand-format the result block for issue comments; this PR makes that handoff reproducible in one command

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| QA posts one reproducible smoke result block that references the merged runtime baseline | `npm run smoke:dispatch:issue11` emits a paste-ready Markdown block from the current runtime smoke suite | `package.json`, `src/runtime/dispatch-smoke.js`, `test/runtime/dispatch-smoke.test.js` |
| Issue #11 either moves off blocked or names the exact blocker with owner | the exported block captures happy-path ids, audit events, and negative-path reason codes so the issue comment can point at concrete runtime evidence instead of freehand notes | `src/runtime/dispatch-smoke.js`, `docs/RUNTIME_EXECUTION_HANDOFF.md` |
| The update distinguishes happy-path success from negative-path gaps | the formatter reports separate rows for happy path, invalid signature, and negative paths, with stable PASS/error vocabulary | `src/runtime/dispatch-smoke.js`, `npm run smoke:dispatch:issue11` output |

## QA Plan

### Preconditions

- Use a clean checkout of `codex/p1-178-qa-smoke-evidence` on top of the latest `origin/main`.
- Node.js 20+ and the OpenSpec CLI are available locally.

### Steps

1. Run `npm test`.
2. Run `npm run smoke:dispatch:issue11`.
3. Run `openspec validate --all`.
4. Run `git diff --check`.
5. Run `bash scripts/agent_prepush_check.sh --github-user avery-chen`.

### Expected Results

- the smoke suite and new formatter test pass
- the issue-ready command prints only the Markdown evidence block with happy-path ids, audit events, and negative-path reason codes
- OpenSpec validation and pre-push checks pass cleanly on the branch

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `npm test`
```text
> test
> node --test

✔ runtime contract drift guard keeps OpenAPI and contracts aligned (11.868875ms)
✔ healthz and readyz return runtime status (21.734958ms)
✔ POST /v1/tasks persists a task and updates runtime summary (9.285333ms)
✔ POST /v1/tasks rejects requests without a workspace header (1.709333ms)
✔ GET /v1/tasks/:taskId returns the persisted task payload (4.115041ms)
✔ GET /v1/tasks/:taskId returns 404 for unknown ids (1.363875ms)
✔ dispatch vertical slice publishes, matches, bids, verifies, awards, and exposes audit trails (30.798792ms)
✔ invalid signature, reveal without a commit, and failed verification return stable errors (9.599292ms)
✔ unknown routes are logged as 404s (0.923667ms)
✔ GET /v1/bids/:bidId/events rejects bid ids shorter than the published contract (0.801041ms)
✔ bid/proof status routes return 404 when the task-scoped projection does not exist (1.39775ms)
✔ bootstrap smoke command exercises the local runtime bootstrap path (27.474334ms)
✔ loadRuntimeConfig applies defaults for local runtime bootstrap (1.458792ms)
✔ loadRuntimeConfig rejects invalid ports (0.231958ms)
✔ loadRuntimeConfig rejects blank host and service names (0.084708ms)
✔ runDispatchSmoke executes the publish to award flow (33.368208ms)
✔ runDispatchSmokeSuite executes happy-path and negative smoke scenarios (37.140625ms)
✔ formatIssue11Comment renders a markdown-ready summary for issue 11 (14.942542ms)
✔ store assigns deterministic ids across the dispatch lifecycle (2.921833ms)
ℹ tests 19
ℹ suites 0
ℹ pass 19
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 271.181375
```
- `npm run smoke:dispatch:issue11`
```text
> smoke:dispatch:issue11
> node src/runtime/dispatch-smoke.js --issue11-comment

Issue #11 executable smoke evidence

Validation command:
- `npm run smoke:dispatch:issue11`

| Scenario | Status | Key evidence |
| --- | --- | --- |
| happy path | PASS | task `task_00000001`, bid `bid_00000001`, proof `proof_00000001`, policy `policytrace_00000001`, award audit `audit_00000005` |
| invalid signature | PASS | proof `proof_00000011`, result `PROOF_VERIFY_FAILED`, reason codes `TRACE_SIGNATURE_INVALID` |
| negative paths | PASS | reveal `BID_REVEAL_COMMIT_NOT_FOUND`, proof `PROOF_VERIFY_FAILED`, award `TASK_AWARD_PRECONDITION_FAILED`, reason codes `QUALITY_SCORE_BELOW_MINIMUM`, `HASHCASH_BITS_BELOW_MINIMUM` |

Happy-path audit events:
- `TASK_CREATED`
- `BID_COMMITTED`
- `BID_REVEALED`
- `POMW_VERIFIED`
- `TASK_AWARDED`

JSON summary:
~~~json
{
  "status": "ok",
  "command": "npm run smoke:dispatch:issue11",
  "scenarios": [
    {
      "name": "happy-path",
      "status": "PASS",
      "verificationResult": "PASS",
      "taskId": "task_00000001",
      "bidId": "bid_00000001",
      "proofId": "proof_00000001",
      "policyTraceId": "policytrace_00000001",
      "awardAuditId": "audit_00000005",
      "eventTypes": [
        "TASK_CREATED",
        "BID_COMMITTED",
        "BID_REVEALED",
        "POMW_VERIFIED",
        "TASK_AWARDED"
      ]
    },
    {
      "name": "invalid-signature",
      "status": "PASS",
      "result": "PROOF_VERIFY_FAILED",
      "reasonCodes": [
        "TRACE_SIGNATURE_INVALID"
      ],
      "taskId": "task_00000001",
      "proofId": "proof_00000011"
    },
    {
      "name": "negative-paths",
      "status": "PASS",
      "revealWithoutCommit": "BID_REVEAL_COMMIT_NOT_FOUND",
      "proofFail": "PROOF_VERIFY_FAILED",
      "awardBlocked": "TASK_AWARD_PRECONDITION_FAILED",
      "taskId": "task_00000001",
      "bidId": "bid_00000002",
      "proofId": "proof_00000002",
      "policyTraceId": "policytrace_00000001",
      "proofFailReasonCodes": [
        "QUALITY_SCORE_BELOW_MINIMUM",
        "HASHCASH_BITS_BELOW_MINIMUM"
      ]
    }
  ]
}
~~~
```
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/p1-178-qa-smoke-evidence' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - the exported issue block could drift if the smoke summary shape changes without updating the formatter/test in the same PR
- Rollback:
  - revert commit `e611f66` to drop the formatter command and docs updates

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
