### PR TITLE
[P1-188] Keep shortlist query flags view-only

### DIFF
--- a/docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md
+++ b/docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md
@@ -1,6 +1,6 @@
 # Frontend Runtime Integration Tranche (P1-40)
 
-Last updated: 2026-03-18
+Last updated: 2026-03-19
 
 Related issue: [#136](https://github.com/jckhang/agent-indeed/issues/136)
 Mainline sync issue: [#145](https://github.com/jckhang/agent-indeed/issues/145)
@@ -43,6 +43,16 @@ Result:
 - remaining risk stays in runtime execution readiness from issues [#110](https://github.com/jckhang/agent-indeed/issues/110), [#115](https://github.com/jckhang/agent-indeed/issues/115), and QA evidence from [#111](https://github.com/jckhang/agent-indeed/issues/111), not in the published field names or fallback rules
 
 Issue [#157](https://github.com/jckhang/agent-indeed/issues/157) narrows the review rule for this pass: if the docs say a read is on `main`, reviewers should be able to find the exact path plus response type in both `src/api/openapi.yaml` and `src/api/contracts.ts`. A local stack still returning empty or lagging projection data is a runtime readiness gap, not proof that the contract path is unpublished.
+
+## Executable follow-up slice for issue #188
+
+Selected runtime-consumer entrypoint:
+- `GET /v1/tasks/{taskId}/candidates`
+
+Acceptance notes for this cut:
+- `limit` stays a response-projection control for the ranked shortlist and does not rewrite the persisted shortlist snapshot that reveal, award-readiness, and later manager reads depend on.
+- `includeScoreBreakdown=false` hides ranking detail only for that response; a later read with `includeScoreBreakdown=true` must still surface the same canonical shortlist members with score data intact.
+- The runtime keeps ineligible candidates visible as review context, so the manager shell can preserve blocker and missing-data fallbacks without inventing a parallel shortlist contract.
 
 ## Canonical handoff status
 

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -38,6 +38,13 @@
 - **AND** 如需控制评审开销，平台 MAY 增加 `includeScoreBreakdown` 这类加性查询开关
 - **AND** 额外评审字段必须通过现有 shortlist 响应做加性扩展，避免同一 endpoint 在并行 PR 中出现不兼容 shape
 
+#### Scenario: Shortlist query projections do not rewrite the canonical snapshot
+- **WHEN** manager 先以较小 `limit` 或 `includeScoreBreakdown=false` 查询 `GET /v1/tasks/{taskId}/candidates`
+- **AND** 后续再以不同 `limit` / `includeScoreBreakdown` 组合重读同一 task 的 shortlist
+- **THEN** 平台保持同一份已持久化 shortlist 快照作为 reveal / award / review 的共同基线
+- **AND** `limit` 只裁剪当前响应中的 ranked shortlist 投影，而不是缩写或重排已持久化候选集
+- **AND** `includeScoreBreakdown=false` 只影响当前响应是否回传评分拆解，不得让后续读取永久丢失评分字段
+
 ### Requirement: Bidding Must Use Commit-Reveal
 
 平台 MUST 支持两阶段竞标，先承诺后揭示，降低抄袭与围标风险。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -49,4 +49,5 @@
 - [x] 5.9 跟进前端 consumer contract claim trim（issue #157），把 shortlist/award/bid/proof 读路径的 `main` 基线解释收敛到 OpenAPI/TS draft anchors，避免把 runtime 数据缺口误写成 contract 缺口。
 - [x] 5.10 补充前端 consumer contract reviewer quick-check 锚点，给出 `origin/main` 的行号与 grep 校验命令，减少对已发布读路径的重复误判。
 - [x] 5.11 输出 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged `smoke:dispatch` 路径固化为 issue #11 / QA / beta consumer 可复用的请求响应示例包。
+- [x] 5.12 固化 shortlist 查询投影语义（issue #188），确保 `limit` / `includeScoreBreakdown` 只影响当前响应视图，不回写或裁剪已持久化 shortlist 快照。
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -38,6 +38,28 @@ function buildError(code, category, message, { auditId, retryable = false, retry
   };
 }
 
+function projectCandidateSnapshot(snapshot, { limit, includeScoreBreakdown }) {
+  const projectCandidate = (candidate) => ({
+    ...candidate,
+    ...(includeScoreBreakdown ? {} : { scoreBreakdown: undefined })
+  });
+
+  const eligibleCandidates = snapshot.candidates
+    .filter((candidate) => candidate.eligible)
+    .slice(0, limit)
+    .map(projectCandidate);
+  const ineligibleCandidates = snapshot.candidates
+    .filter((candidate) => !candidate.eligible)
+    .map(projectCandidate);
+
+  return {
+    taskId: snapshot.taskId,
+    status: snapshot.status,
+    generatedAt: snapshot.generatedAt,
+    candidates: [...eligibleCandidates, ...ineligibleCandidates]
+  };
+}
+
 function buildTaskValidationError(message, details = {}) {
   return {
     statusCode: 400,
@@ -996,9 +1018,7 @@ export function createApp({
       if (store.isMatchingPending(taskId)) {
         const seededSnapshot = buildCandidateSnapshot({
           taskId,
-          task: task.task,
-          includeScoreBreakdown,
-          limit
+          task: task.task
         });
         store.createMatchingSnapshot(taskId, seededSnapshot.candidates);
         return reply(
@@ -1017,15 +1037,7 @@ export function createApp({
       }
 
       const snapshot = store.getMatchingSnapshot(taskId);
-      return reply(200, {
-        taskId,
-        status: snapshot.status,
-        generatedAt: snapshot.generatedAt,
-        candidates: snapshot.candidates.map((candidate) => ({
-          ...candidate,
-          ...(includeScoreBreakdown ? {} : { scoreBreakdown: undefined })
-        }))
-      });
+      return reply(200, projectCandidateSnapshot(snapshot, { limit, includeScoreBreakdown }));
     }
 
     const commitMatch = requestUrl.pathname.match(TASK_BID_COMMIT_PATTERN);

--- a/test/runtime/app.test.js
+++ b/test/runtime/app.test.js
@@ -587,6 +587,51 @@ test("dispatch vertical slice publishes, matches, bids, verifies, awards, and ex
   }
 });
 
+test("candidate shortlist query flags project a canonical snapshot without mutating it", async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const created = await createTaskRecord(baseUrl, buildTask({
+      constraints: {
+        identityTierMin: "T1",
+        requiredSkills: ["backend", "api"],
+        complianceTags: []
+      }
+    }));
+    const taskId = created.taskId;
+
+    const seededResponse = await fetch(
+      `${baseUrl}/v1/tasks/${taskId}/candidates?limit=1&includeScoreBreakdown=false`
+    );
+    assert.equal(seededResponse.status, 409);
+
+    const limitedResponse = await fetch(
+      `${baseUrl}/v1/tasks/${taskId}/candidates?limit=1&includeScoreBreakdown=false`
+    );
+    assert.equal(limitedResponse.status, 200);
+    const limitedBody = await limitedResponse.json();
+    assert.equal(limitedBody.candidates.length, 2);
+    assert.equal(limitedBody.candidates[0].agentId, "agent_kestrel_alpha");
+    assert.equal(limitedBody.candidates[0].eligible, true);
+    assert.equal("scoreBreakdown" in limitedBody.candidates[0], false);
+    assert.equal(limitedBody.candidates[1].eligible, false);
+
+    const expandedResponse = await fetch(`${baseUrl}/v1/tasks/${taskId}/candidates?limit=2`);
+    assert.equal(expandedResponse.status, 200);
+    const expandedBody = await expandedResponse.json();
+    assert.equal(expandedBody.candidates.length, 3);
+    assert.equal(expandedBody.candidates[0].agentId, "agent_kestrel_alpha");
+    assert.equal(expandedBody.candidates[1].agentId, "agent_kestrel_beta");
+    assert.equal(expandedBody.candidates[1].eligible, true);
+    assert.ok(expandedBody.candidates[0].scoreBreakdown);
+    assert.ok(expandedBody.candidates[1].scoreBreakdown);
+    assert.equal(expandedBody.candidates[2].eligible, false);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
 test("invalid signature, reveal without a commit, and failed verification return stable errors", async () => {
   let currentTime = "2026-03-16T00:00:00.000Z";
   const { server, baseUrl, setNow } = await startTestServer({


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): closes #188
- Department label (pick one): `dept/frontend`
- Type label (pick one): `type/bugfix`
- Scope: keep shortlist query flags (`limit`, `includeScoreBreakdown`) view-only so the runtime preserves one canonical manager review snapshot

## What Changed

- updated `/v1/tasks/{taskId}/candidates` in [`src/runtime/app.js`](/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/src/runtime/app.js) to persist one canonical shortlist snapshot and project `limit` / `includeScoreBreakdown` per response instead of seeding snapshot state from the first query
- added regression coverage in [`test/runtime/app.test.js`](/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/test/runtime/app.test.js) proving a first `limit=1&includeScoreBreakdown=false` read does not prevent later reads from returning the full ranked shortlist with score breakdowns restored
- documented the executable frontend runtime-consumer slice in [`docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md`](/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md) and synced the OpenSpec task/spec artifacts in [`openspec/changes/agent-dispatch-platform/tasks.md`](/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/openspec/changes/agent-dispatch-platform/tasks.md) and [`openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md`](/Users/jyxc-dz-0100219/.codex/worktrees/194a/agent-indeed/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md)

## Why

- issue #188 asked for the next frontend runtime-consumer slice to be a small executable cut with one explicit entrypoint and acceptance notes
- before this change, the first shortlist read could accidentally shrink the stored runtime snapshot or permanently omit ranking breakdowns, which makes manager review behavior depend on query order instead of the canonical shortlist contract

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| One frontend runtime-consumer task is selected with explicit entrypoint and acceptance notes. | The tranche doc now selects `GET /v1/tasks/{taskId}/candidates` as the issue #188 follow-up slice and records the query-projection acceptance notes. | `docs/FRONTEND_RUNTIME_INTEGRATION_TRANCHE.md` |
| The issue uses current merged contract names only; no speculative fields. | The runtime and docs stay on the existing `CandidateMatchListResponse` contract and only adjust query projection behavior. | `src/runtime/app.js`; `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md` |
| The follow-up is small enough for one focused PR against `main`. | The PR is limited to shortlist projection behavior, one regression test, and the matching OpenSpec/doc sync. | `src/runtime/app.js`; `test/runtime/app.test.js`; `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Branch `codex/issue-188-shortlist-canonical-query` is checked out from current `origin/main`.
- Node 20+ and OpenSpec CLI are available locally.

### Steps

1. Run `npm test` from the repo root.
2. Run `openspec validate --all` and `openspec validate --changes`.
3. Run `git diff --check` and `bash scripts/agent_prepush_check.sh --github-user lan`.

### Expected Results

- The new shortlist regression test passes and proves query-order does not mutate the stored shortlist snapshot.
- OpenSpec validation succeeds with the new shortlist-projection scenario.
- Diff and pre-push checks pass without formatting or identity drift.

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`

```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

- `npm test`

```text
> test
> node --test
...
ℹ tests 105
ℹ suites 0
ℹ pass 105
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
```

- `openspec validate --changes`

```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

- `git diff --check`

```text
<no output>
```

- `bash scripts/agent_prepush_check.sh --github-user lan`

```text
[ok] Branch 'codex/issue-188-shortlist-canonical-query' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (lan).
[ok] git user.email matches expected account (lan@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - shortlist consumers may have been implicitly relying on the first query to seed a smaller stored snapshot, so this changes that hidden behavior to the contract-safe interpretation.
- Rollback:
  - revert commit `1b72285` to restore the prior shortlist projection behavior.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
