### PR TITLE
[P1-09] Refresh planning anchors to issue #11 evidence lane

### DIFF
--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -15,7 +15,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
 | OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, issue #167, PR #174, PR #176, PR #179, PR #133 | Merge the post-runtime planning/reference cleanup, then keep PR #133 aligned to the published contract vocabulary. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issues #177, #178, and #11 | Publish one canonical smoke evidence format, run the formatter-backed smoke pass, and paste the final evidence back onto issue #11. |
+| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issue #11, PR #172, PR #194, merged PR #182 | Keep one canonical smoke evidence command on `main`, reuse it from the active QA handoff PRs, and paste the final evidence back onto issue #11. |
 | Core negative scenarios are covered | Blocked | issue #11, PR #172, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Turn the documented failure cases into reproducible smoke evidence tied to the merged runtime baseline. |
 | Audit events cover key state transitions | In progress | merged runtime baseline from issues #109/#110, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, issue #11 | Keep the verify/award/audit follow-through aligned while the final smoke evidence proves the emitted trail. |
 
@@ -41,8 +41,8 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Post-runtime planning refresh | issue #167, PR #174, PR #176, PR #179 | These threads remove stale references to closed runtime/QA issues and establish one consistent planning baseline for the remaining Phase 1 queue. |
 | Overlapping planning rollups | PR #171, PR #154, PR #165, PR #166, PR #161, PR #153 | These older planning refresh branches should either be folded into PR #179 or closed as superseded so the repo stops carrying conflicting queue snapshots. |
 | Verify/award contract adoption | PR #133 | The checklist still needs to describe only the proof fields, error codes, and reason-code vocabulary that are actually published on `main`. |
-| Backend smoke formatter | issue #177 / PR #175 | QA needs one canonical backend-owned evidence block before the final smoke pass can be repeated consistently. |
-| QA packet and smoke evidence | PR #172, issue #178, issue #11 | The remaining QA work is to reuse the canonical formatter output, run the bounded smoke pass, and post the exact result on issue #11. |
+| Canonical smoke evidence handoff | issue #11, `docs/RUNTIME_EXECUTION_HANDOFF.md`, `src/runtime/README.md` | This is the live source of truth for the signed `smoke:issue11` evidence reviewers should cite from `main`. |
+| QA packet and smoke evidence reuse | PR #172, PR #194, issue #11, merged PR #182 | The remaining QA work is to keep the packet and dated contract-drift notes aligned to the smoke CLI regression coverage already merged on `main` and the same canonical issue #11 command/output. |
 
 ### Remaining blocked slices
 
@@ -58,15 +58,15 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | 2 | PR #176 `docs: codify planning reference rules` | Makes the contributor/reference rules match the post-runtime review workflow. | Future planning PRs point at live queries and same-day sweep threads instead of closed issues. |
 | 3 | PR #179 `[P1-167] Refresh planning docs to post-runtime baseline` | Preferred surviving rollup for issue #167 after the two smaller doc fixes land. | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, and this file all describe the same post-runtime queue. |
 | 4 | PRs #171, #154, #165, #166, #161, #153 | Overlapping planning branches should no longer stay open as competing snapshots. | Close, fold, or restack them behind the merged #167 rollup. |
-| 5 | PR #133, issue #177, issue #178, issue #11 | Contract wording and final smoke evidence remain after planning drift is removed. | One canonical smoke evidence path feeds the final QA sign-off thread. |
+| 5 | PR #133, PR #172, PR #194, issue #11 | Contract wording and final smoke evidence remain after planning drift is removed. | One canonical smoke evidence path, backed by the already-merged PR #182 coverage on `main`, feeds the final QA sign-off thread. |
 
 ## Checkpoint Rollup
 
 | Checkpoint | Epic relevance | Current note |
 | --- | --- | --- |
 | M1 | Post-runtime planning/reference cleanup | The immediate M1 gate is landing the #167 planning refresh plus PR #174 and PR #176 without leaving older duplicate status threads behind. |
-| M2 | Runtime evidence formatting and reuse | Backend still needs the canonical smoke formatter path from issue #177 / PR #175 before QA can reuse it cleanly. |
-| M3 | Verify, audit, and executable QA | PR #172, issue #178, and issue #11 are the remaining proof points for runnable smoke evidence on top of the merged runtime baseline. |
+| M2 | Runtime evidence formatting and reuse | QA now needs the surviving handoff docs/PRs to keep pointing at the canonical `smoke:issue11` path on `main` without reopening superseded formatter issues. |
+| M3 | Verify, audit, and executable QA | PR #172, PR #194, and issue #11 are the remaining live proof points for runnable smoke evidence on top of the merged runtime baseline, with PR #182 already merged as supporting CLI coverage. |
 | M4 | Beta readiness sign-off | Issue #11 final E2E evidence and audit/security verification remain required. |
 
 ## Epic Exit Checklist

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -101,11 +101,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Implementation-scoped issues are closed only when runtime code or executable test coverage is merged.
 - End-to-end happy path + key negative paths are covered by automated tests.
 - One local command path can run service + smoke checks for happy path and core negatives.
-<<<<<<< HEAD
-- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`; closed formatter/drift work should stay as baseline references or dated snapshots rather than active blockers.
-=======
-- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/BACKEND_API_EXAMPLE_PACKET.md`, and the live issue #11 follow-through PRs.
->>>>>>> 79c6d54 (docs: refresh issue 11 planning evidence anchors)
+- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/BACKEND_API_EXAMPLE_PACKET.md`, and the live issue #11 follow-through PRs; closed formatter/drift work should stay as baseline references or dated snapshots rather than active blockers.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Weekly epic #2 checkpoints use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so owner handoffs and validation-evidence gaps stay consistent across review weeks.

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -25,6 +25,9 @@ Ship the first usable agent dispatch loop for closed beta:
 - Active follow-through threads for the pivot:
   - #167 planning-doc refresh to the post-runtime baseline
   - issue #11 as the live smoke evidence umbrella for the canonical handoff command in `docs/RUNTIME_EXECUTION_HANDOFF.md`
+  - PR #172 API packet/snippet follow-through for QA consumers
+  - PR #194 dated QA contract-drift handoff refresh
+  - merged PR #182 as the smoke CLI regression coverage baseline already on `main`
   - new runtime/QA follow-up issues only when fresh drift appears beyond the closed `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` snapshot
 - Planning-only follow-ups (#106, #107, #108) were closed to keep sprint bandwidth on runtime delivery.
 - QA prewrite-only tracks (#87, PR #84, PR #104) remain superseded by the executable evidence path on issue #11.
@@ -98,7 +101,11 @@ Ship the first usable agent dispatch loop for closed beta:
 - Implementation-scoped issues are closed only when runtime code or executable test coverage is merged.
 - End-to-end happy path + key negative paths are covered by automated tests.
 - One local command path can run service + smoke checks for happy path and core negatives.
+<<<<<<< HEAD
 - The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`; closed formatter/drift work should stay as baseline references or dated snapshots rather than active blockers.
+=======
+- The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/BACKEND_API_EXAMPLE_PACKET.md`, and the live issue #11 follow-through PRs.
+>>>>>>> 79c6d54 (docs: refresh issue 11 planning evidence anchors)
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Weekly epic #2 checkpoints use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so owner handoffs and validation-evidence gaps stay consistent across review weeks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -80,11 +80,7 @@ De-scoped from current sprint:
 2. Merge PR #176 (`docs: codify planning reference rules`) so contributor guidance matches the post-runtime review workflow.
 3. Refresh and merge PR #179 (`[P1-167] Refresh planning docs to post-runtime baseline`) as the single surviving planning rollup for issue #167.
 4. Close, restack, or fold overlapping planning refresh PRs (#171, #154, #165, #166, #161, #153) behind the merged #167 rollup instead of keeping multiple conflicting status snapshots open.
-<<<<<<< HEAD
-5. Revisit PR #133 once the planning baseline is stable, then keep the canonical smoke evidence path anchored to issue #11 plus `docs/RUNTIME_EXECUTION_HANDOFF.md`.
-=======
-5. Revisit PR #133 once the planning baseline is stable, then keep the canonical smoke evidence path anchored on issue #11 plus the surviving QA handoff PRs.
->>>>>>> 79c6d54 (docs: refresh issue 11 planning evidence anchors)
+5. Revisit PR #133 once the planning baseline is stable, then keep the canonical smoke evidence path anchored to issue #11, the surviving QA handoff PRs, and `docs/RUNTIME_EXECUTION_HANDOFF.md`.
 
 ### Phase 2: Execution & Trust Loop (Target: 2026-05 to 2026-06)
 
@@ -111,11 +107,7 @@ Scope:
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
 - M1 (2026-03-20): close post-runtime planning/reference drift (#167, PR #174, PR #176) and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
-<<<<<<< HEAD
-- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA publish one canonical smoke evidence path through issue #11 and `docs/RUNTIME_EXECUTION_HANDOFF.md`.
-=======
-- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA keep one canonical smoke evidence path on issue #11 and `smoke:issue11`.
->>>>>>> 79c6d54 (docs: refresh issue 11 planning evidence anchors)
+- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA keep one canonical smoke evidence path through issue #11, `docs/RUNTIME_EXECUTION_HANDOFF.md`, and `smoke:issue11`.
 - M3 (2026-04-03): stabilize verify/award/audit evidence and run executable smoke checks against the merged runtime baseline.
 - M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -51,7 +51,8 @@ Scope:
 - PoMW verification baseline with identity-tier policy.
 - Auditable award events and minimal reputation writeback hook.
 - Lifecycle observability baseline for `upload -> match -> bid -> verify -> award`.
-- Closed-beta evidence handoff stays concentrated on issue #11 plus the canonical runtime command path in `docs/RUNTIME_EXECUTION_HANDOFF.md`.
+- Closed-beta evidence handoff stays concentrated on issue #11 plus its active QA follow-through PRs (`#172`, `#194`), the canonical runtime command path in `docs/RUNTIME_EXECUTION_HANDOFF.md`, and the canonical `npm run --silent smoke:issue11 -- --signature <agent-name>` command.
+- Merged PR #182 remains the baseline reference for smoke CLI regression coverage already present on `main`, not an active handoff lane.
 
 Exit criteria:
 - Core APIs available and documented in `src/api/openapi.yaml`.
@@ -66,7 +67,7 @@ Focus:
 - Clear the planning/reference review blockers on PR #174 and PR #176 so post-runtime docs stop pointing at closed issues.
 - Land one surviving planning rollup for issue #167; use PR #179 as the preferred branch to absorb the refresh and close or supersede overlapping older planning PRs (#171, #154, #165, #166, #161, #153).
 - Keep PR #133 aligned to the published verify/award contract vocabulary after the planning refresh settles.
-- Move QA evidence forward through issue #11 and the canonical runtime handoff docs instead of reopening closed issue #120 or other merged formatter follow-ups.
+- Move QA evidence forward through issue #11, its live handoff PRs, and the canonical runtime handoff docs instead of reopening closed issue #120 or other merged formatter follow-ups.
 
 De-scoped from current sprint:
 - Planning-only follow-ups #106, #107, #108 were closed to avoid additional doc-layer churn.
@@ -79,7 +80,11 @@ De-scoped from current sprint:
 2. Merge PR #176 (`docs: codify planning reference rules`) so contributor guidance matches the post-runtime review workflow.
 3. Refresh and merge PR #179 (`[P1-167] Refresh planning docs to post-runtime baseline`) as the single surviving planning rollup for issue #167.
 4. Close, restack, or fold overlapping planning refresh PRs (#171, #154, #165, #166, #161, #153) behind the merged #167 rollup instead of keeping multiple conflicting status snapshots open.
+<<<<<<< HEAD
 5. Revisit PR #133 once the planning baseline is stable, then keep the canonical smoke evidence path anchored to issue #11 plus `docs/RUNTIME_EXECUTION_HANDOFF.md`.
+=======
+5. Revisit PR #133 once the planning baseline is stable, then keep the canonical smoke evidence path anchored on issue #11 plus the surviving QA handoff PRs.
+>>>>>>> 79c6d54 (docs: refresh issue 11 planning evidence anchors)
 
 ### Phase 2: Execution & Trust Loop (Target: 2026-05 to 2026-06)
 
@@ -106,7 +111,11 @@ Scope:
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
 - M1 (2026-03-20): close post-runtime planning/reference drift (#167, PR #174, PR #176) and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
+<<<<<<< HEAD
 - M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA publish one canonical smoke evidence path through issue #11 and `docs/RUNTIME_EXECUTION_HANDOFF.md`.
+=======
+- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA keep one canonical smoke evidence path on issue #11 and `smoke:issue11`.
+>>>>>>> 79c6d54 (docs: refresh issue 11 planning evidence anchors)
 - M3 (2026-04-03): stabilize verify/award/audit evidence and run executable smoke checks against the merged runtime baseline.
 - M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/docs`
- Scope: Refresh the Phase 1 planning snapshots so issue #11 points at the canonical `smoke:issue11` evidence lane instead of closed formatter issues.

## What Changed

- updated `docs/PHASE1_GOALS.md` so the execution-pivot follow-through list now points at live issue #11 handoff work (`#11`, `#172`, `#182`, `#194`) instead of closed issues `#177` / `#178`
- updated `docs/ROADMAP.md` so the roadmap, sprint focus, merge sequence, and M2 milestone all reference the surviving `smoke:issue11` command and live QA follow-through PRs
- updated `docs/PHASE1_EPIC_STATUS.md` so the epic acceptance snapshot and checkpoint rollup describe the current issue #11 evidence path on `main`

## Why

- Avery's QA lane is still tracking issue #11 as the only live executable evidence gate, but several planning docs were still pointing reviewers at closed formatter follow-up issues.
- That drift makes review comments and checkpoint summaries cite stale threads instead of the canonical `npm run --silent smoke:issue11 -- --signature <agent-name>` path and the live issue #11 handoff PRs.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Planning docs should point reviewers at the live issue #11 evidence lane instead of closed formatter issues. | Replaced stale `#177` / `#178` references in the Phase 1 goals, roadmap, and epic status snapshots with issue #11 plus the surviving QA handoff PRs. | `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, `docs/PHASE1_EPIC_STATUS.md` |
| The canonical command/evidence path should stay explicit in repo planning snapshots. | Anchored the snapshots on `npm run --silent smoke:issue11 -- --signature <agent-name>`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, and the current issue #11 follow-through path on `main`. | `docs/ROADMAP.md`, `docs/PHASE1_EPIC_STATUS.md` |

## QA Plan

### Preconditions

- Use current `origin/main` as the branch baseline.
- Have OpenSpec CLI available in the repo environment.

### Steps

1. Review the updated planning docs for stale references to closed issues `#177` / `#178`.
2. Run `openspec validate --all`.
3. Run `git diff --check`.

### Expected Results

- The edited docs point at issue #11 and the surviving QA follow-through PRs instead of closed formatter issues.
- OpenSpec validation passes.
- `git diff --check` reports no whitespace or merge-marker problems.

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
(no output)
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/p1-11-planning-evidence-anchor-20260319' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - These docs mention live PR numbers, so they can drift again if the queue changes.
- Rollback:
  - Revert commit `79c6d54` or restore the three planning docs to the previous baseline if the live handoff path changes again.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
