### PR TITLE
[P1-09] Add issue-ready smoke evidence packet

### DIFF
--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -41,6 +41,10 @@ The exact command names are intentionally not frozen in this planning doc. Runti
 may choose the final script names, but they must surface one canonical command path in
 their PR body and linked issue comments.
 
+For the current `main` runtime baseline, QA can use `npm run --silent smoke:issue11 -- --signature <agent-name>`
+to turn the merged smoke suite into one ready-to-paste issue `#11` evidence packet without
+manually rewriting the ids, error codes, or PASS-line transcript.
+
 ## Evidence package
 
 Every PR or issue update claiming runtime progress must include enough evidence for a

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -39,7 +39,7 @@
 
 - [x] 5.1 落地可运行 control-plane service skeleton（issue #109），包含健康检查、基础配置与最小持久化抽象。
 - [x] 5.2 打通可执行的 MVP 垂直路径（issue #110）：`publish -> match -> commit -> reveal -> verify -> award`，并持久化关键状态转移。
-- [ ] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
+- [x] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
 - [x] 5.3.a 增加 QA contract-drift 回归校验（issue #120），自动比对 OpenAPI / TypeScript proof reason-code 与当前 runtime 路由基线，减少 review 期间的手工枚举漂移。
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node src/runtime/server.js",
     "dev": "node --watch src/runtime/server.js",
     "smoke:dispatch": "node src/runtime/dispatch-smoke.js",
+    "smoke:issue11": "node src/runtime/issue11-evidence.js",
     "smoke:bootstrap": "node src/runtime/bootstrap-smoke.js",
     "check:contract-drift": "node scripts/check-runtime-contract-drift.js --assert",
     "test": "node --test"

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -7,6 +7,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start the service: `npm start`
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
+- Print an issue-ready issue `#11` evidence packet: `npm run --silent smoke:issue11 -- --signature avery`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
@@ -52,6 +53,14 @@ npm run smoke:dispatch
 ```
 
 The smoke command boots the runtime on ephemeral ports and runs three bounded scenarios: the happy path (`publish -> match -> commit -> reveal -> verify -> award`), an invalid-signature verification failure, and the minimum negative-path regression checks for `reveal without commit`, `proof FAIL`, and `award blocked`. It prints prefixed PASS lines for human review and a final JSON summary that QA can link back to issue `#11`.
+
+To print the same smoke coverage as a ready-to-paste issue comment for issue `#11`:
+
+```bash
+npm run --silent smoke:issue11 -- --signature avery
+```
+
+That command reuses the dispatch smoke suite, captures the PASS lines and JSON summary, and formats one markdown packet with the happy-path ids, negative-path reason codes, and links to the reusable handoff docs.
 
 Or run the bootstrap path end-to-end with one command:
 

--- a/src/runtime/issue11-evidence.js
+++ b/src/runtime/issue11-evidence.js
@@ -1,0 +1,93 @@
+import { pathToFileURL } from "node:url";
+import { runDispatchSmokeSuite } from "./dispatch-smoke.js";
+
+function findScenario(summary, name) {
+  return summary.scenarios.find((scenario) => scenario.name === name);
+}
+
+export function formatIssue11Evidence({ summary, logLines, signature } = {}) {
+  const happyPath = findScenario(summary, "happy-path");
+  const invalidSignature = findScenario(summary, "invalid-signature");
+  const negativePaths = findScenario(summary, "negative-paths");
+  const evidenceLog = logLines.join("\n");
+  const signedNote = signature ? `\n--${signature}` : "";
+
+  return [
+    "## Issue #11 executable smoke evidence",
+    "",
+    `- Command: \`${summary.command}\``,
+    "- API examples: `docs/BACKEND_API_EXAMPLE_PACKET.md`",
+    "- Handoff contract: `docs/RUNTIME_EXECUTION_HANDOFF.md`",
+    "",
+    "### Happy path",
+    "",
+    `- status: ${happyPath.status}`,
+    `- taskId: \`${happyPath.taskId}\``,
+    `- bidId: \`${happyPath.bidId}\``,
+    `- verificationResult: \`${happyPath.verificationResult}\``,
+    "",
+    "### Negative checks",
+    "",
+    `- invalid signature: \`${invalidSignature.result}\` (${invalidSignature.reasonCodes.join(", ")})`,
+    `- reveal without commit: \`${negativePaths.revealWithoutCommit}\``,
+    `- proof fail: \`${negativePaths.proofFail}\``,
+    `- award blocked: \`${negativePaths.awardBlocked}\``,
+    "",
+    "### Smoke log",
+    "",
+    "```text",
+    evidenceLog,
+    "```",
+    "",
+    "### Machine-readable summary",
+    "",
+    "```json",
+    JSON.stringify(summary, null, 2),
+    "```",
+    signedNote
+  ].join("\n");
+}
+
+export async function runIssue11Evidence({ log = console.log, signature } = {}) {
+  const logLines = [];
+  const summary = await runDispatchSmokeSuite({
+    log: (line) => {
+      logLines.push(line);
+    }
+  });
+  const markdown = formatIssue11Evidence({
+    summary,
+    logLines,
+    signature
+  });
+
+  log(markdown);
+
+  return {
+    summary,
+    logLines,
+    markdown
+  };
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--signature") {
+      options.signature = argv[index + 1];
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const options = parseArgs(process.argv.slice(2));
+
+  runIssue11Evidence(options).catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  formatIssue11Evidence,
+  runIssue11Evidence
+} from "../../src/runtime/issue11-evidence.js";
+
+test("formatIssue11Evidence includes the smoke summary, logs, and signature", () => {
+  const markdown = formatIssue11Evidence({
+    summary: {
+      command: "npm run smoke:dispatch",
+      scenarios: [
+        {
+          name: "happy-path",
+          status: "PASS",
+          taskId: "task_00000001",
+          bidId: "bid_00000001",
+          verificationResult: "PASS"
+        },
+        {
+          name: "invalid-signature",
+          status: "PASS",
+          result: "PROOF_VERIFY_FAILED",
+          reasonCodes: ["TRACE_SIGNATURE_INVALID"]
+        },
+        {
+          name: "negative-paths",
+          status: "PASS",
+          revealWithoutCommit: "BID_REVEAL_COMMIT_NOT_FOUND",
+          proofFail: "PROOF_VERIFY_FAILED",
+          awardBlocked: "TASK_AWARD_PRECONDITION_FAILED"
+        }
+      ]
+    },
+    logLines: ["[happy-path] PASS task-awarded", "[negative-paths] PASS award-blocked"],
+    signature: "avery"
+  });
+
+  assert.match(markdown, /## Issue #11 executable smoke evidence/);
+  assert.match(markdown, /`task_00000001`/);
+  assert.match(markdown, /TRACE_SIGNATURE_INVALID/);
+  assert.match(markdown, /TASK_AWARD_PRECONDITION_FAILED/);
+  assert.match(markdown, /--avery/);
+});
+
+test("runIssue11Evidence returns the smoke markdown packet", async () => {
+  const outputs = [];
+  const result = await runIssue11Evidence({
+    signature: "avery",
+    log: (line) => {
+      outputs.push(line);
+    }
+  });
+
+  assert.equal(result.summary.status, "ok");
+  assert.ok(result.logLines.some((line) => line.includes("PASS task-awarded")));
+  assert.match(result.markdown, /## Issue #11 executable smoke evidence/);
+  assert.match(result.markdown, /```json/);
+  assert.match(outputs[0], /## Issue #11 executable smoke evidence/);
+});


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: add a one-command issue #11 evidence packet on top of the merged dispatch smoke suite and sync the OpenSpec task state

## What Changed

- added `src/runtime/issue11-evidence.js` plus the `smoke:issue11` script to run the merged dispatch smoke suite and print one issue-ready markdown packet with happy-path ids, negative-path reason codes, PASS-line transcript, and JSON summary
- added `test/runtime/issue11-evidence.test.js` to lock the formatter output and the end-to-end evidence command
- documented the new issue writeback command in `src/runtime/README.md` and `docs/RUNTIME_EXECUTION_HANDOFF.md`
- marked OpenSpec task 5.3 complete in `openspec/changes/agent-dispatch-platform/tasks.md` now that the smoke/E2E matrix and issue #11 writeback path are executable from one command

## Why

- issue #11 still needed a concrete way for QA to turn the merged smoke suite into a signed, ready-to-paste evidence packet without manually transcribing ids, error codes, or the PASS-line transcript
- the existing runtime smoke and API example docs were already in place, but the last handoff step into issue #11 was still manual and easy to drift during review

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| CI 中可稳定执行 | `smoke:issue11` reuses the existing dispatch smoke suite and now has a dedicated regression test for the formatter/output packet. | `src/runtime/issue11-evidence.js`, `test/runtime/issue11-evidence.test.js`, `npm test` |
| 覆盖关键正反路径 | The generated packet includes the happy path ids plus invalid-signature, reveal-without-commit, proof-fail, and award-blocked outcomes from the executable smoke suite. | `src/runtime/issue11-evidence.js`, `npm run --silent smoke:issue11 -- --signature avery` |
| 文档可供 Beta 集成方直接使用 | The issue-ready markdown links back to the reusable API example packet and runtime handoff docs instead of relying on ad hoc PR comments. | `src/runtime/README.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, `src/runtime/issue11-evidence.js` |

## QA Plan

### Preconditions

- Node/npm installed locally
- clean checkout on this branch

### Steps

1. Run `npm test`
2. Run `openspec validate --all`
3. Run `npm run --silent smoke:issue11 -- --signature avery`

### Expected Results

- the test suite passes, including the new issue #11 evidence-packet regression coverage
- OpenSpec validation stays green after the task-state/doc updates
- the issue evidence command prints one markdown packet with the happy-path ids, negative-path error codes, PASS-line transcript, and JSON summary ready for a signed GitHub comment

### Validation Output

- `npm test`
```text

> test
> node --test

✔ runtime contract drift guard keeps OpenAPI and contracts aligned (6.263041ms)
✔ healthz and readyz return runtime status (30.0255ms)
✔ POST /v1/tasks persists a task and updates runtime summary (15.620375ms)
✔ POST /v1/tasks rejects requests without a workspace header (4.559833ms)
✔ GET /v1/tasks/:taskId returns the persisted task payload (6.138792ms)
✔ GET /v1/tasks/:taskId returns 404 for unknown ids (4.057584ms)
✔ dispatch vertical slice publishes, matches, bids, verifies, awards, and exposes audit trails (23.7685ms)
✔ invalid signature, reveal without a commit, and failed verification return stable errors (7.94425ms)
✔ unknown routes are logged as 404s (0.778292ms)
✔ GET /v1/bids/:bidId/events rejects bid ids shorter than the published contract (0.672208ms)
✔ bid/proof status routes return 404 when the task-scoped projection does not exist (1.144375ms)
✔ bootstrap smoke command exercises the local runtime bootstrap path (26.88475ms)
✔ loadRuntimeConfig applies defaults for local runtime bootstrap (1.384917ms)
✔ loadRuntimeConfig rejects invalid ports (0.2315ms)
✔ loadRuntimeConfig rejects blank host and service names (0.082208ms)
✔ runDispatchSmoke executes the publish to award flow (49.269833ms)
✔ runDispatchSmokeSuite executes happy-path and negative smoke scenarios (41.406917ms)
✔ store assigns deterministic ids across the dispatch lifecycle (2.856042ms)
✔ formatIssue11Evidence includes the smoke summary, logs, and signature (0.818375ms)
✔ runIssue11Evidence returns the smoke markdown packet (72.222667ms)
ℹ tests 20
ℹ suites 0
ℹ pass 20
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 270.684959
```
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `npm run --silent smoke:issue11 -- --signature avery`
```text
## Issue #11 executable smoke evidence

- Command: `npm run smoke:dispatch`
- API examples: `docs/BACKEND_API_EXAMPLE_PACKET.md`
- Handoff contract: `docs/RUNTIME_EXECUTION_HANDOFF.md`

### Happy path

- status: PASS
- taskId: `task_00000001`
- bidId: `bid_00000001`
- verificationResult: `PASS`

### Negative checks

- invalid signature: `PROOF_VERIFY_FAILED` (TRACE_SIGNATURE_INVALID)
- reveal without commit: `BID_REVEAL_COMMIT_NOT_FOUND`
- proof fail: `PROOF_VERIFY_FAILED`
- award blocked: `TASK_AWARD_PRECONDITION_FAILED`

### Smoke log

```text
[happy-path] PASS task-created :: task_00000001
[happy-path] PASS first-match-blocked :: TASK_MATCH_NOT_READY
[happy-path] PASS candidates-ranked :: 3 candidates
[happy-path] PASS bid-committed :: COMMITTED
[happy-path] PASS proof-policy-issued :: policytrace_00000001
[happy-path] PASS bid-revealed :: PENDING_VERIFY
[happy-path] PASS proof-verified :: PASS
[happy-path] PASS award-ready :: bid_00000001
[happy-path] PASS task-awarded :: audit_00000005
[happy-path] PASS task-audit-timeline :: 5 events
[happy-path] PASS bid-audit-timeline :: 4 events
[invalid-signature] PASS invalid-signature-rejected :: PROOF_VERIFY_FAILED
[negative-paths] PASS reveal-without-commit-rejected :: BID_REVEAL_COMMIT_NOT_FOUND
[negative-paths] PASS proof-fail-rejected :: PROOF_VERIFY_FAILED
[negative-paths] PASS award-blocked :: BLOCKED
```

### Machine-readable summary

```json
{
  "status": "ok",
  "command": "npm run smoke:dispatch",
  "scenarios": [
    {
      "name": "happy-path",
      "status": "PASS",
      "verificationResult": "PASS",
      "taskId": "task_00000001",
      "bidId": "bid_00000001"
    },
    {
      "name": "invalid-signature",
      "status": "PASS",
      "result": "PROOF_VERIFY_FAILED",
      "reasonCodes": [
        "TRACE_SIGNATURE_INVALID"
      ],
      "taskId": "task_00000001",
      "proofId": "proof_00000011"
    },
    {
      "name": "negative-paths",
      "status": "PASS",
      "revealWithoutCommit": "BID_REVEAL_COMMIT_NOT_FOUND",
      "proofFail": "PROOF_VERIFY_FAILED",
      "awardBlocked": "TASK_AWARD_PRECONDITION_FAILED",
      "taskId": "task_00000001"
    }
  ]
}
```

--avery
```
- `git diff --check`
```text
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/p1-09-issue11-evidence-packet' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - low; this adds a formatter/command and documentation around the existing merged smoke flow, without changing runtime behavior
- Rollback:
  - revert commit `89b9c28` if the issue evidence command proves noisy or the markdown shape needs to be redesigned

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
