### PR TITLE
feat: add executable agent onboarding runtime upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ Agent dispatch platform prototype.
 - Frontend/backend delivery tracks: `docs/ENGINEERING_TRACKS_FE_BE.md`
 - HR hiring plan: `docs/HR_HIRING_PLAN.md`
 - Runtime control-plane scaffold: `src/runtime/README.md`
+- Onboarding smoke command: `npm run smoke:onboarding`
 - Runtime bootstrap smoke command: `npm run smoke:bootstrap`
 - Runnable dispatch smoke suite: `npm run smoke:dispatch`

--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -15,6 +15,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
 | OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, issue #167, PR #174, PR #176, PR #179, PR #133 | Merge the post-runtime planning/reference cleanup, then keep PR #133 aligned to the published contract vocabulary. |
+| Agent onboarding upload path is executable | In progress | `src/runtime/app.js`, `src/runtime/onboarding-smoke.js`, `docs/ONBOARDING_PIPELINE.md`, epic #2 follow-through PR for runtime onboarding upload | Extend the same runtime baseline with agent-bundle read/query surfaces and keep the upload smoke command wired into local review. |
 | End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issues #177, #178, and #11 | Publish one canonical smoke evidence format, run the formatter-backed smoke pass, and paste the final evidence back onto issue #11. |
 | Core negative scenarios are covered | Blocked | issue #11, PR #172, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Turn the documented failure cases into reproducible smoke evidence tied to the merged runtime baseline. |
 | Audit events cover key state transitions | In progress | merged runtime baseline from issues #109/#110, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, issue #11 | Keep the verify/award/audit follow-through aligned while the final smoke evidence proves the emitted trail. |
@@ -33,6 +34,7 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 - QA contract-drift guard baseline is merged in PR #159 and retained in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`.
 - Frontend runtime consumer baseline is merged in PR #152.
 - Backend API example packet is merged in PR #164.
+- Agent onboarding runtime upload path is now executable locally via `npm run smoke:onboarding`.
 
 ### Active follow-through slices
 

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -38,6 +38,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Upload validation pipeline implemented (signature, schema, indexing, version conflict).
 - Memory supports index/encrypted reference mode (no raw memory required).
 - Onboarding write/read behavior must stay executable from a local running service, using closed issues #109 and #110 as the baseline reference.
+- `npm run smoke:onboarding` now exercises the published `POST /v1/agents/bundles` route end-to-end, covering create, replay, and payload-hash mismatch behavior for local review.
 
 ### G2. Task publication and matching baseline
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -52,6 +52,7 @@ Scope:
 - Auditable award events and minimal reputation writeback hook.
 - Lifecycle observability baseline for `upload -> match -> bid -> verify -> award`.
 - Closed-beta evidence handoff stays concentrated on issue #11 plus the canonical runtime command path in `docs/RUNTIME_EXECUTION_HANDOFF.md`.
+- Agent onboarding upload also has a local executable baseline through `npm run smoke:onboarding`, so epic #2 can demonstrate both onboarding and dispatch writes on `main`.
 
 Exit criteria:
 - Core APIs available and documented in `src/api/openapi.yaml`.

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,6 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
+- 新增 runtime onboarding upload slice，把已发布的 `POST /v1/agents/bundles` 合同变成可执行本地路径，并覆盖 replay / version-conflict / skill-indexing 基线。
 
 ## Capabilities
 
@@ -39,6 +40,7 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
+- 新增 `src/runtime/onboarding-smoke.js` 与对应测试，使 epic #2 的 onboarding 路径不再停留在文档/合同层。
 - 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -53,3 +53,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.15 为 epic #2 补齐可执行 agent onboarding runtime slice：落地 `POST /v1/agents/bundles`、同步 skill indexing / replay / conflict 语义，并补充本地 smoke/test 命令。

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start": "node src/runtime/server.js",
     "dev": "node --watch src/runtime/server.js",
     "smoke:dispatch": "node src/runtime/dispatch-smoke.js",
+    "smoke:onboarding": "node src/runtime/onboarding-smoke.js",
     "smoke:issue11": "node src/runtime/issue11-evidence.js",
     "smoke:bootstrap": "node src/runtime/bootstrap-smoke.js",
     "check:contract-drift": "node scripts/check-runtime-contract-drift.js --assert",

--- a/scripts/check-runtime-contract-drift.js
+++ b/scripts/check-runtime-contract-drift.js
@@ -13,6 +13,7 @@ const REQUIRED_RUNTIME_ROUTES = [
   "/healthz",
   "/readyz",
   "/v1/runtime/summary",
+  "/v1/agents/bundles",
   "/v1/tasks/{taskId}",
   "/v1/tasks/{taskId}/audit-events",
   "/v1/tasks/{taskId}/candidates",

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -7,6 +7,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start the service: `npm start`
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
+- Run the onboarding upload smoke suite: `npm run smoke:onboarding`
 - Print an issue-ready issue `#11` evidence packet: `npm run --silent smoke:issue11 -- --signature avery`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
@@ -77,6 +78,7 @@ That command starts the runtime on an ephemeral port, checks `/healthz`, `/ready
 - `GET /healthz` - liveness and process metadata
 - `GET /readyz` - readiness plus in-memory storage checks
 - `GET /v1/runtime/summary` - counts for task/bid/proof/award/audit stores
+- `POST /v1/agents/bundles` - validate, version, and index a signed agent bundle
 - `POST /v1/tasks` - create a task using the current contract baseline
 - `GET /v1/tasks/{taskId}` - inspect a persisted task record from the runtime store
 - `GET /v1/tasks/{taskId}/award` - inspect manager-facing award readiness or awarded detail for one task
@@ -95,5 +97,7 @@ That command starts the runtime on an ephemeral port, checks `/healthz`, `/ready
 
 - Storage is intentionally in-memory for the first bootstrap slice.
 - IDs are deterministic, monotonic prefixes (`task_00000001`, `audit_00000001`, ...).
+- Agent upload ids are deterministic per manifest name (`agent_support_triage_agent`).
 - Persistence abstractions now cover task, bid, proof, award, and audit entities with deterministic ids.
+- Onboarding upload currently validates signer binding, canonical payload hash, schema version, version replay/conflict handling, and synchronous skill indexing.
 - This scaffold is the runtime base for the later dispatch vertical slice work.

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -17,6 +17,16 @@ const TASK_PROOF_VERIFY_PATTERN = /^\/v1\/tasks\/(task_[a-zA-Z0-9_-]{8,64})\/pro
 const TASK_PROOF_STATUS_PATTERN = /^\/v1\/tasks\/(task_[a-zA-Z0-9_-]{8,64})\/proofs\/(proof_[a-zA-Z0-9_-]{8,64})$/;
 const TASK_AWARD_PATTERN = /^\/v1\/tasks\/(task_[a-zA-Z0-9_-]{8,64})\/award$/;
 const BID_EVENTS_PATTERN = /^\/v1\/bids\/(bid_[a-zA-Z0-9_-]{8,64})\/events$/;
+const SUPPORTED_AGENT_BUNDLE_SCHEMA_VERSION = "1.0";
+const AGENT_BUNDLE_AUDIT_IDS = {
+  invalidJson: "audit_bundle_upload_invalid_json",
+  schemaInvalid: "audit_bundle_upload_schema_invalid",
+  unsupportedSchema: "audit_bundle_upload_unsupported_schema",
+  signerMismatch: "audit_bundle_upload_signer_mismatch",
+  payloadHashMismatch: "audit_bundle_upload_payload_hash_mismatch",
+  signatureInvalid: "audit_bundle_upload_signature_invalid",
+  versionConflict: "audit_bundle_upload_version_conflict"
+};
 
 function sha256(value) {
   return `sha256:${createHash("sha256").update(value).digest("hex")}`;
@@ -24,6 +34,26 @@ function sha256(value) {
 
 function round(value) {
   return Number(value.toFixed(3));
+}
+
+function stableSerialize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableSerialize(entry)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerialize(value[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function canonicalBundlePayloadHash(bundle) {
+  const { signature: _signature, ...unsignedBundle } = bundle;
+  return sha256(stableSerialize(unsignedBundle));
 }
 
 function buildError(code, category, message, { auditId, retryable = false, retryAfterSeconds, details } = {}) {
@@ -68,6 +98,304 @@ function buildTaskValidationError(message, details = {}) {
       details
     })
   };
+}
+
+function buildAgentBundleError(code, category, message, { auditId, details, conflict } = {}) {
+  return {
+    code,
+    category,
+    message,
+    auditId,
+    retryable: false,
+    ...(details ? { details } : {}),
+    ...(conflict ? { conflict } : {})
+  };
+}
+
+function validateAgentBundleSignature(payload) {
+  if (!payload || typeof payload !== "object") {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "request body is required",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "body",
+          rule: "required",
+          expected: "object",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  if (!payload.idempotencyKey) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "idempotencyKey is required",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "idempotencyKey",
+          rule: "required",
+          expected: "present",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  const bundle = payload.bundle;
+  if (!bundle || typeof bundle !== "object") {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "bundle is required",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "bundle",
+          rule: "required",
+          expected: "object",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  if (!bundle.identity?.did) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "bundle.identity.did is required",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "bundle.identity.did",
+          rule: "required",
+          expected: "present",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  if (!bundle.signature?.signerDid) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "bundle.signature.signerDid is required",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "bundle.signature.signerDid",
+          rule: "required",
+          expected: "present",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  if (bundle.signature.signerDid !== bundle.identity.did) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SIGNATURE_SIGNER_MISMATCH",
+      "SIGNATURE",
+      "signature.signerDid must match bundle.identity.did",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.signerMismatch,
+        details: {
+          fieldPath: "bundle.signature.signerDid",
+          rule: "signer_matches_identity",
+          expected: bundle.identity.did,
+          actual: bundle.signature.signerDid
+        }
+      }
+    );
+  }
+
+  const canonicalPayloadHash = canonicalBundlePayloadHash(bundle);
+  if (!bundle.signature?.payloadHash || bundle.signature.payloadHash !== canonicalPayloadHash) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH",
+      "SIGNATURE",
+      "signature.payloadHash must match the canonical bundle payload hash",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.payloadHashMismatch,
+        details: {
+          fieldPath: "bundle.signature.payloadHash",
+          rule: "payload_hash_matches_bundle",
+          expected: canonicalPayloadHash,
+          actual: bundle.signature?.payloadHash ?? "missing"
+        }
+      }
+    );
+  }
+
+  if (
+    typeof bundle.signature.signature !== "string" ||
+    !/^(base64:|sig-).+/.test(bundle.signature.signature)
+  ) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SIGNATURE_INVALID",
+      "SIGNATURE",
+      "signature.signature must contain a verifiable signature payload",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.signatureInvalid,
+        details: {
+          fieldPath: "bundle.signature.signature",
+          rule: "signature_format",
+          expected: "base64:<signature>",
+          actual: String(bundle.signature.signature ?? "missing")
+        }
+      }
+    );
+  }
+
+  return null;
+}
+
+function validateAgentBundleSchema(payload) {
+  const bundle = payload.bundle;
+
+  if (bundle.schemaVersion !== SUPPORTED_AGENT_BUNDLE_SCHEMA_VERSION) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_UNSUPPORTED_VERSION",
+      "SCHEMA",
+      `bundle.schemaVersion ${bundle.schemaVersion ?? "missing"} is not supported`,
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.unsupportedSchema,
+        details: {
+          fieldPath: "bundle.schemaVersion",
+          rule: "supported_schema_version",
+          expected: SUPPORTED_AGENT_BUNDLE_SCHEMA_VERSION,
+          actual: String(bundle.schemaVersion ?? "missing")
+        }
+      }
+    );
+  }
+
+  const requiredStringFields = [
+    ["bundle.manifest.name", bundle.manifest?.name],
+    ["bundle.manifest.version", bundle.manifest?.version],
+    ["bundle.manifest.runtime", bundle.manifest?.runtime],
+    ["bundle.manifest.entrypoint", bundle.manifest?.entrypoint],
+    ["bundle.identity.publicKey", bundle.identity?.publicKey],
+    ["bundle.identity.credentialLevel", bundle.identity?.credentialLevel],
+    ["bundle.memoryRef.mode", bundle.memoryRef?.mode],
+    ["bundle.memoryRef.summaryHash", bundle.memoryRef?.summaryHash],
+    ["bundle.signature.algorithm", bundle.signature?.algorithm]
+  ];
+
+  for (const [fieldPath, value] of requiredStringFields) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      return buildAgentBundleError(
+        "AGENT_BUNDLE_SCHEMA_INVALID",
+        "SCHEMA",
+        `${fieldPath} is required`,
+        {
+          auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+          details: {
+            fieldPath,
+            rule: "required",
+            expected: "present",
+            actual: "missing"
+          }
+        }
+      );
+    }
+  }
+
+  if (!Array.isArray(bundle.skills) || bundle.skills.length === 0) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "bundle.skills must include at least one skill",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "bundle.skills",
+          rule: "min_items",
+          expected: ">= 1",
+          actual: Array.isArray(bundle.skills) ? "0" : "missing"
+        }
+      }
+    );
+  }
+
+  for (let index = 0; index < bundle.skills.length; index += 1) {
+    const skill = bundle.skills[index];
+    const requiredSkillFields = [
+      ["skillId", skill?.skillId],
+      ["version", skill?.version],
+      ["inputSchema", skill?.inputSchema],
+      ["outputSchema", skill?.outputSchema]
+    ];
+
+    for (const [fieldName, value] of requiredSkillFields) {
+      if (
+        value === undefined ||
+        value === null ||
+        (typeof value === "string" && value.trim().length === 0)
+      ) {
+        return buildAgentBundleError(
+          "AGENT_BUNDLE_SCHEMA_INVALID",
+          "SCHEMA",
+          `bundle.skills[${index}].${fieldName} is required`,
+          {
+            auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+            details: {
+              fieldPath: `bundle.skills[${index}].${fieldName}`,
+              rule: "required",
+              expected: "present",
+              actual: "missing"
+            }
+          }
+        );
+      }
+    }
+  }
+
+  if (bundle.memoryRef.mode === "INDEX_ONLY" && !bundle.memoryRef.vectorIndexUri) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "bundle.memoryRef.vectorIndexUri is required for INDEX_ONLY mode",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "bundle.memoryRef.vectorIndexUri",
+          rule: "required_for_mode",
+          expected: "present",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  if (
+    (bundle.memoryRef.mode === "ENCRYPTED_REF" || bundle.memoryRef.mode === "FULL") &&
+    !bundle.memoryRef.encryptedBlobUri
+  ) {
+    return buildAgentBundleError(
+      "AGENT_BUNDLE_SCHEMA_INVALID",
+      "SCHEMA",
+      "bundle.memoryRef.encryptedBlobUri is required for encrypted memory modes",
+      {
+        auditId: AGENT_BUNDLE_AUDIT_IDS.schemaInvalid,
+        details: {
+          fieldPath: "bundle.memoryRef.encryptedBlobUri",
+          rule: "required_for_mode",
+          expected: "present",
+          actual: "missing"
+        }
+      }
+    );
+  }
+
+  return null;
 }
 
 function validateTaskSpec(task) {
@@ -931,6 +1259,96 @@ export function createApp({
         service: config.serviceName,
         generatedAt: nowValue,
         storage: store.summary()
+      });
+    }
+
+    if (req.method === "POST" && requestUrl.pathname === "/v1/agents/bundles") {
+      let payload;
+      try {
+        payload = await readJson(req);
+      } catch {
+        return reply(
+          400,
+          buildAgentBundleError(
+            "AGENT_BUNDLE_SCHEMA_INVALID",
+            "SCHEMA",
+            "Request body must be valid JSON",
+            {
+              auditId: AGENT_BUNDLE_AUDIT_IDS.invalidJson,
+              details: {
+                fieldPath: "body",
+                rule: "valid_json",
+                expected: "valid JSON object",
+                actual: "invalid"
+              }
+            }
+          )
+        );
+      }
+
+      const signatureError = validateAgentBundleSignature(payload);
+      if (signatureError) {
+        return reply(400, signatureError);
+      }
+
+      const schemaError = validateAgentBundleSchema(payload);
+      if (schemaError) {
+        return reply(400, schemaError);
+      }
+
+      const payloadHash = canonicalBundlePayloadHash(payload.bundle);
+      const outcome = store.saveAgentBundle({
+        idempotencyKey: payload.idempotencyKey,
+        bundle: payload.bundle,
+        payloadHash
+      });
+
+      if (outcome.conflict) {
+        return reply(
+          409,
+          buildAgentBundleError(
+            "AGENT_BUNDLE_VERSION_CONFLICT",
+            "VERSION",
+            `${outcome.record.agentId}@${outcome.record.version} already exists with a different payload hash`,
+            {
+              auditId: AGENT_BUNDLE_AUDIT_IDS.versionConflict,
+              conflict: {
+                strategy: "REJECT_ON_HASH_MISMATCH",
+                existingAgentId: outcome.record.agentId,
+                existingVersion: outcome.record.version,
+                existingPayloadHash: outcome.record.payloadHash,
+                incomingPayloadHash: payloadHash
+              }
+            }
+          )
+        );
+      }
+
+      if (outcome.replay) {
+        return reply(200, {
+          agentId: outcome.record.agentId,
+          version: outcome.record.version,
+          status: "EXISTING",
+          result: "RETURNED_EXISTING",
+          indexing: outcome.record.indexing,
+          replay: {
+            strategy: "RETURN_EXISTING_ON_HASH_MATCH",
+            existingAgentId: outcome.record.agentId,
+            existingVersion: outcome.record.version,
+            existingPayloadHash: outcome.record.payloadHash,
+            incomingPayloadHash: payloadHash
+          },
+          indexedAt: outcome.record.indexedAt
+        });
+      }
+
+      return reply(201, {
+        agentId: outcome.record.agentId,
+        version: outcome.record.version,
+        status: "ACCEPTED",
+        result: "CREATED",
+        indexing: outcome.record.indexing,
+        indexedAt: outcome.record.indexedAt
       });
     }
 

--- a/src/runtime/onboarding-smoke.js
+++ b/src/runtime/onboarding-smoke.js
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { createApp } from "./app.js";
+
+function stableSerialize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableSerialize(entry)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerialize(value[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
+function sha256(value) {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+function buildBundlePayloadHash(bundle) {
+  const { signature: _signature, ...unsignedBundle } = bundle;
+  return sha256(stableSerialize(unsignedBundle));
+}
+
+function buildBundle() {
+  const bundle = {
+    schemaVersion: "1.0",
+    manifest: {
+      name: "support_triage_agent",
+      version: "1.2.0",
+      runtime: "OPENCLAW",
+      entrypoint: "./bin/triage"
+    },
+    identity: {
+      did: "did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8Kestrel",
+      publicKey: "z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8KestrelPubKey",
+      credentialLevel: "T1"
+    },
+    skills: [
+      {
+        skillId: "skill_support.triage",
+        version: "1.4.0",
+        tags: ["support", "routing"],
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" }
+      }
+    ],
+    memoryRef: {
+      mode: "INDEX_ONLY",
+      summaryHash: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      vectorIndexUri: "s3://agent-memory/support-triage/index.bin"
+    }
+  };
+
+  return {
+    ...bundle,
+    signature: {
+      algorithm: "ED25519",
+      payloadHash: buildBundlePayloadHash(bundle),
+      signature: "base64:MEUCIQDdExampleSignatureForBundleUploadFlow1234567890==",
+      signerDid: bundle.identity.did,
+      signedAt: "2026-03-19T01:30:00Z"
+    }
+  };
+}
+
+async function expectJson(response, expectedStatus) {
+  assert.equal(response.status, expectedStatus);
+  return response.json();
+}
+
+export async function runOnboardingSmoke({
+  host = "127.0.0.1",
+  serviceName = "agent-indeed-onboarding-smoke",
+  log = (message) => console.log(message)
+} = {}) {
+  const app = createApp({
+    config: { serviceName },
+    logger: () => {}
+  });
+  const server = createServer(app);
+
+  try {
+    server.listen(0, host);
+    await once(server, "listening");
+
+    const address = server.address();
+    const baseUrl = `http://${host}:${address.port}`;
+    const bundle = buildBundle();
+    const request = {
+      idempotencyKey: "idem_agentbundle_001",
+      bundle
+    };
+
+    log(`onboarding smoke listening on ${baseUrl}`);
+
+    const created = await expectJson(
+      await fetch(`${baseUrl}/v1/agents/bundles`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(request)
+      }),
+      201
+    );
+    assert.equal(created.result, "CREATED");
+    assert.equal(created.agentId, "agent_support_triage_agent");
+    assert.equal(created.indexing.indexedSkillCount, 1);
+    log(`PASS POST /v1/agents/bundles -> ${created.agentId}@${created.version}`);
+
+    const replay = await expectJson(
+      await fetch(`${baseUrl}/v1/agents/bundles`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(request)
+      }),
+      200
+    );
+    assert.equal(replay.result, "RETURNED_EXISTING");
+    assert.equal(replay.replay.strategy, "RETURN_EXISTING_ON_HASH_MATCH");
+    log(`PASS replay /v1/agents/bundles -> ${replay.replay.strategy}`);
+
+    const mismatchedHash = {
+      idempotencyKey: "idem_agentbundle_bad_hash",
+      bundle: {
+        ...bundle,
+        signature: {
+          ...bundle.signature,
+          payloadHash: "sha256:badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad"
+        }
+      }
+    };
+    const mismatch = await expectJson(
+      await fetch(`${baseUrl}/v1/agents/bundles`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json"
+        },
+        body: JSON.stringify(mismatchedHash)
+      }),
+      400
+    );
+    assert.equal(mismatch.code, "AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH");
+    log(`PASS payload hash mismatch -> ${mismatch.code}`);
+
+    return {
+      serviceName,
+      baseUrl,
+      agentId: created.agentId,
+      version: created.version,
+      replayStrategy: replay.replay.strategy,
+      mismatchCode: mismatch.code
+    };
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href) {
+  runOnboardingSmoke()
+    .then((result) => {
+      console.log(JSON.stringify({ status: "ok", ...result }, null, 2));
+    })
+    .catch((error) => {
+      console.error("onboarding smoke failed");
+      console.error(error);
+      process.exitCode = 1;
+    });
+}

--- a/src/runtime/store/in-memory-control-plane-store.js
+++ b/src/runtime/store/in-memory-control-plane-store.js
@@ -16,6 +16,9 @@ function roundScore(value) {
 export class InMemoryControlPlaneStore {
   constructor({ now = () => new Date().toISOString() } = {}) {
     this.now = now;
+    this.agentBundles = new Map();
+    this.agentBundleVersions = new Map();
+    this.agentBundleIdempotency = new Map();
     this.tasks = new Map();
     this.bids = new Map();
     this.proofs = new Map();
@@ -30,6 +33,76 @@ export class InMemoryControlPlaneStore {
     this.eventIds = new IdSequence("aev");
     this.matchingTraceIds = new IdSequence("matchtrace");
     this.policyTraceIds = new IdSequence("policytrace");
+  }
+
+  saveAgentBundle({ idempotencyKey, bundle, payloadHash }) {
+    const versionKey = `${bundle.identity.did}::${bundle.manifest.version}`;
+    const indexedAt = this.now();
+    const existingVersion = this.agentBundleVersions.get(versionKey);
+
+    if (existingVersion) {
+      const samePayload = existingVersion.payloadHash === payloadHash;
+      const existingRecord = this.agentBundles.get(existingVersion.agentBundleId);
+      if (!existingRecord) {
+        return null;
+      }
+
+      if (samePayload) {
+        this.agentBundleIdempotency.set(idempotencyKey, existingRecord.agentBundleId);
+        return {
+          record: clone(existingRecord),
+          created: false,
+          replay: true,
+          conflict: false
+        };
+      }
+
+      return {
+        record: clone(existingRecord),
+        created: false,
+        replay: false,
+        conflict: true
+      };
+    }
+
+    const replayAgentBundleId = this.agentBundleIdempotency.get(idempotencyKey);
+    if (replayAgentBundleId) {
+      const replayRecord = this.agentBundles.get(replayAgentBundleId);
+      if (replayRecord) {
+        return {
+          record: clone(replayRecord),
+          created: false,
+          replay: true,
+          conflict: false
+        };
+      }
+    }
+
+    const agentId = buildAgentId(bundle);
+    const record = {
+      agentBundleId: `${agentId}@${bundle.manifest.version}`,
+      agentId,
+      version: bundle.manifest.version,
+      payloadHash,
+      idempotencyKey,
+      indexedAt,
+      bundle: clone(bundle),
+      indexing: buildIndexingSummary({ agentId, bundle })
+    };
+
+    this.agentBundles.set(record.agentBundleId, record);
+    this.agentBundleVersions.set(versionKey, {
+      agentBundleId: record.agentBundleId,
+      payloadHash
+    });
+    this.agentBundleIdempotency.set(idempotencyKey, record.agentBundleId);
+
+    return {
+      record: clone(record),
+      created: true,
+      replay: false,
+      conflict: false
+    };
   }
 
   createTask({ workspaceId, task }) {
@@ -511,6 +584,30 @@ export class InMemoryControlPlaneStore {
       latestAuditId: this.auditEvents.at(-1)?.auditId ?? null
     };
   }
+}
+
+function buildAgentId(bundle) {
+  const normalized = bundle.manifest.name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return `agent_${normalized || "bundle"}`;
+}
+
+function buildIndexingSummary({ agentId, bundle }) {
+  return {
+    status: "INDEXED",
+    indexedSkillCount: bundle.skills.length,
+    memoryMode: bundle.memoryRef.mode,
+    skills: bundle.skills.map((skill) => ({
+      skillId: skill.skillId,
+      version: skill.version,
+      sourceAgentId: agentId,
+      sourceVersion: bundle.manifest.version,
+      ...(skill.tags ? { tags: clone(skill.tags) } : {})
+    }))
+  };
 }
 
 export function buildCandidateSnapshot({ taskId, task, includeScoreBreakdown = true, limit = 10 }) {

--- a/test/runtime/app.test.js
+++ b/test/runtime/app.test.js
@@ -5,6 +5,21 @@ import { createServer } from "node:http";
 import { once } from "node:events";
 import { createApp } from "../../src/runtime/app.js";
 
+function stableSerialize(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableSerialize(entry)).join(",")}]`;
+  }
+
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableSerialize(value[key])}`)
+      .join(",")}}`;
+  }
+
+  return JSON.stringify(value);
+}
+
 function buildTask(overrides = {}) {
   return {
     title: "Run dispatch loop baseline",
@@ -86,6 +101,71 @@ function buildRevealHash(reveal) {
     executionPlan: reveal.executionPlan,
     proof: reveal.proof
   })).digest("hex")}`;
+}
+
+function buildBundlePayloadHash(bundle) {
+  const { signature: _signature, ...unsignedBundle } = bundle;
+  return `sha256:${createHash("sha256").update(stableSerialize(unsignedBundle)).digest("hex")}`;
+}
+
+function buildAgentBundle(overrides = {}) {
+  const bundle = {
+    schemaVersion: "1.0",
+    manifest: {
+      name: "support_triage_agent",
+      version: "1.2.0",
+      runtime: "OPENCLAW",
+      entrypoint: "./bin/triage"
+    },
+    identity: {
+      did: "did:key:z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8Kestrel",
+      publicKey: "z6MkhaXgBZDvotDkL9Q1Y1w2X5h2k2u6Y8VnSx4Q8KestrelPubKey",
+      credentialLevel: "T1"
+    },
+    skills: [
+      {
+        skillId: "skill_support.triage",
+        version: "1.4.0",
+        tags: ["support", "routing"],
+        inputSchema: { type: "object" },
+        outputSchema: { type: "object" }
+      }
+    ],
+    memoryRef: {
+      mode: "INDEX_ONLY",
+      summaryHash: "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      vectorIndexUri: "s3://agent-memory/support-triage/index.bin"
+    }
+  };
+
+  const signature = {
+    algorithm: "ED25519",
+    payloadHash: buildBundlePayloadHash(bundle),
+    signature: "base64:MEUCIQDdExampleSignatureForBundleUploadFlow1234567890==",
+    signerDid: bundle.identity.did
+  };
+
+  return {
+    ...bundle,
+    signature,
+    ...overrides,
+    manifest: {
+      ...bundle.manifest,
+      ...overrides.manifest
+    },
+    identity: {
+      ...bundle.identity,
+      ...overrides.identity
+    },
+    memoryRef: {
+      ...bundle.memoryRef,
+      ...overrides.memoryRef
+    },
+    signature: {
+      ...signature,
+      ...overrides.signature
+    }
+  };
 }
 
 async function startTestServer({ now } = {}) {
@@ -178,6 +258,139 @@ test("POST /v1/tasks persists a task and updates runtime summary", async () => {
     assert.equal(summaryBody.storage.latestTaskId, "task_00000001");
     assert.equal(logEntries[0].workspaceId, "workspace-kestrel");
     assert.equal(logEntries[0].statusCode, 201);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("POST /v1/agents/bundles accepts a valid bundle and returns indexed skill records", async () => {
+  const { server, baseUrl, logEntries } = await startTestServer();
+
+  try {
+    const bundle = buildAgentBundle();
+    const response = await fetch(`${baseUrl}/v1/agents/bundles`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem_agentbundle_001",
+        bundle
+      })
+    });
+
+    assert.equal(response.status, 201);
+    const body = await response.json();
+    assert.equal(body.agentId, "agent_support_triage_agent");
+    assert.equal(body.result, "CREATED");
+    assert.equal(body.indexing.indexedSkillCount, 1);
+    assert.equal(body.indexing.skills[0].sourceVersion, "1.2.0");
+    assert.equal(logEntries.at(-1)?.path, "/v1/agents/bundles");
+    assert.equal(logEntries.at(-1)?.statusCode, 201);
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("POST /v1/agents/bundles replays the same accepted version and rejects payload hash drift", async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const bundle = buildAgentBundle();
+    const created = await fetch(`${baseUrl}/v1/agents/bundles`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem_agentbundle_001",
+        bundle
+      })
+    });
+    assert.equal(created.status, 201);
+
+    const replay = await fetch(`${baseUrl}/v1/agents/bundles`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem_agentbundle_001",
+        bundle
+      })
+    });
+    assert.equal(replay.status, 200);
+    const replayBody = await replay.json();
+    assert.equal(replayBody.result, "RETURNED_EXISTING");
+
+    const drift = await fetch(`${baseUrl}/v1/agents/bundles`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem_agentbundle_002",
+        bundle: buildAgentBundle({
+          signature: {
+            payloadHash: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          }
+        })
+      })
+    });
+    assert.equal(drift.status, 400);
+    const driftBody = await drift.json();
+    assert.equal(driftBody.code, "AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH");
+  } finally {
+    server.close();
+    await once(server, "close");
+  }
+});
+
+test("POST /v1/agents/bundles rejects same version with a different bundle payload", async () => {
+  const { server, baseUrl } = await startTestServer();
+
+  try {
+    const created = await fetch(`${baseUrl}/v1/agents/bundles`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem_agentbundle_001",
+        bundle: buildAgentBundle()
+      })
+    });
+    assert.equal(created.status, 201);
+
+    const changedBundle = buildAgentBundle({
+      skills: [
+        {
+          skillId: "skill_support.priority_score",
+          version: "1.5.0",
+          inputSchema: { type: "object" },
+          outputSchema: { type: "object" }
+        }
+      ]
+    });
+    changedBundle.signature.payloadHash = buildBundlePayloadHash(changedBundle);
+
+    const conflict = await fetch(`${baseUrl}/v1/agents/bundles`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json"
+      },
+      body: JSON.stringify({
+        idempotencyKey: "idem_agentbundle_003",
+        bundle: changedBundle
+      })
+    });
+
+    assert.equal(conflict.status, 409);
+    const body = await conflict.json();
+    assert.equal(body.code, "AGENT_BUNDLE_VERSION_CONFLICT");
+    assert.equal(body.conflict.strategy, "REJECT_ON_HASH_MISMATCH");
   } finally {
     server.close();
     await once(server, "close");

--- a/test/runtime/onboarding-smoke.test.js
+++ b/test/runtime/onboarding-smoke.test.js
@@ -1,0 +1,18 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runOnboardingSmoke } from "../../src/runtime/onboarding-smoke.js";
+
+test("onboarding smoke command exercises agent bundle upload happy and replay paths", async () => {
+  const lines = [];
+  const result = await runOnboardingSmoke({
+    serviceName: "test-onboarding-smoke",
+    log: (message) => lines.push(message)
+  });
+
+  assert.equal(result.agentId, "agent_support_triage_agent");
+  assert.equal(result.version, "1.2.0");
+  assert.equal(result.replayStrategy, "RETURN_EXISTING_ON_HASH_MATCH");
+  assert.equal(result.mismatchCode, "AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH");
+  assert.ok(lines.some((line) => line.includes("PASS POST /v1/agents/bundles")));
+  assert.ok(lines.some((line) => line.includes("PASS replay /v1/agents/bundles")));
+});


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): part of #2
- Department label (pick one): `dept/backend`
- Type label (pick one): `type/feature`
- Scope: executable runtime slice for agent bundle onboarding uploads

## What Changed

- added `POST /v1/agents/bundles` to the local runtime with signature/schema validation, idempotent replay handling, and same-version conflict detection
- taught the in-memory control-plane store to persist agent bundles and emit skill indexing summaries with deterministic agent ids
- added `src/runtime/onboarding-smoke.js` plus runtime tests covering create, replay, payload-hash mismatch, and version-conflict cases
- updated the runtime drift guard, docs, and OpenSpec planning artifacts so the onboarding route is reflected in the runnable baseline

## Why

- epic #2 already published onboarding contracts, but the runtime only executed the task marketplace path
- this closes a concrete MVP gap by making agent onboarding reviewable locally with repeatable smoke/test evidence

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| OpenSpec artifacts 与 API/实现保持一致 | runtime route, smoke coverage, and docs were added alongside OpenSpec/proposal/tasks updates | `src/runtime/app.js`, `scripts/check-runtime-contract-drift.js`, `openspec/changes/agent-dispatch-platform/tasks.md` |
| E2E happy path 可跑通 | onboarding smoke now exercises create and replay end-to-end against the runtime server | `src/runtime/onboarding-smoke.js`, `test/runtime/onboarding-smoke.test.js`, `npm run smoke:onboarding` |
| 核心负面场景有测试 | payload-hash mismatch and same-version payload conflict are asserted in runtime tests | `test/runtime/app.test.js` |

## QA Plan

### Preconditions

- Use Node/npm from `/opt/homebrew/bin`
- Start from this branch with no local modifications

### Steps

1. Run `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npx -y @fission-ai/openspec validate --all`
2. Run `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test`
3. Run `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run check:contract-drift`
4. Run `PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run smoke:onboarding`
5. Run `git diff --check`
6. Run `bash scripts/agent_prepush_check.sh --github-user jckhang`

### Expected Results

- OpenSpec validation passes for `agent-dispatch-platform`
- runtime tests stay green, including the new onboarding coverage
- contract-drift output lists `/v1/agents/bundles` with no missing required routes
- onboarding smoke prints PASS lines for create, replay, and payload-hash mismatch
- diff and pre-push guard pass cleanly

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
- `npm test`
- `npm run check:contract-drift`
- `npm run smoke:onboarding`
- `git diff --check`
- `bash scripts/agent_prepush_check.sh --github-user jckhang`

```text
$ PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npx -y @fission-ai/openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

```text
$ PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm test
> test
> node --test
...
ℹ tests 44
ℹ suites 0
ℹ pass 44
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 645.318791
```

```text
$ PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run check:contract-drift
> check:contract-drift
> node scripts/check-runtime-contract-drift.js --assert

runtimeRoutes.missingRequired: []
/v1/agents/bundles present in published route set
```

```text
$ PATH=/opt/homebrew/bin:$PATH /opt/homebrew/bin/npm run smoke:onboarding
> smoke:onboarding
> node src/runtime/onboarding-smoke.js

onboarding smoke listening on http://127.0.0.1:53926
PASS POST /v1/agents/bundles -> agent_support_triage_agent@1.2.0
PASS replay /v1/agents/bundles -> RETURN_EXISTING_ON_HASH_MATCH
PASS payload hash mismatch -> AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH
{
  "status": "ok",
  "serviceName": "agent-indeed-onboarding-smoke",
  "baseUrl": "http://127.0.0.1:53926",
  "agentId": "agent_support_triage_agent",
  "version": "1.2.0",
  "replayStrategy": "RETURN_EXISTING_ON_HASH_MATCH",
  "mismatchCode": "AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH"
}
```

```text
$ git diff --check
```

```text
$ bash scripts/agent_prepush_check.sh --github-user jckhang
[ok] Branch 'codex/issue-2-onboarding-runtime-upload' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (jckhang).
[ok] git user.email matches expected account (jckhang@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - signature validation is intentionally format-level only for now, so future crypto verification work must preserve these replay/conflict semantics
  - runtime storage remains in-memory, so onboarding uploads are still process-local smoke evidence rather than durable persistence
- Rollback:
  - revert commit `2c4182a` or disable use of `POST /v1/agents/bundles` until the route is reworked

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--albatross-dev-agent`
