### PR TITLE
docs: retire closed sweep issue from checkpoint workflow

### DIFF
--- a/docs/MERGE_TRAIN_PLAYBOOK.md
+++ b/docs/MERGE_TRAIN_PLAYBOOK.md
@@ -21,7 +21,8 @@ Use this playbook when albatross is coordinating the active PR queue. It keeps l
 - Validation-evidence gaps: [runtime PRs that still need pasted command output](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+label%3A%22status%2Fin-review%22)
 - Planning lane: [owner:albatross issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aalbatross%22)
 - Review-requested planning PRs: [owner:albatross PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22owner%3Aalbatross%22)
-- Merge-evidence umbrella: [issue #146](https://github.com/jckhang/agent-indeed/issues/146)
+- Planning sweep query: [open planning follow-through](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22owner%3Aalbatross%22)
+- QA evidence anchor: [issue #11](https://github.com/jckhang/agent-indeed/issues/11)
 - Dated runtime blocker ledger: `docs/RUNTIME_UNBLOCKER_CONTROL_2026-03-17.md`
 
 ## Merge-train routine
@@ -41,7 +42,7 @@ Use this playbook when albatross is coordinating the active PR queue. It keeps l
    - the exact next step (`rebase origin/main`, rerun validation, or address the named review comment)
    - whether a new blocker issue should be opened instead of growing the PR thread further
 6. Post the same-day sweep output in GitHub:
-   - add the evidence/blocker sweep note to issue #146 when the queue meaningfully changes
+   - reply on the affected PR or live owner issue when the queue meaningfully changes
    - add or refresh the four-bucket checkpoint comment on epic #2 when the sweep changes merge order, blockers, or validation gaps
 7. Only update repo docs when the planning structure changes. Do not copy day-to-day issue/PR state into `docs/issues/PHASE1_ISSUES.md` or `docs/PHASE1_CHECKPOINT_BOARD.md`.
 
@@ -60,9 +61,9 @@ Use this rubric for frontend, backend, QA, and planning lanes so reviewers can s
 
 Keep the volatile merge-evidence record in GitHub, not in repo docs:
 
-1. Use issue #146 as the umbrella note for same-day queue sweeps, reviewer-follow-up burndown, and validation-evidence collection.
+1. Use the live planning sweep query plus issue #11 as the same-day sources for queue sweeps, reviewer-follow-up burndown, and validation-evidence collection.
 2. When the sweep changes the clean tranche, blocker ownership, or validation-gap list, mirror the result into epic #2 using the weekly checkpoint template below.
-3. If a blocker is resolved entirely inside one PR thread, reply on that PR with the signed validation rerun note first, then summarize the net queue change in issue #146 and epic #2 instead of copying the whole thread history.
+3. If a blocker is resolved entirely inside one PR thread, reply on that PR with the signed validation rerun note first, then summarize the net queue change on epic #2 instead of copying the whole thread history into repo docs.
 
 ## Validation gates
 
@@ -120,9 +121,10 @@ Validation evidence gaps
 --<agent-name>
 ```
 
-## Merge-evidence sweep note template
+## Queue sweep note template
 
-Use this on issue #146 after the current queue review or review-burndown pass:
+Use this on epic #2 or the current live planning follow-through issue after the
+current queue review or review-burndown pass:
 
 ```text
 Sweep <YYYY-MM-DD>

--- a/docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md
+++ b/docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md
@@ -9,6 +9,7 @@ consistent, owner-specific, and reviewable.
 
 - Open the milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Run the metadata hygiene queries from `docs/PHASE1_CHECKPOINT_BOARD.md`.
+- Check the live planning sweep query and issue #11 before copying any blocker or evidence note into the checkpoint comment.
 - Pull the current runtime blocker snapshot from the dated control doc when one
   exists.
 - Verify every blocker references a live issue or PR and the owner label already
@@ -53,6 +54,7 @@ consistent, owner-specific, and reviewable.
 - `Ready next` should describe executable slices only; defer design-only follow-ups unless they unblock the runtime path this week.
 - `Validation evidence gaps` should call out the exact missing command output so reviewers know what to ask for next.
 - The owner handoff table should stay short enough to scan in GitHub without expanding code blocks.
+- Prefer live queries or issue #11 for same-day evidence threads; do not cite closed umbrella issues as active blocker owners.
 
 ## Minimum evidence checklist
 

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -49,3 +49,4 @@
 - [x] 5.9 跟进前端 consumer contract claim trim（issue #157），把 shortlist/award/bid/proof 读路径的 `main` 基线解释收敛到 OpenAPI/TS draft anchors，避免把 runtime 数据缺口误写成 contract 缺口。
 - [x] 5.10 补充前端 consumer contract reviewer quick-check 锚点，给出 `origin/main` 的行号与 grep 校验命令，减少对已发布读路径的重复误判。
 - [x] 5.11 输出 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged `smoke:dispatch` 路径固化为 issue #11 / QA / beta consumer 可复用的请求响应示例包。
+- [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: retire closed issue #146 from the weekly checkpoint / merge-train workflow

## What Changed

- updated `docs/MERGE_TRAIN_PLAYBOOK.md` so the queue routine no longer treats closed issue #146 as the active sweep umbrella
- refreshed `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so checkpoint comments verify blockers against live planning threads and issue #11 before copying evidence notes
- synced `openspec/changes/agent-dispatch-platform/tasks.md` with a new completed item for the checkpoint-template refresh

## Why

- the current planning workflow still points reviewers at a closed blocker umbrella, which makes same-day queue notes drift away from the live owner threads
- epic #2 checkpoints should pull from live planning follow-through queries and issue #11, not a closed sweep issue

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Weekly checkpoint / merge-train guidance references only live blocker and evidence threads | Replaces issue #146 as the active sweep anchor with live planning-query + issue #11 guidance in the playbook and checkpoint template | `docs/MERGE_TRAIN_PLAYBOOK.md`, `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` |
| OpenSpec-first workflow stays aligned with the planning process change | Adds a completed runtime sprint task for the checkpoint workflow refresh | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Repo is on branch `codex/issue-2-epic-checkpoint-template`
- OpenSpec CLI is available in the workspace

### Steps

1. Review `docs/MERGE_TRAIN_PLAYBOOK.md` and confirm the queue sweep guidance no longer names closed issue #146 as an active umbrella.
2. Review `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` and confirm checkpoint comments now verify blockers against live planning threads and issue #11.
3. Run `openspec validate --all`.
4. Run `git diff --check` and `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`.

### Expected Results

- The merge-train workflow uses live planning/QA threads instead of closed issue #146.
- The checkpoint template explicitly rejects closed umbrella issues as active blocker owners.
- OpenSpec validation and pre-push checks pass cleanly.

### Validation Output

- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-epic-checkpoint-template' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - Reviewers may still post ad hoc sweep notes on stale issues if they follow older comments instead of the updated playbook.
- Rollback:
  - Revert this PR to restore the previous wording, then reopen a narrower docs-only follow-up with the preferred live anchor.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
