### PR TITLE
[P1-09] Cover dispatch smoke CLI contract in CI

### DIFF
--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -39,7 +39,7 @@
 
 - [x] 5.1 落地可运行 control-plane service skeleton（issue #109），包含健康检查、基础配置与最小持久化抽象。
 - [x] 5.2 打通可执行的 MVP 垂直路径（issue #110）：`publish -> match -> commit -> reveal -> verify -> award`，并持久化关键状态转移。
-- [ ] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
+- [x] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
 - [x] 5.3.a 增加 QA contract-drift 回归校验（issue #120），自动比对 OpenAPI / TypeScript proof reason-code 与当前 runtime 路由基线，减少 review 期间的手工枚举漂移。
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -53,6 +53,8 @@ npm run smoke:dispatch
 
 The smoke command boots the runtime on ephemeral ports and runs three bounded scenarios: the happy path (`publish -> match -> commit -> reveal -> verify -> award`), an invalid-signature verification failure, and the minimum negative-path regression checks for `reveal without commit`, `proof FAIL`, and `award blocked`. It prints prefixed PASS lines for human review and a final JSON summary that QA can link back to issue `#11`.
 
+`npm test` also shells this command end-to-end and asserts the PASS-line plus JSON-summary contract, so CI covers the exact smoke output shape that QA copies into issue evidence.
+
 Or run the bootstrap path end-to-end with one command:
 
 ```bash

--- a/test/runtime/dispatch-smoke.cli.test.js
+++ b/test/runtime/dispatch-smoke.cli.test.js
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+function parseSmokeOutput(stdout) {
+  const lines = stdout.trim().split("\n");
+  const jsonStart = lines.findIndex((line) => line.trim() === "{");
+  assert.notEqual(jsonStart, -1, "expected JSON summary in stdout");
+
+  return {
+    lines: lines.slice(0, jsonStart),
+    summary: JSON.parse(lines.slice(jsonStart).join("\n"))
+  };
+}
+
+test("dispatch smoke CLI emits PASS lines and a machine-readable summary", async () => {
+  const { stdout, stderr } = await execFileAsync(process.execPath, ["src/runtime/dispatch-smoke.js"], {
+    cwd: process.cwd(),
+    maxBuffer: 1024 * 1024
+  });
+
+  assert.equal(stderr, "");
+
+  const { lines, summary } = parseSmokeOutput(stdout);
+
+  assert.ok(lines.some((line) => line.includes("[happy-path] PASS task-awarded")));
+  assert.ok(
+    lines.some((line) => line.includes("[invalid-signature] PASS invalid-signature-rejected"))
+  );
+  assert.ok(
+    lines.some((line) => line.includes("[negative-paths] PASS reveal-without-commit-rejected"))
+  );
+
+  assert.equal(summary.status, "ok");
+  assert.equal(summary.command, "npm run smoke:dispatch");
+  assert.deepEqual(
+    summary.scenarios.map((scenario) => scenario.name),
+    ["happy-path", "invalid-signature", "negative-paths"]
+  );
+  assert.deepEqual(
+    summary.scenarios.map((scenario) => scenario.status),
+    ["PASS", "PASS", "PASS"]
+  );
+});


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: add CI-backed coverage for the canonical dispatch smoke CLI contract and sync the OpenSpec task state

## What Changed

- added [`test/runtime/dispatch-smoke.cli.test.js`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/test/runtime/dispatch-smoke.cli.test.js) to execute `node src/runtime/dispatch-smoke.js` end-to-end and assert both the PASS-line output and the final JSON summary
- documented in [`src/runtime/README.md`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/src/runtime/README.md) that `npm test` now covers the exact smoke output shape QA copies into issue #11 evidence
- marked OpenSpec task 5.3 complete in [`openspec/changes/agent-dispatch-platform/tasks.md`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/openspec/changes/agent-dispatch-platform/tasks.md) now that the smoke/E2E command path is executable, evidence-backed, and CI-covered

## Why

- issue #11 still depends on a repeatable executable evidence path, and the repo previously tested the smoke helpers directly without asserting the real CLI contract that QA actually runs and pastes into GitHub threads
- this closes that gap without overlapping the in-review packet/formatter PRs, because it hardens the existing `main` command path instead of introducing another evidence format

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| One command runs a bounded smoke suite against the local runtime service. | The new CLI test shells the published smoke command entrypoint and parses its real stdout contract. | [`test/runtime/dispatch-smoke.cli.test.js`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/test/runtime/dispatch-smoke.cli.test.js) |
| The suite covers happy path and minimum negative scenarios. | The test asserts the emitted PASS lines for award success, invalid signature rejection, and reveal-without-commit rejection, plus the three canonical JSON scenarios. | [`test/runtime/dispatch-smoke.cli.test.js`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/test/runtime/dispatch-smoke.cli.test.js) |
| Results are stable enough for QA/CI handoff. | The runtime README now states that `npm test` covers the smoke output contract, and OpenSpec task 5.3 is updated to match repository reality. | [`src/runtime/README.md`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/src/runtime/README.md), [`openspec/changes/agent-dispatch-platform/tasks.md`](/Users/jyxc-dz-0100219/.codex/worktrees/6e94/agent-indeed/openspec/changes/agent-dispatch-platform/tasks.md) |

## QA Plan

### Preconditions

- Node/npm installed locally
- clean checkout on this branch

### Steps

1. Run `npm test`
2. Run `npm run smoke:dispatch`
3. Confirm the smoke output still includes the canonical PASS lines and final JSON summary

### Expected Results

- `npm test` passes, including the new CLI smoke contract test
- `npm run smoke:dispatch` prints the happy-path, invalid-signature, and negative-path PASS lines plus the machine-readable summary block
- OpenSpec task 5.3 stays aligned with the executable command path already used for issue #11 evidence

### Validation Output

- `npm test`
```text
> test
> node --test

✔ runtime contract drift guard keeps OpenAPI and contracts aligned
✔ healthz and readyz return runtime status
✔ POST /v1/tasks persists a task and updates runtime summary
✔ POST /v1/tasks rejects requests without a workspace header
✔ GET /v1/tasks/:taskId returns the persisted task payload
✔ GET /v1/tasks/:taskId returns 404 for unknown ids
✔ dispatch vertical slice publishes, matches, bids, verifies, awards, and exposes audit trails
✔ invalid signature, reveal without a commit, and failed verification return stable errors
✔ unknown routes are logged as 404s
✔ GET /v1/bids/:bidId/events rejects bid ids shorter than the published contract
✔ bid/proof status routes return 404 when the task-scoped projection does not exist
✔ bootstrap smoke command exercises the local runtime bootstrap path
✔ loadRuntimeConfig applies defaults for local runtime bootstrap
✔ loadRuntimeConfig rejects invalid ports
✔ loadRuntimeConfig rejects blank host and service names
✔ dispatch smoke CLI emits PASS lines and a machine-readable summary
✔ runDispatchSmoke executes the publish to award flow
✔ runDispatchSmokeSuite executes happy-path and negative smoke scenarios
✔ store assigns deterministic ids across the dispatch lifecycle
ℹ pass 19
ℹ fail 0
```
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/p1-09-smoke-cli-coverage' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - low; this adds test/documentation coverage and a task-state sync, but does not change runtime behavior
- Rollback:
  - revert commit `a1d5517` if the CLI test proves too brittle or slows the suite unexpectedly

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
