### PR TITLE
docs: refresh beta readiness gate dependencies

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -1,6 +1,6 @@
 # Phase 1 Beta Readiness Gates
 
-Last updated: 2026-03-18
+Last updated: 2026-03-19
 
 This document turns epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`) into a small set of
 reviewable release gates for closed-beta readiness. It complements:
@@ -9,17 +9,18 @@ reviewable release gates for closed-beta readiness. It complements:
 - `docs/ROADMAP.md` for phase checkpoints and milestone dates
 - `docs/PHASE1_EPIC_STATUS.md` for the current issue/PR rollup
 - `docs/RUNTIME_CUTLINE_2026-03-16.md` for the runtime-start cutline on open contract deltas
-- the live planning sweep query plus issue #11 for same-day blocker/evidence handoff instead of closed historical sweep issues
+- `docs/RUNTIME_EXECUTION_HANDOFF.md` plus issue #11 for the canonical runnable evidence path on current `main`
+- the live planning sweep query for same-day blocker/handoff checks instead of closed historical sweep issues
 
 ## Gate Summary
 
 | Gate | Status | Ready when | Active dependencies | Evidence to collect |
 | --- | --- | --- | --- | --- |
-| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #120, PR #159, PR #133, PR #152, PR #153, PR #154, PR #161, PR #164, PR #165, PR #166, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
-| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | issue #115, merged PR #129, merged PR #127 baseline, issue #111, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
-| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #120, issue #111, issue #11, merged PR #127 baseline, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
+| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #11, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PR #133, PR #170, PR #189, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
+| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | issue #115, `docs/RUNTIME_EXECUTION_HANDOFF.md`, PR #191, PR #182, PR #172, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
+| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #11, PR #182, PR #172, `docs/BACKEND_API_EXAMPLE_PACKET.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
 | Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | merged PR #127, merged PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | issue #137, issue #115, issue #111, issue #11, current `owner:albatross` + `stream/review-burndown` planning sweep issue | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
+| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | PR #190, PR #174, PR #166, issue #115, issue #11, current `owner:albatross` + `stream/review-burndown` planning sweep | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/ROADMAP.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
 
 ## Gate Details
 
@@ -28,8 +29,8 @@ reviewable release gates for closed-beta readiness. It complements:
 This remains the prerequisite for durable runtime behavior and executable QA checks.
 
 - Verifier terminal vocabulary and award-trace expectations now come from merged PR #83 and merged PR #92.
-- The merged runtime/frontend baseline is on `main` through PR #126 and PR #139; PR #127 merged on 2026-03-17 at 13:54:46Z and PRs #129, #140, and #141 all merged later that day, so the active convergence risk is now keeping the live review queue (`#159`, `#133`, `#152`, `#153`, `#154`, `#161`, `#164`, `#165`, `#166`) synced to the published contract vocabulary.
-- The dated QA sweep in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` now records which runtime routes are actually published on `main`, so reviewers can distinguish proof-enum drift from still-pending read-model routes.
+- The merged runtime/frontend baseline is on `main` through PR #126 and PR #139; PR #127 merged on 2026-03-17 at 13:54:46Z and PRs #129, #140, and #141 all merged later that day, so the active convergence risk is now keeping the surviving live review queue (`#133`, `#170`, `#189`) synced to the published contract vocabulary instead of reopening older contract snapshots.
+- The dated QA sweep in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` records which runtime routes are actually published on `main`, so reviewers can distinguish proof-enum drift from still-pending read-model routes without treating closed issue #120 as current work.
 - Merged PR #140 is the planning guardrail for the dated blocker ledger; the current doc queue should reuse that merged baseline instead of reopening stale snapshots across long-lived docs.
 
 Release note: if any active runtime branch changes enum names, required fields, route shapes, or error-code wording, the same update must land in OpenSpec plus both API drafts before the gate can be marked ready.
@@ -38,15 +39,15 @@ Release note: if any active runtime branch changes enum names, required fields, 
 
 Happy-path readiness is runtime-first, not docs-first.
 
-While this gate remains blocked until the runnable flow exists, the runtime threads do not have to wait for every historical contract branch. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus the current planning sweep / issue #11 evidence threads to separate true blockers from additive-safe follow-ups.
+While this gate remains blocked until the runnable flow exists, the runtime threads do not have to wait for every historical contract branch. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus `docs/RUNTIME_EXECUTION_HANDOFF.md` and the live issue #11 evidence thread to separate true blockers from additive-safe follow-ups.
 
 Required outcome:
 
 - a local service starts from one documented command
 - one reproducible request sequence executes `publish -> match -> commit -> reveal -> verify -> award`
-- results are captured by executable smoke/E2E checks tied to issue #111 and linked back to issue #11
+- results are captured by the canonical signed issue #11 evidence path (`npm run --silent smoke:issue11 -- --signature <agent-name>`) plus the reusable request/response packet in `docs/BACKEND_API_EXAMPLE_PACKET.md`
 
-Reference docs and planning notes are only useful if they map directly to runnable assertions and a stable local command path.
+Reference docs and planning notes are only useful if they map directly to runnable assertions and a stable local command path. PR #191, PR #182, and PR #172 are the current surviving follow-through threads because they keep that one `main` command reviewable across backend, CI, and QA.
 
 ### 3. Negative-scenario coverage
 
@@ -59,7 +60,7 @@ Minimum scenarios to keep visible:
 - proof verification returns `FAIL`
 - award attempt blocked before prerequisite verification is complete
 
-Expected output for each scenario must cite a stable error code or terminal status/result from the merged contract vocabulary. Use `npm run check:contract-drift` when a PR claims a route or proof-verification enum is already on `main`.
+Expected output for each scenario must cite a stable error code or terminal status/result from the merged contract vocabulary. Use `npm run check:contract-drift` when a PR claims a route or proof-verification enum is already on `main`, and use the signed issue #11 evidence command when QA needs one paste-ready negative-path bundle instead of ad hoc PR comments.
 
 ### 4. Audit evidence trail
 
@@ -84,8 +85,8 @@ At minimum, these must stay in lockstep:
 - `docs/PHASE1_EPIC_STATUS.md`
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
-- the current planning sweep issue returned by the `owner:albatross` + `stream/review-burndown` query
-- runtime delivery threads (`#115`, `#159`, `#164`, `#165`, `#166`, `#161`, `#154`, `#153`, `#152`, `#133`, `#111`, and blocked follow-through `#11`)
+- `docs/RUNTIME_EXECUTION_HANDOFF.md`
+- current planning sweep queries plus runtime delivery threads (`#115`, `#133`, `#170`, `#189`, PR #191, PR #182, PR #172, and the live evidence gate `#11`)
 
 ## Review Routine
 
@@ -95,5 +96,7 @@ Review these gates whenever one of the following happens:
 - a contract enum or error-code changes
 - QA smoke/E2E execution scope changes
 - epic #2 checklist changes
+
+Closed issue references such as #111 and #120 may stay in dated historical notes, but they should not be listed as active gate dependencies once the runnable evidence lane has moved to issue #11.
 
 If a gate changes status, update the epic rollup and checkpoint board in the same review window.


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: Refresh the Phase 1 beta-readiness gate doc so issue #2 points at the current issue #11 evidence path and surviving review queue.

## What Changed

- refreshed `docs/PHASE1_BETA_READINESS_GATES.md` to use `docs/RUNTIME_EXECUTION_HANDOFF.md` plus issue #11 as the canonical runnable evidence lane
- replaced stale closed-blocker dependencies in the gate table with the current surviving review queue (`#133`, `#170`, `#189`, `#191`, `#182`, `#172`)
- clarified the execution/handoff hygiene gate so planning docs track the live planning sweep plus issue #11 instead of older historical blocker ledgers

## Why

- `main` still described beta-readiness gates through closed issues and older review stacks, which made issue #2 look blocked on stale references instead of the current runnable evidence path
- the epic needs one compact gate sheet that matches the surviving runtime, QA, CI, and planning follow-through threads reviewers are actually using now

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Epic release-gate docs point to the live runnable evidence lane | The beta-readiness sheet now treats `docs/RUNTIME_EXECUTION_HANDOFF.md` + issue #11 as the canonical happy/negative-path handoff instead of older closed blockers | `docs/PHASE1_BETA_READINESS_GATES.md` |
| Planning and review surfaces describe the same remaining blockers | The gate summary and hygiene section now name the current planning sweep and surviving review queue rather than closed issues #111/#120 or retired stacks | `docs/PHASE1_BETA_READINESS_GATES.md`, `openspec validate --all` |

## QA Plan

### Preconditions

- Branch `codex/issue-2-beta-gates-runtime-refresh` is rebased on current `origin/main`

### Steps

1. Open `docs/PHASE1_BETA_READINESS_GATES.md`.
2. Confirm the complements and happy-path sections point at `docs/RUNTIME_EXECUTION_HANDOFF.md` plus issue #11.
3. Confirm the gate table and hygiene section list the current surviving review queue instead of closed issues #111/#120 as active dependencies.

### Expected Results

- Beta-readiness guidance matches the live issue #11 evidence lane on `main`.
- Reviewers can see which open PRs still matter for contract, smoke, and planning follow-through.
- The doc no longer treats closed historical blockers as active release-gate owners.

### Validation Output

- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent --skip-fetch`
```text
[ok] Branch 'codex/issue-2-beta-gates-runtime-refresh' uses codex/ prefix.
[warn] Skipping git fetch (--skip-fetch).
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - another active planning/beta-readiness PR may rewrite the same gate references, so this branch may need one more rebase before merge
- Rollback:
  - revert commit `bdf99ac` to restore the prior beta-readiness wording

## Checklist

- [x] Exactly one department label is set (`dept/planning`)
- [x] Exactly one type label is set (`type/docs`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
