### PR TITLE
docs: refresh planning sweep references

### DIFF
--- a/docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md
+++ b/docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md
@@ -9,7 +9,7 @@ consistent, owner-specific, and reviewable.
 
 - Open the milestone links in `docs/PHASE1_CHECKPOINT_BOARD.md`.
 - Run the metadata hygiene queries from `docs/PHASE1_CHECKPOINT_BOARD.md`.
-- Check the live planning sweep query and issue #11 before copying any blocker or evidence note into the checkpoint comment.
+- Open the current planning sweep issue from the `owner:albatross` + `stream/review-burndown` query before copying any blocker or evidence note into the checkpoint comment.
 - Pull the current runtime blocker snapshot from the dated control doc when one
   exists.
 - Verify every blocker references a live issue or PR and the owner label already
@@ -54,7 +54,7 @@ consistent, owner-specific, and reviewable.
 - `Ready next` should describe executable slices only; defer design-only follow-ups unless they unblock the runtime path this week.
 - `Validation evidence gaps` should call out the exact missing command output so reviewers know what to ask for next.
 - The owner handoff table should stay short enough to scan in GitHub without expanding code blocks.
-- Prefer live queries or issue #11 for same-day evidence threads; do not cite closed umbrella issues as active blocker owners.
+- Prefer the current planning sweep issue plus issue #11 for same-day evidence threads; do not cite closed historical sweep issues as active blocker owners.
 
 ## Minimum evidence checklist
 

--- a/docs/issues/PHASE1_ISSUES.md
+++ b/docs/issues/PHASE1_ISSUES.md
@@ -16,7 +16,7 @@ This file intentionally stays lightweight so we do not duplicate fast-changing i
 - [Runtime PRs missing priority](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22stream%2Fruntime-execution%22+-label%3A%22priority%2FP0%22+-label%3A%22priority%2FP1%22)
 - [Planning lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Aalbatross%22)
 - [Planning PR review queue](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+is%3Aopen+label%3A%22owner%3Aalbatross%22)
-- [Current planning sweep issue](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22owner%3Aalbatross%22+label%3A%22stream%2Freview-burndown%22)
+- [Planning sweep query](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22owner%3Aalbatross%22+label%3A%22stream%2Freview-burndown%22)
 - [Architecture unblocker control issue](https://github.com/jckhang/agent-indeed/issues/137)
 - [Issue #11 executable evidence thread](https://github.com/jckhang/agent-indeed/issues/11)
 - [Backend lane](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+label%3A%22owner%3Akestrel%22)
@@ -46,7 +46,6 @@ review history, and linked PRs, open the GitHub issue directly.
 
 ### Phase 1 delivery
 
-- Planning PR stack collapse before M1 checkpoint: [#186](https://github.com/jckhang/agent-indeed/issues/186)
 - Planning sweep / blocker review query: [current open owner:albatross + stream/review-burndown issue](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+is%3Aopen+label%3A%22owner%3Aalbatross%22+label%3A%22stream%2Freview-burndown%22)
 - Weekly architecture runtime unblocker control: [#137](https://github.com/jckhang/agent-indeed/issues/137)
 - P1-01 Define AgentBundle contract and validation rules: [#3](https://github.com/jckhang/agent-indeed/issues/3)

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -80,8 +80,8 @@
    - merge-train blocker note 必须同时说明：main 上发生了什么变化、当前 owner label、下一步命令/评审动作，以及是否需要新开 follow-up issue 保持 PR 聚焦。
    - 任何请求 re-review 的 PR 都必须附带 literal validation output；未贴出输出时，规划侧将其视为阻塞项而不是“默认已跑”。
    - 当新 blocker 会跨越多个 rebase 周期、需要跨 lane 接力，或会让现有 PR 超出原始验收范围时，必须升级为 follow-up issue，而不是只留在 PR 评论里。
-   - 同日 merge-evidence sweep 的短记录放在当前 `owner:albatross` + `stream/review-burndown` 查询返回的开放 planning sweep issue，至少覆盖 clean tranche、dirty follow-ons 与 validation evidence gaps；跨 lane 的 checkpoint 总结再同步到 epic #2。
-   - 同一 checkpoint/rollup 语义只保留一个 mergeable planning-sync PR；其他重叠 PR 必须在 GitHub 线程里写明 merge/close rationale，而不是继续并行改写相同文档。
+   - 同日 merge-evidence sweep 的短记录放在当前开放的 planning sweep issue，至少覆盖 clean tranche、dirty follow-ons 与 validation evidence gaps；跨 lane 的 checkpoint 总结再同步到 epic #2。
+   - 同一 checkpoint/rollup 语义出现重叠 PR 时，必须选定 survivor PR，并在 superseded PR 的 GitHub 线程里写明 merge/close rationale，而不是继续并行改写相同文档。
    - 例行流程写入 `docs/MERGE_TRAIN_PLAYBOOK.md` 并在 `CONTRIBUTING.md` 链接，减少多 agent 并行时的重复沟通和冲突。
 
 11. Phase 1 当前冲刺采用 runtime-first 交付

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -20,7 +20,7 @@
 - 定义从任务发布到中标执行的关键状态流转与审计要求。
 - 新增 runtime 落地冲刺任务（issue #109/#110/#111），要求将核心流程转为可运行服务与可执行 QA 校验。
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
-- 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
+- 增补 merge-evidence sweep 回写规则，要求当前开放的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
 
 ## Capabilities
@@ -39,6 +39,6 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
-- 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
+- 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求重叠的 planning checkpoint 改写在 GitHub 线程里写明 merge/close rationale，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -44,11 +44,11 @@
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。
 - [x] 5.6 输出 `docs/RUNTIME_EXECUTION_HANDOFF.md`，统一 runtime sprint 的本地命令契约、证据包与 issue #11 回写规则。
-- [x] 5.7 明确 issue #146 merge-evidence sweep 与 epic #2 checkpoint 的双轨回写规则，统一 clean tranche、dirty follow-on 与 validation evidence gap 的 GitHub 记录方式。
+- [x] 5.7 明确 planning sweep issue 与 epic #2 checkpoint 的双轨回写规则，统一 clean tranche、dirty follow-on 与 validation evidence gap 的 GitHub 记录方式。
 - [x] 5.8 完成前端 runtime consumer verification pass（issue #150），校准 task composer、shortlist/award、bid workspace、verification timeline 对当前 `main` runtime 字段与 fallback 语义的引用。
 - [x] 5.9 跟进前端 consumer contract claim trim（issue #157），把 shortlist/award/bid/proof 读路径的 `main` 基线解释收敛到 OpenAPI/TS draft anchors，避免把 runtime 数据缺口误写成 contract 缺口。
 - [x] 5.10 补充前端 consumer contract reviewer quick-check 锚点，给出 `origin/main` 的行号与 grep 校验命令，减少对已发布读路径的重复误判。
 - [x] 5.11 输出 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged `smoke:dispatch` 路径固化为 issue #11 / QA / beta consumer 可复用的请求响应示例包。
-- [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
+- [x] 5.12 刷新 checkpoint / merge-train 模板，移除对历史 planning sweep issue 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
-- [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.14 收敛 planning sweep 规则：同一 checkpoint 出现重叠 planning-sync PR 时，只保留一个 survivor，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: refresh planning sweep references so Phase 1 planning docs and OpenSpec stop depending on stale historical sweep issues

## What Changed

- removed the stale `#186` planning-stack-collapse pointer from the stable Phase 1 issue index and renamed the quick link to the live planning sweep query
- updated the epic checkpoint template to anchor same-day evidence to the current planning sweep issue plus issue #11 instead of closed historical sweep issues
- aligned the OpenSpec proposal, design, and tasks with the live planning sweep workflow and a generic survivor-PR rule for overlapping checkpoint rewrites

## Why

- the planning lane now uses the live `owner:albatross` + `stream/review-burndown` sweep issue as the durable same-day queue anchor, so repo docs should not point reviewers at one historical sweep issue or one temporary stack-collapse issue
- keeping these references generic reduces planning-doc churn and avoids sending reviewers to closed or superseded threads during checkpoint sweeps

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Repo planning docs keep only stable planning anchors and live queries | `docs/issues/PHASE1_ISSUES.md` now drops the stale `#186` pointer and keeps the live planning sweep query as the durable reference | `docs/issues/PHASE1_ISSUES.md` |
| OpenSpec and checkpoint guidance stay aligned with the live planning-sweep workflow | `docs/PHASE1_EPIC_CHECKPOINT_TEMPLATE.md`, `openspec/changes/agent-dispatch-platform/proposal.md`, `openspec/changes/agent-dispatch-platform/design.md`, and `openspec/changes/agent-dispatch-platform/tasks.md` all now reference the current planning sweep issue / survivor-PR workflow instead of historical issue IDs | those files |

## QA Plan

### Preconditions

- use a clean branch rebased from current `main`
- inspect the Phase 1 planning docs and OpenSpec change together so wording stays in sync

### Steps

1. Review the current planning references in the Phase 1 issue index and epic checkpoint template.
2. Update the OpenSpec proposal/design/tasks wording to match the same live planning sweep workflow.
3. Run diff hygiene and the agent pre-push guard.

### Expected Results

- repo docs point to the live planning sweep query rather than stale historical issue IDs
- OpenSpec artifacts describe the same planning sweep / survivor-PR rule as the docs
- diff hygiene and pre-push guard pass on the branch

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
- `git diff --check`
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent --skip-fetch`

```text
$ git diff --check

$ bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent --skip-fetch
[ok] Branch 'codex/p1-2-epic-gate-refresh' uses codex/ prefix.
[warn] Skipping git fetch (--skip-fetch).
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.

$ openspec validate --all
not run: openspec CLI not installed in environment
```

## Risks and Rollback

- Risk:
  - reviewers may prefer one specific current sweep issue to be named explicitly if the planning process stabilizes around a single durable umbrella again
- Rollback:
  - revert this PR to restore the previous historical issue references and survivor-PR wording

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
