### PR TITLE
docs: add phase 1 acceptance trace

### DIFF
--- a/docs/PHASE1_ACCEPTANCE_TRACE.md
+++ b/docs/PHASE1_ACCEPTANCE_TRACE.md
@@ -1,0 +1,59 @@
+# Phase 1 Acceptance Trace
+
+Last updated: 2026-03-19
+
+This document is the durable acceptance-to-evidence map for epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`).
+Use it to decide whether a milestone, issue, or PR comment is actually moving Phase 1 toward a shippable closed-beta baseline.
+
+Keep volatile queue state in GitHub. This file should only answer three stable questions:
+- which epic acceptance area is being advanced
+- which docs or live issue/query own the next executable step
+- which evidence must exist before the acceptance area can be treated as satisfied
+
+## Acceptance map
+
+| Epic acceptance area | Stable source of truth | Live delivery lane | Required evidence before we call it done | Review notes |
+| --- | --- | --- | --- | --- |
+| OpenSpec artifacts, OpenAPI draft, and implementation stay aligned | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts` | merge-ready runtime and planning PRs plus the issue `#11` evidence lane | `openspec validate --all` passes on the merge-ready branch; any contract-scope diff updates OpenSpec plus both API drafts in the same change; runnable proof links back into issue `#11` when the branch changes execution behavior | Treat this as a release-wide invariant, not a one-time milestone gate |
+| Happy-path dispatch flow is runnable end to end | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/BACKEND_API_EXAMPLE_PACKET.md` | issue `#11` using the canonical smoke command and packet baseline published on `main` | One local command path exercises `publish -> match -> commit -> reveal -> verify -> award`, records the evidence bundle expected by `docs/RUNTIME_EXECUTION_HANDOFF.md`, and is replayable without reconstructing payloads from PR comments | Do not accept doc-only claims for this area |
+| Core negative scenarios are covered by executable checks | `docs/RUNTIME_EXECUTION_HANDOFF.md`, `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` | issue `#11` plus the current QA/runtime review queue | Automated checks cover blocked reveal, invalid signature, proof `FAIL`, and award-blocked paths; expected results use the published contract vocabulary and the rerun evidence links back into issue `#11` | If the check is manual-only, the acceptance area is still open |
+| Audit trail covers key state transitions | `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/PHASE1_BETA_READINESS_GATES.md` | issue `#11` plus the backend-owned smoke evidence path already merged on `main` | Runtime evidence shows audit output for task creation, bid commit, bid reveal, proof verification, and award; the emitted fields stay traceable to the published contracts and packet examples | Audit docs without runtime evidence are preparatory, not sufficient |
+
+## Milestone handoff rules
+
+### M1: post-runtime baseline hygiene
+
+Use M1 review to answer:
+- are OpenSpec, OpenAPI, and TypeScript contract updates still merged together whenever scope changes
+- do checkpoint and roadmap docs point reviewers at live planning queries plus issue `#11`, instead of closed blocker issues
+- does the runtime handoff packet still name one canonical command path that later milestones can reuse
+
+### M2: dispatch loop replayability
+
+Use M2 review to answer:
+- does issue `#11` contain one replayable happy-path packet instead of scattered PR-only evidence
+- do merged runtime-facing docs stay inside the published API baseline
+- is the evidence output concrete enough for QA or beta consumers to rerun without inventing missing steps
+
+### M3: verify, audit, and smoke durability
+
+Use M3 review to answer:
+- do the negative-path checks remain runnable against the merged baseline
+- do verify and audit outputs show up in the same evidence packet as the happy-path run
+- does the dated QA sweep still agree with the published OpenAPI and TypeScript contract vocabulary
+
+### M4: beta readiness closure
+
+Use M4 review to answer:
+- does issue `#11` contain the final evidence chain for happy path plus key negatives
+- are the audit, telemetry, and security readiness docs still aligned to the executable baseline
+- is there any remaining acceptance area whose proof still depends on a docs-only claim
+
+## Review routine
+
+1. Start from the milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
+2. Use `docs/PHASE1_ACCEPTANCE_TRACE.md` to map the checkpoint back to the epic acceptance area it is supposed to close.
+3. Check `docs/RUNTIME_EXECUTION_HANDOFF.md` for the command contract and evidence bundle shape.
+4. Confirm the branch or PR under review updates OpenSpec and the API drafts whenever scope changes.
+5. Post weekly epic #2 checkpoints with `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so each update uses the same Done, Blocked, Ready next, and Validation evidence gaps structure.
+6. If evidence is missing, keep the acceptance area open and push the gap back into the relevant GitHub issue or PR instead of copying transient status into repo docs.

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -8,8 +8,8 @@ This document keeps only the stable checkpoint structure and links to the live m
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
 | M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus verify/award contract adoption (planning review-burndown queue, PR #174, PR #133). |
-| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend publishes canonical smoke formatting and evidence (#177, PR #175). |
-| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Formatter-backed smoke pass, QA packet updates, and final issue #11 evidence handoff (#178, PR #172, issue #11). |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend evidence stays anchored on merged PR #175 and the issue #11 replay path. |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Smoke-command replay on merged PR #172 plus final issue #11 evidence handoff. |
 | M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
 
 ## Metadata hygiene queries
@@ -27,8 +27,8 @@ Sprint pivot dated 2026-03-16 now uses these anchors by default:
 
 - Closed runtime baseline: `#109`, `#110`, `#111`
 - Live planning refresh: `owner:albatross` + `stream/review-burndown` query
-- Live backend formatter handoff: `#177`
-- Live QA smoke handoff: `#178`
+- Backend evidence baseline on `main`: merged PR #175
+- Smoke-command handoff on `main`: merged PR #172
 - Final evidence gate: `#11`
 
 ## Review routine
@@ -36,12 +36,13 @@ Sprint pivot dated 2026-03-16 now uses these anchors by default:
 1. Open milestone issue and PR links instead of editing status snapshots in-repo.
 2. Use labels such as `status/ready-next`, `status/in-review`, and owner labels to decide next merge or rebase action.
 3. Run the metadata hygiene queries and clear any missing milestone or priority gaps before posting the checkpoint.
-4. Use `docs/RUNTIME_EXECUTION_HANDOFF.md` and `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` for dated runtime evidence context instead of copying those volatile notes into this guide.
-5. Run the same-day planning sweep from the `owner:albatross` + `stream/review-burndown` query before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a live GitHub trail.
-6. Keep at most one mergeable `dept/planning` checkpoint-sync PR open for that sweep; all other overlapping planning PRs should get signed merge/close rationale in GitHub instead of staying in parallel review.
-7. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
-8. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
-9. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
+4. Use `docs/PHASE1_ACCEPTANCE_TRACE.md` to map the checkpoint back to the epic acceptance area and evidence expectation it is meant to close.
+5. Use `docs/RUNTIME_EXECUTION_HANDOFF.md` and `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` for dated runtime evidence context instead of copying those volatile notes into this guide.
+6. Run the same-day planning sweep from the `owner:albatross` + `stream/review-burndown` query before the checkpoint comment so blocker notes, clean-order updates, and validation gaps all have a live GitHub trail.
+7. Keep at most one mergeable `dept/planning` checkpoint-sync PR open for that sweep; all other overlapping planning PRs should get signed merge/close rationale in GitHub instead of staying in parallel review.
+8. Treat missing validation evidence in a PR body/comment as a real blocker, even when the code diff looks complete.
+9. Capture only durable planning changes in repo docs; keep comments, review notes, and volatile state in GitHub threads.
+10. If merge-train triage uncovers a new durable blocker, open or link a follow-up issue instead of adding a status snapshot here.
 
 ## When to edit this file
 

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -17,15 +17,16 @@ Ship the first usable agent dispatch loop for closed beta:
 
 - The runtime pivot delivered its baseline implementation threads and now moves into evidence and planning cleanup.
 - Runtime cutline decisions for open contract PRs live in `docs/RUNTIME_CUTLINE_2026-03-16.md`; use that table to decide which deltas block follow-through versus which are additive-safe.
-- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when issue #177, issue #178, or issue #11 claims executable progress.
+- Runtime command/evidence expectations live in `docs/RUNTIME_EXECUTION_HANDOFF.md`; use that handoff contract when merged PR #175, merged PR #172, or issue #11 claims executable progress.
+- `docs/PHASE1_ACCEPTANCE_TRACE.md` is the durable acceptance map for epic #2; use it to decide which evidence lane is supposed to close each acceptance area.
 - Closed baseline issues from the pivot:
   - #109 backend runtime skeleton
   - #110 runnable dispatch vertical slice
   - #111 executable QA smoke/E2E checks
 - Active follow-through threads for the pivot:
-  - #167 planning-doc refresh to the post-runtime baseline
-  - #177 canonical backend smoke formatter and evidence block
-  - #178 formatter-backed smoke pass that feeds issue #11
+  - live planning refresh from the `owner:albatross` + `stream/review-burndown` query
+  - merged PR #175 as the backend evidence-format baseline on `main`
+  - merged PR #172 as the smoke-command handoff on `main` that feeds issue #11
 - Planning-only follow-ups (#106, #107, #108) were closed to keep sprint bandwidth on runtime delivery.
 - QA prewrite-only tracks (#87, PR #84, PR #104) remain superseded by the executable evidence path on issue #11.
 - Closed issue #120 is a dated QA sweep baseline, not an active blocker.
@@ -99,6 +100,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - End-to-end happy path + key negative paths are covered by automated tests.
 - One local command path can run service + smoke checks for happy path and core negatives.
 - The canonical command path and evidence handoff into issue #11 are documented in `docs/RUNTIME_EXECUTION_HANDOFF.md` and the active formatter/smoke follow-through threads.
+- `docs/PHASE1_ACCEPTANCE_TRACE.md` remains the canonical acceptance-to-evidence map for epic #2 and milestone reviews.
 - GitHub issues for Phase 1 epics/tasks are created and linked to this plan.
 - Every active P1 issue/PR is discoverable from the M1-M4 milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Weekly epic #2 checkpoints use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` so owner handoffs and validation-evidence gaps stay consistent across review weeks.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,6 +14,7 @@ Build a trustworthy agent dispatch network where managers can publish tasks, age
 - Keep API-first implementation aligned with OpenSpec artifacts.
 - Resolve repository readiness blockers (P0) before broad Phase 1 implementation.
 - Runtime implementation evidence is required before closing `Implement`-scoped issues (spec/docs-only PRs are not sufficient).
+- Epic acceptance reviews use `docs/PHASE1_ACCEPTANCE_TRACE.md` so milestone closure stays tied to executable evidence instead of doc-only status claims.
 
 ## Phase Plan
 
@@ -51,7 +52,7 @@ Scope:
 - PoMW verification baseline with identity-tier policy.
 - Auditable award events and minimal reputation writeback hook.
 - Lifecycle observability baseline for `upload -> match -> bid -> verify -> award`.
-- Closed-beta evidence handoff stays concentrated on issue #11 plus its immediate formatter/smoke follow-through issues (#177 and #178).
+- Closed-beta evidence handoff stays concentrated on issue #11 plus the merged backend evidence and smoke-command baselines on `main` (PR #175 and PR #172).
 
 Exit criteria:
 - Core APIs available and documented in `src/api/openapi.yaml`.
@@ -64,9 +65,9 @@ Exit criteria:
 Focus:
 - Treat issues #109, #110, and #111 as merged runtime baseline work.
 - Clear the planning/reference review blockers on PR #174 and PR #176 so post-runtime docs stop pointing at closed issues.
-- Land one surviving planning rollup for issue #167; use PR #179 as the preferred branch to absorb the refresh and close or supersede overlapping older planning PRs (#171, #154, #165, #166, #161, #153).
+- Use the live `owner:albatross` + `stream/review-burndown` query to keep only one surviving planning-sync PR per sweep and close or supersede overlapping older planning PRs.
 - Keep PR #133 aligned to the published verify/award contract vocabulary after the planning refresh settles.
-- Move QA evidence forward through issue #177, issue #178, and issue #11 instead of reopening closed issue #120.
+- Move QA evidence forward through merged PR #175, merged PR #172, and issue #11 instead of reopening closed issue #120.
 
 De-scoped from current sprint:
 - Planning-only follow-ups #106, #107, #108 were closed to avoid additional doc-layer churn.
@@ -77,9 +78,9 @@ De-scoped from current sprint:
 
 1. Merge PR #174 (`docs: refresh runtime handoff baseline`) after removing the last stale references to closed issue #120.
 2. Merge PR #176 (`docs: codify planning reference rules`) so contributor guidance matches the post-runtime review workflow.
-3. Refresh and merge PR #179 (`[P1-167] Refresh planning docs to post-runtime baseline`) as the single surviving planning rollup for issue #167.
-4. Close, restack, or fold overlapping planning refresh PRs (#171, #154, #165, #166, #161, #153) behind the merged #167 rollup instead of keeping multiple conflicting status snapshots open.
-5. Revisit PR #133 once the planning baseline is stable, then hand the canonical smoke evidence path to issue #177, issue #178, and issue #11.
+3. Merge one clean planning-sync refresh from the live `owner:albatross` + `stream/review-burndown` sweep and close or supersede overlapping planning rollups behind it.
+4. Revisit PR #133 once the planning baseline is stable and the verify/award checklist stays aligned to the published contract vocabulary.
+5. Keep issue #11 as the only live final evidence gate, using merged PR #175 and merged PR #172 as the reusable backend/smoke baseline on `main`.
 
 ### Phase 2: Execution & Trust Loop (Target: 2026-05 to 2026-06)
 
@@ -105,8 +106,8 @@ Scope:
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
-- M1 (2026-03-20): close post-runtime planning/reference drift (#167, PR #174, PR #176) and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
-- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA publish one canonical smoke evidence path (#177, #178, issue #11).
+- M1 (2026-03-20): close post-runtime planning/reference drift (live planning sweep, PR #174, PR #176) and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
+- M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA keep one canonical smoke evidence path replayable on `main` (merged PR #175, merged PR #172, issue #11).
 - M3 (2026-04-03): stabilize verify/award/audit evidence and run executable smoke checks against the merged runtime baseline.
 - M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.
 - M4 readiness also requires `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, and `docs/CLOSED_BETA_SECURITY_READINESS.md` so telemetry owners plus auth, secret-handling, and redaction follow-ons stay reviewable.
@@ -114,6 +115,7 @@ Scope:
 
 Checkpoint status board:
 - Review `docs/PHASE1_CHECKPOINT_BOARD.md` for milestone links, target owners, and checkpoint review prompts.
+- Use `docs/PHASE1_ACCEPTANCE_TRACE.md` to decide which acceptance area a checkpoint comment or review thread is actually closing.
 - Use `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md` when posting the weekly epic #2 checkpoint so the comment keeps the same Done/Blocked/Ready next/Validation evidence gaps shape plus owner handoff table.
 
 ## Phase 1 KPIs

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -9,6 +9,7 @@
 - [x] 0.7 收敛 `docs/issues/PHASE1_ISSUES.md` 与 `docs/PHASE1_CHECKPOINT_BOARD.md` 为稳定索引，改用 GitHub 查询承载高频 issue / PR 状态。
 - [x] 0.8 输出 `docs/MVP_STATE_MODEL.md`，冻结 MVP 状态机与关键写入时序约束。
 - [x] 0.9 输出 `docs/MERGE_TRAIN_PLAYBOOK.md`，统一 clean LGTM merge train、dirty queue 回写与 rebase 协作流程。
+- [x] 0.10 输出 `docs/PHASE1_ACCEPTANCE_TRACE.md`，把 epic #2 的验收项、里程碑 handoff 与证据要求收敛为稳定索引，避免把高频队列状态写回仓库文档。
 
 ## 1. OpenSpec 基础落地
 


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: add one durable acceptance-to-evidence trace for epic #2 and refresh the stable checkpoint anchors to current runtime evidence lanes

## What Changed

- added `docs/PHASE1_ACCEPTANCE_TRACE.md` as the canonical map from epic #2 acceptance areas to stable source docs, live evidence lanes, and milestone review questions
- linked the new acceptance trace from `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` so checkpoint reviews close against evidence instead of stale queue snapshots
- refreshed the checkpoint/goals/roadmap runtime anchors to use the live planning sweep query, merged PR #175, merged PR #172, and issue #11 instead of closed blocker issues
- recorded the new planning artifact in `openspec/changes/agent-dispatch-platform/tasks.md`

## Why

- `main` still lacked one durable place that says what evidence actually closes each acceptance area for epic #2
- the stable planning docs were still mixing current review guidance with closed issue references, which keeps reopening the same blocker churn in PR reviews
- this makes the post-runtime planning lane point at live evidence sources while leaving volatile queue state in GitHub where it belongs

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Epic acceptance reviews stay grounded in stable docs instead of volatile PR snapshots | `docs/PHASE1_ACCEPTANCE_TRACE.md` now maps each acceptance area to stable docs, live evidence lanes, and milestone questions | `docs/PHASE1_ACCEPTANCE_TRACE.md` |
| Checkpoint/goals/roadmap docs reference current runtime evidence anchors rather than closed blocker issues | `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` now point at the planning sweep query, merged PR #175, merged PR #172, and issue #11 | `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, `docs/PHASE1_CHECKPOINT_BOARD.md` |
| OpenSpec planning artifacts stay synchronized with the new durable acceptance baseline | the OpenSpec task ledger records the acceptance trace artifact as completed baseline work | `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- clean worktree on `codex/issue-2-acceptance-trace-refresh`
- git identity bootstrapped for `albatross-dev-agent`

### Steps

1. Open `docs/PHASE1_ACCEPTANCE_TRACE.md` and confirm each epic acceptance area now points at stable docs plus the live issue #11 evidence lane.
2. Review `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md`, and `docs/PHASE1_CHECKPOINT_BOARD.md` to confirm they reference the same acceptance trace and current runtime anchors.
3. Run the OpenSpec validation, diff check, and pre-push guard commands.

### Expected Results

- the repo has one durable acceptance-to-evidence map for epic #2
- stable planning docs no longer point at closed runtime blockers as the live handoff path
- OpenSpec validation and repo guard checks pass on the branch

### Validation Output

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)

$ git diff --check
<no output>

$ bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent
[ok] Branch 'codex/issue-2-acceptance-trace-refresh' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - other open planning refresh PRs may still touch nearby docs and need to be closed or superseded after this lands
- Rollback:
  - revert commit `d09e7e2` to remove the acceptance trace and restore the prior checkpoint anchors

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
