### PR TITLE
[Week 2026-03-19] Prepare issue #206 onboarding evidence handoff

### DIFF
--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -87,6 +87,11 @@ issue `#206`; keep the dispatch smoke transcript on issue `#11` and the onboardi
 smoke transcript on epic `#2` so reviewers can see both executable lanes without mixing
 their identifiers.
 
+When QA needs to attach the onboarding handoff to a PR or local evidence bundle, prefer
+`npm run --silent smoke:onboarding:evidence -- --signature <agent-name> --output-dir <path>`
+so the same run produces a signed markdown comment plus machine-readable smoke and
+contract-drift artifacts under one directory.
+
 The backend-owned reusable API packet for that final handoff lives in
 `docs/BACKEND_API_EXAMPLE_PACKET.md`; issue #11 and future QA runs should point at that
 doc instead of reconstructing payloads from PR review threads.

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -46,6 +46,11 @@ as the canonical backend-owned issue `#11` evidence command. It turns the merged
 into one ready-to-paste packet without manually rewriting the task/bid/proof ids, error
 codes, PASS-line transcript, or decision-trace fields.
 
+Once the onboarding upload smoke path lands on `main`, QA should pair that dispatch packet
+with `node src/runtime/onboarding-evidence.js --signature <agent-name>` so epic `#2` gets
+the signed onboarding upload/replay/hash-mismatch transcript plus the matching
+`check:contract-drift` confirmation that `/v1/agents/bundles` is published.
+
 ## Evidence package
 
 Every PR or issue update claiming runtime progress must include enough evidence for a
@@ -76,6 +81,11 @@ Minimum evidence:
 Issue #11 remains the aggregation point for final beta-readiness evidence. Runtime PRs
 should link their evidence there rather than duplicating large transcripts across multiple
 planning docs.
+
+Epic `#2` remains the cross-lane checkpoint sink for the companion onboarding evidence in
+issue `#206`; keep the dispatch smoke transcript on issue `#11` and the onboarding upload
+smoke transcript on epic `#2` so reviewers can see both executable lanes without mixing
+their identifiers.
 
 The backend-owned reusable API packet for that final handoff lives in
 `docs/BACKEND_API_EXAMPLE_PACKET.md`; issue #11 and future QA runs should point at that

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -47,7 +47,7 @@ into one ready-to-paste packet without manually rewriting the task/bid/proof ids
 codes, PASS-line transcript, or decision-trace fields.
 
 Once the onboarding upload smoke path lands on `main`, QA should pair that dispatch packet
-with `node src/runtime/onboarding-evidence.js --signature <agent-name>` so epic `#2` gets
+with `npm run --silent smoke:onboarding:evidence -- --signature <agent-name>` so epic `#2` gets
 the signed onboarding upload/replay/hash-mismatch transcript plus the matching
 `check:contract-drift` confirmation that `/v1/agents/bundles` is published.
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -90,6 +90,7 @@
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
    - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
+   - onboarding upload smoke 合入后，QA 需要同时向 epic #2 发布 companion evidence，确认上传 happy path、幂等 replay、payload-hash mismatch 以及 `/v1/agents/bundles` 已进入 published route 集；该回贴应复用统一 formatter，避免评论里手抄 agent/version/error code。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -90,7 +90,7 @@
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
    - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
-   - onboarding upload smoke 合入后，QA 需要同时向 epic #2 发布 companion evidence，确认上传 happy path、幂等 replay、payload-hash mismatch 以及 `/v1/agents/bundles` 已进入 published route 集；该回贴应复用统一 formatter，避免评论里手抄 agent/version/error code。
+   - onboarding upload smoke 合入后，QA 需要同时向 epic #2 发布 companion evidence，确认上传 happy path、幂等 replay、payload-hash mismatch 以及 `/v1/agents/bundles` 已进入 published route 集；该回贴应复用统一 formatter，并通过固定命令 `npm run --silent smoke:onboarding:evidence -- --signature <agent-name>` 生成，避免评论里手抄 agent/version/error code。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -41,6 +41,7 @@
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
 - 新增 onboarding evidence formatter 与固定 CLI 入口，减少 QA 在 epic #2 回贴上传 smoke 证据时手抄 agent/version/error code 与 route anchor，也避免评论里继续传播临时 `node ...` 调用方式。
+- 为 onboarding evidence formatter 增补 artifact export 选项，允许同一次 smoke 运行同时输出 signed markdown、smoke summary JSON 与 contract-drift JSON，便于 PR 附件和本地 QA 归档复用。
 - 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,6 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
+- 增补 onboarding smoke evidence handoff，要求 QA 在 `smoke:onboarding` 合入 `main` 后把上传/重放/hash-mismatch 结果与 `/v1/agents/bundles` contract-drift 确认一起回写到 epic #2。
 
 ## Capabilities
 
@@ -39,6 +40,7 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
+- 新增 onboarding evidence formatter，减少 QA 在 epic #2 回贴上传 smoke 证据时手抄 agent/version/error code 与 route anchor。
 - 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,7 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
-- 增补 onboarding smoke evidence handoff，要求 QA 在 `smoke:onboarding` 合入 `main` 后把上传/重放/hash-mismatch 结果与 `/v1/agents/bundles` contract-drift 确认一起回写到 epic #2。
+- 增补 onboarding smoke evidence handoff，要求 QA 在 `smoke:onboarding` 合入 `main` 后通过固定命令 `npm run --silent smoke:onboarding:evidence -- --signature <agent-name>` 回贴上传/重放/hash-mismatch 结果，并附带 `/v1/agents/bundles` contract-drift 确认到 epic #2。
 
 ## Capabilities
 
@@ -40,7 +40,7 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
-- 新增 onboarding evidence formatter，减少 QA 在 epic #2 回贴上传 smoke 证据时手抄 agent/version/error code 与 route anchor。
+- 新增 onboarding evidence formatter 与固定 CLI 入口，减少 QA 在 epic #2 回贴上传 smoke 证据时手抄 agent/version/error code 与 route anchor，也避免评论里继续传播临时 `node ...` 调用方式。
 - 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -53,3 +53,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.15 为 issue #206 增补 onboarding smoke evidence formatter 与 handoff 文档，确保 epic #2 回贴可直接复用 happy-path/replay/hash-mismatch 结果，并附带 `/v1/agents/bundles` contract-drift 确认。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -55,3 +55,4 @@
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
 - [x] 5.15 为 issue #206 增补 onboarding smoke evidence formatter 与 handoff 文档，确保 epic #2 回贴可直接复用 happy-path/replay/hash-mismatch 结果，并附带 `/v1/agents/bundles` contract-drift 确认。
 - [x] 5.15.a 为 onboarding evidence formatter 增补固定 `npm run --silent smoke:onboarding:evidence -- --signature <agent-name>` 入口和 CLI 参数校验，避免 QA 在 `main` 回归时继续依赖临时脚本路径或静默吞掉错误参数。
+- [x] 5.15.b 为 onboarding evidence formatter 增补 `--output-dir` artifact export，统一导出 epic #2 comment markdown、onboarding smoke summary JSON 与 contract-drift JSON，减少 PR/本地 QA 手动整理证据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -54,3 +54,4 @@
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
 - [x] 5.15 为 issue #206 增补 onboarding smoke evidence formatter 与 handoff 文档，确保 epic #2 回贴可直接复用 happy-path/replay/hash-mismatch 结果，并附带 `/v1/agents/bundles` contract-drift 确认。
+- [x] 5.15.a 为 onboarding evidence formatter 增补固定 `npm run --silent smoke:onboarding:evidence -- --signature <agent-name>` 入口和 CLI 参数校验，避免 QA 在 `main` 回归时继续依赖临时脚本路径或静默吞掉错误参数。

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "node --watch src/runtime/server.js",
     "smoke:dispatch": "node src/runtime/dispatch-smoke.js",
     "smoke:issue11": "node src/runtime/issue11-evidence.js",
+    "smoke:onboarding:evidence": "node src/runtime/onboarding-evidence.js",
     "smoke:bootstrap": "node src/runtime/bootstrap-smoke.js",
     "check:contract-drift": "node scripts/check-runtime-contract-drift.js --assert",
     "test": "node --test"

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -8,6 +8,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
 - Print an issue-ready issue `#11` evidence packet: `npm run --silent smoke:issue11 -- --signature avery`
+- After the onboarding upload smoke path lands on `main`, print the epic `#2` onboarding evidence packet: `node src/runtime/onboarding-evidence.js --signature avery`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
@@ -63,6 +64,17 @@ npm run --silent smoke:issue11 -- --signature avery
 That command reuses the dispatch smoke suite, captures the PASS lines and JSON summary, and formats one markdown packet with the happy-path ids, negative-path reason codes, and links to the reusable handoff docs.
 
 `npm test` also shells this command end-to-end and asserts the PASS-line plus JSON-summary contract, so CI covers the exact smoke output shape that QA copies into issue evidence.
+
+After the onboarding runtime upload route merges, QA can also run:
+
+```bash
+node src/runtime/onboarding-evidence.js --signature avery
+```
+
+That helper expects `src/runtime/onboarding-smoke.js` to exist on the current branch. When
+available, it reruns the onboarding smoke, confirms `npm run check:contract-drift` still
+publishes `/v1/agents/bundles`, and prints one ready-to-paste markdown packet for epic `#2`
+so issue `#206` can keep onboarding evidence separate from the issue `#11` dispatch lane.
 
 Or run the bootstrap path end-to-end with one command:
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -9,6 +9,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
 - Print an issue-ready issue `#11` evidence packet: `npm run --silent smoke:issue11 -- --signature avery`
 - After the onboarding upload smoke path lands on `main`, print the epic `#2` onboarding evidence packet: `npm run --silent smoke:onboarding:evidence -- --signature avery`
+- Persist the onboarding evidence packet plus JSON artifacts locally: `npm run --silent smoke:onboarding:evidence -- --signature avery --output-dir ./artifacts/onboarding`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
@@ -75,6 +76,8 @@ That helper expects `src/runtime/onboarding-smoke.js` to exist on the current br
 available, it reruns the onboarding smoke, confirms `npm run check:contract-drift` still
 publishes `/v1/agents/bundles`, and prints one ready-to-paste markdown packet for epic `#2`
 so issue `#206` can keep onboarding evidence separate from the issue `#11` dispatch lane.
+When `--output-dir <path>` is provided, it also writes the markdown packet plus the smoke
+summary and contract-drift confirmation as JSON files for local QA artifacts or PR uploads.
 
 Or run the bootstrap path end-to-end with one command:
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -8,7 +8,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
 - Print an issue-ready issue `#11` evidence packet: `npm run --silent smoke:issue11 -- --signature avery`
-- After the onboarding upload smoke path lands on `main`, print the epic `#2` onboarding evidence packet: `node src/runtime/onboarding-evidence.js --signature avery`
+- After the onboarding upload smoke path lands on `main`, print the epic `#2` onboarding evidence packet: `npm run --silent smoke:onboarding:evidence -- --signature avery`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
@@ -68,7 +68,7 @@ That command reuses the dispatch smoke suite, captures the PASS lines and JSON s
 After the onboarding runtime upload route merges, QA can also run:
 
 ```bash
-node src/runtime/onboarding-evidence.js --signature avery
+npm run --silent smoke:onboarding:evidence -- --signature avery
 ```
 
 That helper expects `src/runtime/onboarding-smoke.js` to exist on the current branch. When

--- a/src/runtime/onboarding-evidence.js
+++ b/src/runtime/onboarding-evidence.js
@@ -119,21 +119,32 @@ export async function runEpic2OnboardingEvidence({ log = console.log, signature 
   };
 }
 
-function parseArgs(argv) {
+export function parseEpic2OnboardingEvidenceArgs(argv) {
   const options = {};
 
   for (let index = 0; index < argv.length; index += 1) {
-    if (argv[index] === "--signature") {
-      options.signature = argv[index + 1];
+    const arg = argv[index];
+
+    if (arg === "--signature") {
+      const value = argv[index + 1];
+
+      if (!value || value.startsWith("--")) {
+        throw new Error("--signature requires a value");
+      }
+
+      options.signature = value;
       index += 1;
+      continue;
     }
+
+    throw new Error(`Unknown argument: ${arg}`);
   }
 
   return options;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const options = parseArgs(process.argv.slice(2));
+  const options = parseEpic2OnboardingEvidenceArgs(process.argv.slice(2));
 
   runEpic2OnboardingEvidence(options).catch((error) => {
     console.error(error.message);

--- a/src/runtime/onboarding-evidence.js
+++ b/src/runtime/onboarding-evidence.js
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { buildSnapshot, assertNoDrift } from "../../scripts/check-runtime-contract-drift.js";
 
@@ -75,7 +77,11 @@ export function formatEpic2OnboardingEvidence({
   ].join("\n");
 }
 
-export async function runEpic2OnboardingEvidence({ log = console.log, signature } = {}) {
+export async function runEpic2OnboardingEvidence({
+  log = console.log,
+  outputDir,
+  signature
+} = {}) {
   let onboardingSmokeModule;
 
   try {
@@ -108,14 +114,50 @@ export async function runEpic2OnboardingEvidence({ log = console.log, signature 
     contractDrift,
     signature
   });
+  const artifactPaths = await writeEpic2OnboardingArtifacts({
+    markdown,
+    outputDir,
+    summary,
+    contractDrift
+  });
 
   log(markdown);
 
   return {
+    artifactPaths,
     summary,
     logLines,
     contractDrift,
     markdown
+  };
+}
+
+export async function writeEpic2OnboardingArtifacts({
+  markdown,
+  outputDir,
+  summary,
+  contractDrift
+} = {}) {
+  if (!outputDir) {
+    return null;
+  }
+
+  const resolvedOutputDir = path.resolve(outputDir);
+  const markdownPath = path.join(resolvedOutputDir, "epic2-onboarding-evidence.md");
+  const summaryPath = path.join(resolvedOutputDir, "onboarding-smoke-summary.json");
+  const contractDriftPath = path.join(resolvedOutputDir, "onboarding-contract-drift.json");
+
+  await mkdir(resolvedOutputDir, { recursive: true });
+  await Promise.all([
+    writeFile(markdownPath, `${markdown}\n`, "utf8"),
+    writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8"),
+    writeFile(contractDriftPath, `${JSON.stringify(contractDrift, null, 2)}\n`, "utf8")
+  ]);
+
+  return {
+    markdownPath,
+    summaryPath,
+    contractDriftPath
   };
 }
 
@@ -125,19 +167,24 @@ export function parseEpic2OnboardingEvidenceArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
 
-    if (arg === "--signature") {
+    if (arg === "--signature" || arg === "--output-dir") {
       const value = argv[index + 1];
 
       if (!value || value.startsWith("--")) {
-        throw new Error("--signature requires a value");
+        throw new Error(`missing value for ${arg}`);
       }
 
-      options.signature = value;
+      if (arg === "--signature") {
+        options.signature = value;
+      } else {
+        options.outputDir = value;
+      }
+
       index += 1;
       continue;
     }
 
-    throw new Error(`Unknown argument: ${arg}`);
+    throw new Error(`unknown argument: ${arg}`);
   }
 
   return options;

--- a/src/runtime/onboarding-evidence.js
+++ b/src/runtime/onboarding-evidence.js
@@ -1,0 +1,142 @@
+import { pathToFileURL } from "node:url";
+import { buildSnapshot, assertNoDrift } from "../../scripts/check-runtime-contract-drift.js";
+
+const ONBOARDING_ROUTE = "/v1/agents/bundles";
+
+function formatCompanionIssue11Command(signature) {
+  return signature
+    ? `npm run --silent smoke:issue11 -- --signature ${signature}`
+    : "npm run --silent smoke:issue11";
+}
+
+function buildContractDriftEvidence() {
+  const snapshot = buildSnapshot();
+  assertNoDrift(snapshot);
+
+  const routeAnchor = snapshot.runtimeRoutes.anchors[ONBOARDING_ROUTE];
+
+  if (!snapshot.runtimeRoutes.published.includes(ONBOARDING_ROUTE) || !routeAnchor) {
+    throw new Error(
+      `${ONBOARDING_ROUTE} is not published in the current OpenAPI snapshot yet. ` +
+        "Merge the onboarding upload route before posting epic #2 onboarding evidence."
+    );
+  }
+
+  return {
+    command: "npm run check:contract-drift",
+    route: ONBOARDING_ROUTE,
+    routeAnchor
+  };
+}
+
+export function formatEpic2OnboardingEvidence({
+  summary,
+  logLines = [],
+  contractDrift,
+  signature
+} = {}) {
+  const signedNote = signature ? `\n--${signature}` : "";
+  const onboardingCommand = "npm run smoke:onboarding";
+
+  return [
+    "## Epic #2 onboarding smoke evidence",
+    "",
+    "- Evidence issue: `#206`",
+    `- Onboarding smoke command: \`${onboardingCommand}\``,
+    `- Companion issue #11 command: \`${formatCompanionIssue11Command(signature)}\``,
+    `- Contract drift check: \`${contractDrift.command}\``,
+    "",
+    "### Onboarding smoke summary",
+    "",
+    `- status: \`${summary.status}\``,
+    `- baseUrl: \`${summary.baseUrl}\``,
+    `- agentId: \`${summary.agentId}\``,
+    `- version: \`${summary.version}\``,
+    `- replay strategy: \`${summary.replayStrategy}\``,
+    `- payload mismatch code: \`${summary.mismatchCode}\``,
+    "",
+    "### Contract drift confirmation",
+    "",
+    `- published route present: \`${contractDrift.route}\``,
+    `- OpenAPI anchor: \`${contractDrift.routeAnchor}\``,
+    "",
+    "### Smoke log",
+    "",
+    "```text",
+    logLines.join("\n"),
+    "```",
+    "",
+    "### Machine-readable summary",
+    "",
+    "```json",
+    JSON.stringify(summary, null, 2),
+    "```",
+    signedNote
+  ].join("\n");
+}
+
+export async function runEpic2OnboardingEvidence({ log = console.log, signature } = {}) {
+  let onboardingSmokeModule;
+
+  try {
+    onboardingSmokeModule = await import("./onboarding-smoke.js");
+  } catch (error) {
+    if (error && error.code === "ERR_MODULE_NOT_FOUND") {
+      throw new Error(
+        "src/runtime/onboarding-smoke.js is not available on this branch yet. " +
+          "Run this helper after the onboarding upload smoke path lands on main."
+      );
+    }
+
+    throw error;
+  }
+
+  const logLines = [];
+  const summary = await onboardingSmokeModule.runOnboardingSmoke({
+    log: (line) => {
+      logLines.push(line);
+    }
+  });
+  const contractDrift = buildContractDriftEvidence();
+  const markdown = formatEpic2OnboardingEvidence({
+    summary: {
+      status: "ok",
+      command: "npm run smoke:onboarding",
+      ...summary
+    },
+    logLines,
+    contractDrift,
+    signature
+  });
+
+  log(markdown);
+
+  return {
+    summary,
+    logLines,
+    contractDrift,
+    markdown
+  };
+}
+
+function parseArgs(argv) {
+  const options = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--signature") {
+      options.signature = argv[index + 1];
+      index += 1;
+    }
+  }
+
+  return options;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const options = parseArgs(process.argv.slice(2));
+
+  runEpic2OnboardingEvidence(options).catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/test/runtime/onboarding-evidence.test.js
+++ b/test/runtime/onboarding-evidence.test.js
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 
-import { formatEpic2OnboardingEvidence } from "../../src/runtime/onboarding-evidence.js";
+import {
+  formatEpic2OnboardingEvidence,
+  parseEpic2OnboardingEvidenceArgs
+} from "../../src/runtime/onboarding-evidence.js";
 
 test("formatEpic2OnboardingEvidence includes the smoke summary, contract drift, and signature", () => {
   const markdown = formatEpic2OnboardingEvidence({
@@ -37,4 +41,28 @@ test("formatEpic2OnboardingEvidence includes the smoke summary, contract drift, 
   assert.match(markdown, /`\/v1\/agents\/bundles`/);
   assert.match(markdown, /`src\/api\/openapi\.yaml:68`/);
   assert.match(markdown, /--avery/);
+});
+
+test("parseEpic2OnboardingEvidenceArgs accepts --signature and rejects invalid flags", () => {
+  assert.deepEqual(parseEpic2OnboardingEvidenceArgs(["--signature", "avery"]), {
+    signature: "avery"
+  });
+  assert.throws(
+    () => parseEpic2OnboardingEvidenceArgs(["--signature"]),
+    /--signature requires a value/
+  );
+  assert.throws(
+    () => parseEpic2OnboardingEvidenceArgs(["--unknown"]),
+    /Unknown argument: --unknown/
+  );
+});
+
+test("onboarding-evidence CLI exits non-zero for invalid args", () => {
+  const result = spawnSync(process.execPath, ["src/runtime/onboarding-evidence.js", "--bad-flag"], {
+    cwd: process.cwd(),
+    encoding: "utf8"
+  });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /Unknown argument: --bad-flag/);
 });

--- a/test/runtime/onboarding-evidence.test.js
+++ b/test/runtime/onboarding-evidence.test.js
@@ -1,10 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 import {
   formatEpic2OnboardingEvidence,
-  parseEpic2OnboardingEvidenceArgs
+  parseEpic2OnboardingEvidenceArgs,
+  writeEpic2OnboardingArtifacts
 } from "../../src/runtime/onboarding-evidence.js";
 
 test("formatEpic2OnboardingEvidence includes the smoke summary, contract drift, and signature", () => {
@@ -43,26 +48,82 @@ test("formatEpic2OnboardingEvidence includes the smoke summary, contract drift, 
   assert.match(markdown, /--avery/);
 });
 
-test("parseEpic2OnboardingEvidenceArgs accepts --signature and rejects invalid flags", () => {
-  assert.deepEqual(parseEpic2OnboardingEvidenceArgs(["--signature", "avery"]), {
-    signature: "avery"
+test("writeEpic2OnboardingArtifacts persists markdown, summary, and contract-drift files", async () => {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "onboarding-evidence-"));
+  const artifactPaths = await writeEpic2OnboardingArtifacts({
+    markdown: "## Epic #2 onboarding smoke evidence\n--avery",
+    outputDir,
+    summary: {
+      status: "ok",
+      agentId: "agent_support_triage_agent"
+    },
+    contractDrift: {
+      command: "npm run check:contract-drift",
+      route: "/v1/agents/bundles"
+    }
   });
+
+  assert.equal(
+    artifactPaths.markdownPath,
+    path.join(outputDir, "epic2-onboarding-evidence.md")
+  );
+  assert.equal(
+    artifactPaths.summaryPath,
+    path.join(outputDir, "onboarding-smoke-summary.json")
+  );
+  assert.equal(
+    artifactPaths.contractDriftPath,
+    path.join(outputDir, "onboarding-contract-drift.json")
+  );
+
+  const markdown = await readFile(artifactPaths.markdownPath, "utf8");
+  const summary = JSON.parse(await readFile(artifactPaths.summaryPath, "utf8"));
+  const contractDrift = JSON.parse(await readFile(artifactPaths.contractDriftPath, "utf8"));
+
+  assert.match(markdown, /## Epic #2 onboarding smoke evidence/);
+  assert.match(markdown, /--avery/);
+  assert.equal(summary.agentId, "agent_support_triage_agent");
+  assert.equal(contractDrift.route, "/v1/agents/bundles");
+});
+
+test("parseEpic2OnboardingEvidenceArgs accepts signature and output directory flags", () => {
+  assert.deepEqual(
+    parseEpic2OnboardingEvidenceArgs([
+      "--signature",
+      "avery",
+      "--output-dir",
+      "./artifacts/onboarding"
+    ]),
+    {
+      signature: "avery",
+      outputDir: "./artifacts/onboarding"
+    }
+  );
+});
+
+test("parseEpic2OnboardingEvidenceArgs rejects missing flag values and unknown flags", () => {
   assert.throws(
     () => parseEpic2OnboardingEvidenceArgs(["--signature"]),
-    /--signature requires a value/
+    /missing value for --signature/
+  );
+  assert.throws(
+    () => parseEpic2OnboardingEvidenceArgs(["--output-dir", "--signature"]),
+    /missing value for --output-dir/
   );
   assert.throws(
     () => parseEpic2OnboardingEvidenceArgs(["--unknown"]),
-    /Unknown argument: --unknown/
+    /unknown argument: --unknown/
   );
 });
 
 test("onboarding-evidence CLI exits non-zero for invalid args", () => {
-  const result = spawnSync(process.execPath, ["src/runtime/onboarding-evidence.js", "--bad-flag"], {
-    cwd: process.cwd(),
+  const cliPath = fileURLToPath(
+    new URL("../../src/runtime/onboarding-evidence.js", import.meta.url)
+  );
+  const result = spawnSync(process.execPath, [cliPath, "--output-dir", "--signature", "avery"], {
     encoding: "utf8"
   });
 
   assert.notEqual(result.status, 0);
-  assert.match(result.stderr, /Unknown argument: --bad-flag/);
+  assert.match(result.stderr, /missing value for --output-dir/);
 });

--- a/test/runtime/onboarding-evidence.test.js
+++ b/test/runtime/onboarding-evidence.test.js
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { formatEpic2OnboardingEvidence } from "../../src/runtime/onboarding-evidence.js";
+
+test("formatEpic2OnboardingEvidence includes the smoke summary, contract drift, and signature", () => {
+  const markdown = formatEpic2OnboardingEvidence({
+    summary: {
+      status: "ok",
+      baseUrl: "http://127.0.0.1:43123",
+      agentId: "agent_support_triage_agent",
+      version: "1.2.0",
+      replayStrategy: "RETURN_EXISTING_ON_HASH_MATCH",
+      mismatchCode: "AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH"
+    },
+    logLines: [
+      "PASS POST /v1/agents/bundles -> agent_support_triage_agent@1.2.0",
+      "PASS replay /v1/agents/bundles -> RETURN_EXISTING_ON_HASH_MATCH",
+      "PASS payload hash mismatch -> AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH"
+    ],
+    contractDrift: {
+      command: "npm run check:contract-drift",
+      route: "/v1/agents/bundles",
+      routeAnchor: "src/api/openapi.yaml:68"
+    },
+    signature: "avery"
+  });
+
+  assert.match(markdown, /## Epic #2 onboarding smoke evidence/);
+  assert.match(markdown, /`#206`/);
+  assert.match(markdown, /`npm run smoke:onboarding`/);
+  assert.match(markdown, /`npm run --silent smoke:issue11 -- --signature avery`/);
+  assert.match(markdown, /`http:\/\/127\.0\.0\.1:43123`/);
+  assert.match(markdown, /`agent_support_triage_agent`/);
+  assert.match(markdown, /RETURN_EXISTING_ON_HASH_MATCH/);
+  assert.match(markdown, /AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH/);
+  assert.match(markdown, /`\/v1\/agents\/bundles`/);
+  assert.match(markdown, /`src\/api\/openapi\.yaml:68`/);
+  assert.match(markdown, /--avery/);
+});


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #206
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: add a reusable onboarding evidence formatter and handoff notes for the post-merge QA follow-up in issue #206

## What Changed

- added `src/runtime/onboarding-evidence.js` to format one signed epic #2 comment for the onboarding smoke lane once `src/runtime/onboarding-smoke.js` is available on `main`
- wired the helper to confirm `npm run check:contract-drift` still publishes `/v1/agents/bundles` before printing the markdown packet
- documented the issue #11 vs epic #2 evidence split in `docs/RUNTIME_EXECUTION_HANDOFF.md` and `src/runtime/README.md`
- synced the `agent-dispatch-platform` OpenSpec proposal/design/tasks artifacts to cover the new issue #206 handoff helper
- added `test/runtime/onboarding-evidence.test.js` for the markdown formatter contract

## Why

- issue #206 is the highest-priority QA-owned ready-next thread, but its final acceptance depends on PR #204 merging first
- this keeps the QA follow-up focused and executable by giving Avery a single formatter for the onboarding upload/replay/hash-mismatch evidence instead of hand-editing epic #2 comments
- the helper also protects the route-set acceptance check by refusing to format evidence until `/v1/agents/bundles` is present in the published contract snapshot

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| QA can publish onboarding smoke evidence to epic #2 once the onboarding upload path lands on `main` | `src/runtime/onboarding-evidence.js` formats the signed happy-path/replay/hash-mismatch packet and errors early if the onboarding smoke module is not on the branch yet | `src/runtime/onboarding-evidence.js`, `test/runtime/onboarding-evidence.test.js` |
| The onboarding evidence lane stays aligned with the published route set and repo handoff docs | The helper verifies `npm run check:contract-drift` and the docs/OpenSpec artifacts now explain the epic #2 vs issue #11 split | `src/runtime/onboarding-evidence.js`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, `src/runtime/README.md`, `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- PR #204 (or equivalent onboarding upload work) has merged so `src/runtime/onboarding-smoke.js` and `npm run smoke:onboarding` exist on `main`
- local PATH includes Node tooling (`/opt/homebrew/bin` in this worktree)

### Steps

1. Run `node src/runtime/onboarding-evidence.js --signature avery` after the onboarding upload smoke path lands.
2. Run `npm run --silent smoke:issue11 -- --signature avery` to refresh the dispatch evidence companion comment.
3. Paste the onboarding packet into epic #2 and the dispatch packet into issue #11.

### Expected Results

- the onboarding helper prints one markdown packet with agent/version/replay/hash-mismatch details plus `/v1/agents/bundles` contract-drift confirmation
- issue #11 keeps the dispatch smoke transcript while epic #2 carries the onboarding upload transcript
- no manual transcription of ids, route anchors, or error codes is needed

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```text
not run: `openspec` CLI is not installed in this worktree.
attempted fallback:
$ npx -y openspec@latest validate --all
npm error could not determine executable to run
npm error A complete log of this run can be found in: /Users/jyxc-dz-0100219/.npm/_logs/2026-03-19T15_16_38_084Z-debug-0.log
```
- `npm test`
```text
> test
> node --test
...
ℹ tests 23
ℹ pass 23
ℹ fail 0
```
- `git diff --check`
```text
<no output>
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/issue-206-onboarding-evidence-handoff' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - the helper intentionally stays blocked until the onboarding smoke module exists on the branch, so it is preparatory infrastructure rather than the final evidence comment itself
- Rollback:
  - revert this PR to remove the formatter/docs/test additions if the QA evidence flow is redesigned

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
