### PR TITLE
docs: refresh planning sweep evidence links

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -9,7 +9,7 @@ reviewable release gates for closed-beta readiness. It complements:
 - `docs/ROADMAP.md` for phase checkpoints and milestone dates
 - `docs/PHASE1_EPIC_STATUS.md` for the current issue/PR rollup
 - `docs/RUNTIME_CUTLINE_2026-03-16.md` for the runtime-start cutline on open contract deltas
-- `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` for the dated owner/blocker ledger during the 2026-03-20 push
+- the live planning sweep query plus issue #11 for same-day blocker/evidence handoff instead of closed historical sweep issues
 
 ## Gate Summary
 
@@ -19,7 +19,7 @@ reviewable release gates for closed-beta readiness. It complements:
 | Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | issue #115, merged PR #129, merged PR #127 baseline, issue #111, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
 | Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #120, issue #111, issue #11, merged PR #127 baseline, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
 | Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | merged PR #127, merged PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | issue #137, PR #140, PR #141, issue #115, PR #129, issue #120, issue #111, issue #11 | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`, milestone/label queries stay aligned |
+| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | issue #137, issue #115, issue #111, issue #11, current `owner:albatross` + `stream/review-burndown` planning sweep issue | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
 
 ## Gate Details
 
@@ -38,7 +38,7 @@ Release note: if any active runtime branch changes enum names, required fields, 
 
 Happy-path readiness is runtime-first, not docs-first.
 
-While this gate remains blocked until the runnable flow exists, the runtime threads do not have to wait for every historical contract branch. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md` to separate true blockers from additive-safe follow-ups.
+While this gate remains blocked until the runnable flow exists, the runtime threads do not have to wait for every historical contract branch. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus the current planning sweep / issue #11 evidence threads to separate true blockers from additive-safe follow-ups.
 
 Required outcome:
 
@@ -84,8 +84,8 @@ At minimum, these must stay in lockstep:
 - `docs/PHASE1_EPIC_STATUS.md`
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
-- `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`
-- runtime delivery threads (`#115`, `#159`, `#164`, `#165`, `#166`, `#161`, `#154`, `#153`, `#152`, `#133`, `#120`, `#111`, and blocked follow-through `#11`)
+- the current planning sweep issue returned by the `owner:albatross` + `stream/review-burndown` query
+- runtime delivery threads (`#115`, `#159`, `#164`, `#165`, `#166`, `#161`, `#154`, `#153`, `#152`, `#133`, `#111`, and blocked follow-through `#11`)
 
 ## Review Routine
 

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -16,8 +16,9 @@ This file intentionally stays lightweight so we do not duplicate fast-changing i
 - [Runtime PRs missing priority](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+-label%3A%22priority%2FP0%22+-label%3A%22priority%2FP1%22)
 - [Planning lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aalbatross%22)
 - [Planning PR review queue](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22owner%3Aalbatross%22)
-- [Merge evidence umbrella issue](https://github.com/jckhang/agent-indeed/issues/146)
+- [Current planning sweep issue](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22owner%3Aalbatross%22+label%3A%22stream%2Freview-burndown%22)
 - [Architecture unblocker control issue](https://github.com/jckhang/agent-indeed/issues/137)
+- [Issue #11 executable evidence thread](https://github.com/jckhang/agent-indeed/issues/11)
 - [Backend lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Akestrel%22)
 - [Frontend lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Alanzhou-fe-agent%22)
 - [QA lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aavery%22)
@@ -45,7 +46,7 @@ review history, and linked PRs, open the GitHub issue directly.
 
 ### Phase 1 delivery
 
-- Weekly merge evidence and blocker sweep: [#146](https://github.com/jckhang/agent-indeed/issues/146)
+- Planning sweep / blocker review query: [current open owner:albatross + stream/review-burndown issue](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22owner%3Aalbatross%22+label%3A%22stream%2Freview-burndown%22)
 - Weekly architecture runtime unblocker control: [#137](https://github.com/jckhang/agent-indeed/issues/137)
 - P1-01 Define AgentBundle contract and validation rules: [#3](https://github.com/jckhang/agent-indeed/issues/3)
 - P1-02 Implement onboarding pipeline (signature/schema/index): [#4](https://github.com/jckhang/agent-indeed/issues/4)

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -49,3 +49,4 @@
 - [x] 5.9 跟进前端 consumer contract claim trim（issue #157），把 shortlist/award/bid/proof 读路径的 `main` 基线解释收敛到 OpenAPI/TS draft anchors，避免把 runtime 数据缺口误写成 contract 缺口。
 - [x] 5.10 补充前端 consumer contract reviewer quick-check 锚点，给出 `origin/main` 的行号与 grep 校验命令，减少对已发布读路径的重复误判。
 - [x] 5.11 输出 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged `smoke:dispatch` 路径固化为 issue #11 / QA / beta consumer 可复用的请求响应示例包。
+- [x] 5.12 刷新稳定 issue 索引与 beta-readiness 锚点，改用当前 planning sweep 查询与 issue #11 证据线程承接同日 blocker/evidence 回写，避免继续引用已关闭的 issue #146。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: replace closed planning-sweep anchors with the live planning sweep query and issue #11 evidence thread in the stable Phase 1 indexes

## What Changed

- updated `docs/issues/PHASE1_ISSUES.md` quick links and stable Phase 1 delivery index so they point at the live `owner:albatross` + `stream/review-burndown` planning sweep query instead of closed issue `#146`
- added the issue `#11` executable evidence thread to the stable issue index so reviewers can jump directly to the current QA handoff target
- refreshed `docs/PHASE1_BETA_READINESS_GATES.md` so the execution/handoff gate now names the live planning sweep query and issue `#11` evidence thread as the current same-day blocker/evidence sources
- recorded the docs/OpenSpec sync in `openspec/changes/agent-dispatch-platform/tasks.md` as completed task `5.12`

## Why

- epic #2 still depends on current planning review burndown plus the issue `#11` evidence chain, but the stable repo index was still sending readers to closed issue `#146`
- keeping the stable index and beta-readiness gate anchored to live GitHub queries reduces review churn without reopening broad queue-snapshot rollups

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Planning docs use durable links for live blocker/evidence follow-through instead of closed historical sweep issues | `docs/issues/PHASE1_ISSUES.md` now points to the live planning sweep query and issue `#11` evidence thread | `docs/issues/PHASE1_ISSUES.md` |
| Beta-readiness handoff guidance names the current same-day evidence sources | `docs/PHASE1_BETA_READINESS_GATES.md` now references the planning sweep query and issue `#11` instead of the closed sweep issue | `docs/PHASE1_BETA_READINESS_GATES.md` |
| OpenSpec task tracking stays in sync with the docs follow-up | task `5.12` records the stable-index / beta-readiness anchor refresh | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Branch created fresh from updated `origin/main`
- GitHub planning and issue state checked on 2026-03-19 before updating the stable links

### Steps

1. Open `docs/issues/PHASE1_ISSUES.md` and confirm the planning sweep link uses the `owner:albatross` + `stream/review-burndown` query.
2. Confirm `docs/issues/PHASE1_ISSUES.md` links directly to issue `#11` for executable evidence.
3. Review `docs/PHASE1_BETA_READINESS_GATES.md` and verify the execution/handoff gate points to the live planning sweep query plus issue `#11`.
4. Run `openspec validate --all`.
5. Run `git diff --check`.
6. Run `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`.

### Expected Results

- stable repo indexes no longer point to closed issue `#146` as the live planning sweep anchor
- beta-readiness guidance references the same live GitHub sweep/evidence sources as the current review flow
- OpenSpec validation and pre-push checks pass cleanly

### Validation Output

- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-sweep-query-index' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - the planning sweep query could still be empty on days when no dedicated review-burndown issue is open
- Rollback:
  - revert commit `cb7ef49` to restore the prior stable-link wording

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
