### PR TITLE
docs: refresh epic issue #11 baseline snapshot

### DIFF
--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -14,10 +14,10 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
-| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, issue #167, PR #174, PR #176, PR #179, PR #133 | Merge the post-runtime planning/reference cleanup, then keep PR #133 aligned to the published contract vocabulary. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issues #177, #178, and #11 | Publish one canonical smoke evidence format, run the formatter-backed smoke pass, and paste the final evidence back onto issue #11. |
-| Core negative scenarios are covered | Blocked | issue #11, PR #172, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Turn the documented failure cases into reproducible smoke evidence tied to the merged runtime baseline. |
-| Audit events cover key state transitions | In progress | merged runtime baseline from issues #109/#110, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, issue #11 | Keep the verify/award/audit follow-through aligned while the final smoke evidence proves the emitted trail. |
+| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PR #190, PR #166, PR #174, and PR #133 | Merge the surviving planning-sync baseline on PR #190, keep the smaller planning follow-ons aligned to that same baseline, and close the remaining verify/award vocabulary drift on PR #133. |
+| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issue #11, PR #191, PR #182, and PR #172 | Land the backend-owned evidence path, CI smoke contract coverage, and QA packet snippets, then paste the final bounded smoke evidence back onto issue #11. |
+| Core negative scenarios are covered | Blocked | issue #11, PR #172, PR #182, `docs/CLOSED_BETA_SECURITY_READINESS.md`, and `docs/ERROR_CODE_RETRY_POLICY.md` | Turn the documented failure cases into reproducible smoke evidence tied to the merged runtime baseline and keep the negative-path proof in the same issue #11 handoff thread. |
+| Audit events cover key state transitions | In progress | merged runtime baseline from issues #109/#110, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, issue #11, and PR #191 | Keep the verify/award/audit follow-through aligned while the refreshed issue #11 evidence path proves emitted task, proof, and award traces. |
 
 ## Delivery Slice Status
 
@@ -33,40 +33,42 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 - QA contract-drift guard baseline is merged in PR #159 and retained in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`.
 - Frontend runtime consumer baseline is merged in PR #152.
 - Backend API example packet is merged in PR #164.
+- Canonical smoke-comment formatter guidance is merged in PR #175.
 
 ### Active follow-through slices
 
 | Epic step | Active issue / PR | Why it still matters to epic #2 |
 | --- | --- | --- |
-| Post-runtime planning refresh | issue #167, PR #174, PR #176, PR #179 | These threads remove stale references to closed runtime/QA issues and establish one consistent planning baseline for the remaining Phase 1 queue. |
-| Overlapping planning rollups | PR #171, PR #154, PR #165, PR #166, PR #161, PR #153 | These older planning refresh branches should either be folded into PR #179 or closed as superseded so the repo stops carrying conflicting queue snapshots. |
+| Planning-stack consolidation | issue #2 / PR #190 | This is the current surviving planning-sync thread for the M1 checkpoint sweep and should replace overlapping checkpoint-rollup rewrites instead of creating another competing snapshot. |
+| Planning follow-on cleanup | PR #166 and PR #174 | These smaller planning docs still need to stay consistent with the same post-runtime baseline while PR #190 decides the durable checkpoint rule. |
 | Verify/award contract adoption | PR #133 | The checklist still needs to describe only the proof fields, error codes, and reason-code vocabulary that are actually published on `main`. |
-| Backend smoke formatter | issue #177 / PR #175 | QA needs one canonical backend-owned evidence block before the final smoke pass can be repeated consistently. |
-| QA packet and smoke evidence | PR #172, issue #178, issue #11 | The remaining QA work is to reuse the canonical formatter output, run the bounded smoke pass, and post the exact result on issue #11. |
+| Frontend runtime consumer cleanup | PR #170 and PR #189 | Frontend consumers still need to keep shortlist and runtime-refresh guidance tied to the current published read surfaces. |
+| Issue #11 backend and QA evidence handoff | issue #11, PR #191, PR #182, and PR #172 | The remaining happy/negative-path work is now concentrated on one executable evidence lane that can be replayed and reviewed without reopening closed planning or QA umbrella issues. |
 
 ### Remaining blocked slices
 
-- Issue #11 remains the only live end-to-end evidence gate; closed issue #120 is historical context, not active work.
-- The planning lane still has overlapping open PRs that touch the same roadmap/checkpoint docs, so one surviving rollup must land before the queue can stop restating stale blocker snapshots.
+- Issue #11 remains the only live end-to-end evidence gate for epic #2.
+- PR #190 still needs review/merge before the planning lane can stop carrying overlapping checkpoint-sync wording.
 - PR #133 remains blocked on contract-vocabulary drift until its checklist matches the published OpenAPI and TypeScript contracts.
+- The frontend runtime-consumer follow-ons (PR #170 and PR #189) must stay constrained to merged runtime behavior so issue #11 evidence does not drift from the actual UI/read-model baseline.
 
 ## Next 24h Merge Sequence
 
 | Order | Thread | Why now | Expected result |
 | --- | --- | --- | --- |
-| 1 | PR #174 `docs: refresh runtime handoff baseline` | Smallest live planning fix with direct stale-reference feedback. | Runtime handoff docs stop treating closed issue #120 as active. |
-| 2 | PR #176 `docs: codify planning reference rules` | Makes the contributor/reference rules match the post-runtime review workflow. | Future planning PRs point at live queries and same-day sweep threads instead of closed issues. |
-| 3 | PR #179 `[P1-167] Refresh planning docs to post-runtime baseline` | Preferred surviving rollup for issue #167 after the two smaller doc fixes land. | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, and this file all describe the same post-runtime queue. |
-| 4 | PRs #171, #154, #165, #166, #161, #153 | Overlapping planning branches should no longer stay open as competing snapshots. | Close, fold, or restack them behind the merged #167 rollup. |
-| 5 | PR #133, issue #177, issue #178, issue #11 | Contract wording and final smoke evidence remain after planning drift is removed. | One canonical smoke evidence path feeds the final QA sign-off thread. |
+| 1 | PR #190 `docs: collapse planning sweep stack before M1` | It is the designated surviving planning-sync PR for the current checkpoint sweep and reduces duplicate review churn across the planning lane. | One durable planning baseline remains open for epic #2 instead of multiple overlapping roadmap/checkpoint rollups. |
+| 2 | PR #191 `[P1-187] Flatten issue #11 backend evidence path` | Backend-owned smoke/evidence formatting is the fastest way to make the remaining QA handoff deterministic. | Issue #11 gets one canonical backend evidence path to reuse in comments and smoke reruns. |
+| 3 | PR #182 `[P1-09] Cover dispatch smoke CLI contract in CI` | CI coverage lowers the risk that the issue #11 smoke contract drifts while follow-on docs and QA packets land. | The smoke CLI contract becomes continuously checked instead of comment-only guidance. |
+| 4 | PR #172 `[P1-11] Add QA packet snippets for issue #11` | QA still needs reusable packet snippets once the backend-owned evidence format is stable. | The issue #11 handoff thread can carry exact happy/negative-path snippets without ad hoc PR comment copying. |
+| 5 | PR #133 plus issue #11 final rerun | Contract wording and final smoke evidence remain after the planning/evidence path is stable. | Verify/award wording and executable evidence both converge on the merged runtime baseline. |
 
 ## Checkpoint Rollup
 
 | Checkpoint | Epic relevance | Current note |
 | --- | --- | --- |
-| M1 | Post-runtime planning/reference cleanup | The immediate M1 gate is landing the #167 planning refresh plus PR #174 and PR #176 without leaving older duplicate status threads behind. |
-| M2 | Runtime evidence formatting and reuse | Backend still needs the canonical smoke formatter path from issue #177 / PR #175 before QA can reuse it cleanly. |
-| M3 | Verify, audit, and executable QA | PR #172, issue #178, and issue #11 are the remaining proof points for runnable smoke evidence on top of the merged runtime baseline. |
+| M1 | Planning-stack cleanup + stable evidence path | The immediate M1 gate is merging PR #190 while keeping PR #166, PR #174, PR #191, PR #182, and PR #172 aligned to the same post-runtime baseline. |
+| M2 | Runnable publish/match/bid foundation | The merged dispatch slice stays intact; the live follow-through is keeping frontend consumers (PR #170 / PR #189) and verify/award wording (PR #133) within that published contract surface. |
+| M3 | Verify, audit, and executable QA | Issue #11 plus PR #191 / PR #182 / PR #172 now carry the remaining happy-path, negative-path, and audit-evidence burden for the merged runtime. |
 | M4 | Beta readiness sign-off | Issue #11 final E2E evidence and audit/security verification remain required. |
 
 ## Epic Exit Checklist

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -43,7 +43,7 @@ Scope:
   - #109 bootstrap runnable backend skeleton
   - #110 implement runnable dispatch vertical slice (`publish -> match -> commit -> reveal -> verify -> award`)
   - #111 convert QA smoke/E2E matrices into executable checks
-- Post-runtime planning work now focuses on keeping roadmap/checkpoint references aligned to the merged baseline, not reopening the bootstrap queue.
+- Post-runtime planning work now focuses on one surviving planning-sync thread per checkpoint sweep instead of parallel roadmap/checkpoint rewrites.
 - Agent onboarding and metadata sync (`AgentBundle` with identity/memory/skills).
 - Task publication and candidate matching (hard filter + soft ranking baseline).
 - Manager shortlist and award review contracts with audit-linked status context.
@@ -51,7 +51,7 @@ Scope:
 - PoMW verification baseline with identity-tier policy.
 - Auditable award events and minimal reputation writeback hook.
 - Lifecycle observability baseline for `upload -> match -> bid -> verify -> award`.
-- Closed-beta evidence handoff stays concentrated on issue #11 plus its immediate formatter/smoke follow-through issues (#177 and #178).
+- Closed-beta evidence handoff stays concentrated on issue #11 plus its immediate backend, CI, and QA follow-through PRs (#191, #182, #172).
 
 Exit criteria:
 - Core APIs available and documented in `src/api/openapi.yaml`.
@@ -63,23 +63,26 @@ Exit criteria:
 
 Focus:
 - Treat issues #109, #110, and #111 as merged runtime baseline work.
-- Clear the planning/reference review blockers on PR #174 and PR #176 so post-runtime docs stop pointing at closed issues.
-- Land one surviving planning rollup for issue #167; use PR #179 as the preferred branch to absorb the refresh and close or supersede overlapping older planning PRs (#171, #154, #165, #166, #161, #153).
-- Keep PR #133 aligned to the published verify/award contract vocabulary after the planning refresh settles.
-- Move QA evidence forward through issue #177, issue #178, and issue #11 instead of reopening closed issue #120.
+- Merge PR #190 as the single surviving planning-sync thread for the M1 checkpoint sweep.
+- Keep PR #166 and PR #174 aligned to that same post-runtime planning baseline while they finish review.
+- Keep PR #133 aligned to the published verify/award contract vocabulary.
+- Move issue #11 evidence forward through PR #191, PR #182, and PR #172.
+- Keep frontend runtime-consumer follow-ons (PR #170 and PR #189) tied to the merged read and refresh surfaces.
 
 De-scoped from current sprint:
 - Planning-only follow-ups #106, #107, #108 were closed to avoid additional doc-layer churn.
+- Older planning-stack rewrites should be closed, superseded, or restacked behind PR #190 instead of reopened as fresh snapshots.
 - QA prewrite-only threads (#87, PR #84, PR #104) remain superseded by the executable QA path that now runs through issue #11.
-- Closed issue #120 remains a dated baseline reference only; it is not an active evidence lane.
+- Closed issue #120 remains a dated contract baseline reference only; it is not an active evidence lane.
 
 ## Next 24h Merge Sequence
 
-1. Merge PR #174 (`docs: refresh runtime handoff baseline`) after removing the last stale references to closed issue #120.
-2. Merge PR #176 (`docs: codify planning reference rules`) so contributor guidance matches the post-runtime review workflow.
-3. Refresh and merge PR #179 (`[P1-167] Refresh planning docs to post-runtime baseline`) as the single surviving planning rollup for issue #167.
-4. Close, restack, or fold overlapping planning refresh PRs (#171, #154, #165, #166, #161, #153) behind the merged #167 rollup instead of keeping multiple conflicting status snapshots open.
-5. Revisit PR #133 once the planning baseline is stable, then hand the canonical smoke evidence path to issue #177, issue #178, and issue #11.
+1. Merge PR #190 (`docs: collapse planning sweep stack before M1`) so the planning lane stops carrying parallel checkpoint-rollup rewrites.
+2. Merge PR #191 (`[P1-187] Flatten issue #11 backend evidence path`) to give issue #11 one canonical backend-owned evidence format.
+3. Merge PR #182 (`[P1-09] Cover dispatch smoke CLI contract in CI`) so the smoke handoff contract is continuously checked.
+4. Merge PR #172 (`[P1-11] Add QA packet snippets for issue #11`) once the backend evidence block is stable.
+5. Revisit PR #133 and the final issue #11 rerun after the planning and evidence-path updates are settled.
+6. Keep PR #170 and PR #189 constrained to merged runtime behavior while the issue #11 evidence chain closes.
 
 ### Phase 2: Execution & Trust Loop (Target: 2026-05 to 2026-06)
 
@@ -105,9 +108,9 @@ Scope:
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
-- M1 (2026-03-20): close post-runtime planning/reference drift (#167, PR #174, PR #176) and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
-- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA publish one canonical smoke evidence path (#177, #178, issue #11).
-- M3 (2026-04-03): stabilize verify/award/audit evidence and run executable smoke checks against the merged runtime baseline.
+- M1 (2026-03-20): collapse the planning-stack duplicates behind PR #190 and keep the surviving evidence-path PRs reviewable on current `main`.
+- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while frontend runtime consumers and verify/award wording converge on the same published contracts.
+- M3 (2026-04-03): stabilize verify/award/audit evidence and complete the remaining executable smoke handoff on issue #11.
 - M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.
 - Review `docs/PHASE1_BETA_READINESS_GATES.md` as the compact release-gate checklist for the remaining Phase 1 contract, QA, audit, and planning blockers.

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -44,7 +44,7 @@
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。
 - [x] 5.6 输出 `docs/RUNTIME_EXECUTION_HANDOFF.md`，统一 runtime sprint 的本地命令契约、证据包与 issue #11 回写规则。
-- [x] 5.7 明确 issue #146 merge-evidence sweep 与 epic #2 checkpoint 的双轨回写规则，统一 clean tranche、dirty follow-on 与 validation evidence gap 的 GitHub 记录方式。
+- [x] 5.7 明确 planning sweep issue 与 epic #2 checkpoint 的双轨回写规则，统一 clean tranche、dirty follow-on 与 validation evidence gap 的 GitHub 记录方式。
 - [x] 5.8 完成前端 runtime consumer verification pass（issue #150），校准 task composer、shortlist/award、bid workspace、verification timeline 对当前 `main` runtime 字段与 fallback 语义的引用。
 - [x] 5.9 跟进前端 consumer contract claim trim（issue #157），把 shortlist/award/bid/proof 读路径的 `main` 基线解释收敛到 OpenAPI/TS draft anchors，避免把 runtime 数据缺口误写成 contract 缺口。
 - [x] 5.10 补充前端 consumer contract reviewer quick-check 锚点，给出 `origin/main` 的行号与 grep 校验命令，减少对已发布读路径的重复误判。
@@ -52,3 +52,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.15 刷新 epic #2 的稳定执行快照（`docs/PHASE1_EPIC_STATUS.md` 与 `docs/ROADMAP.md`），把 M1 规划收敛、issue #11 证据路径与当前 follow-through PR 队列对齐到 2026-03-19 基线。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: refresh the stable epic status / roadmap snapshot to the current issue #11 evidence queue and surviving planning-sync baseline

## What Changed

- updated `docs/PHASE1_EPIC_STATUS.md` so epic #2 now points at the current planning-stack survivor (PR #190), the live issue #11 evidence path, and the active frontend/backend follow-through PRs
- refreshed `docs/ROADMAP.md` so the current sprint pivot, merge sequence, and M1-M3 milestone notes match the 2026-03-19 queue instead of older #167/#177/#178-era threads
- synced `openspec/changes/agent-dispatch-platform/tasks.md` by generalizing the planning-sweep wording in task `5.7` and recording this epic/roadmap refresh as completed task `5.14`

## Why

- epic #2 is the only open albatross issue, but its stable repo snapshot was still anchored to superseded planning and evidence threads
- reviewers need one current execution snapshot that matches the surviving planning-sync PR plus the live issue #11 evidence lane without reopening older queue state

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Epic acceptance docs point at the current planning-stack and issue #11 evidence path | `docs/PHASE1_EPIC_STATUS.md` now names PR #190, PR #191, PR #182, PR #172, PR #170, PR #189, PR #166, PR #174, and issue #11 as the active follow-through queue | `docs/PHASE1_EPIC_STATUS.md` |
| Roadmap sprint notes reflect the current post-runtime merge order instead of superseded planning/evidence issues | `docs/ROADMAP.md` rewrites the sprint focus, next-24h merge sequence, and M1-M3 milestone notes to the 2026-03-19 baseline | `docs/ROADMAP.md` |
| OpenSpec task tracking stays aligned with the docs refresh | tasks `5.7` and `5.14` record the generalized planning-sweep rule and the new epic/roadmap baseline refresh | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- branch created fresh from updated `origin/main`
- current open issue/PR queue reviewed on 2026-03-19 before editing the stable snapshot docs

### Steps

1. Review `docs/PHASE1_EPIC_STATUS.md` and confirm the active follow-through queue names the current planning-stack survivor plus the live issue #11 evidence path.
2. Review `docs/ROADMAP.md` and confirm the sprint focus, merge sequence, and milestone notes match the same 2026-03-19 queue.
3. Review `openspec/changes/agent-dispatch-platform/tasks.md` and confirm runtime task progress plus task `5.14` match the doc refresh.
4. Run `openspec validate --all`.
5. Run `git diff --check`.
6. Run `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent --skip-fetch`.

### Expected Results

- epic status and roadmap docs no longer point at superseded planning/evidence threads
- OpenSpec task tracking matches the refreshed stable docs
- validation commands pass without diff or identity guard failures

### Validation Output

- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent --skip-fetch`
```text
[ok] Branch 'codex/issue-2-epic-baseline-refresh' uses codex/ prefix.
[warn] Skipping git fetch (--skip-fetch).
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - the issue/PR queue may keep moving, so this stable snapshot will need later follow-up instead of pretending to be permanent live state
- Rollback:
  - revert commit `7cec351` to restore the previous epic/roadmap snapshot

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
