### PR TITLE
docs: add onboarding runtime handoff

### DIFF
--- a/docs/ONBOARDING_PIPELINE.md
+++ b/docs/ONBOARDING_PIPELINE.md
@@ -185,3 +185,6 @@ The upload response reports:
   from onboarding.
 - Audit must log the rejected or accepted outcome with a stable `auditId` for
   every terminal pipeline result.
+- Use `docs/ONBOARDING_RUNTIME_HANDOFF.md` when a PR claims the upload path is
+  executable so review, QA, and epic #2 write-back all reuse one validation
+  contract.

--- a/docs/ONBOARDING_RUNTIME_HANDOFF.md
+++ b/docs/ONBOARDING_RUNTIME_HANDOFF.md
@@ -1,0 +1,104 @@
+# Onboarding Runtime Handoff
+
+Last updated: 2026-03-19
+
+## Goal
+
+Define one review and evidence workflow for the executable agent onboarding upload
+slice tied to epic #2. This keeps backend, QA, and planning aligned once a
+branch introduces `POST /v1/agents/bundles` and its local smoke path.
+
+Use this document when a PR claims that the onboarding runtime path is runnable.
+Keep live pass/fail state in the relevant PR and issue threads; use this file as
+an execution contract, not as a status board.
+
+## When This Applies
+
+Treat this handoff as required when a branch adds or changes any of the
+following:
+
+- the runtime handler for `POST /v1/agents/bundles`
+- bundle replay, version-conflict, or payload-hash mismatch semantics
+- skill-indexing output returned from the upload path
+- onboarding smoke commands or their expected output shape
+- planning docs that claim the onboarding upload path is executable
+
+## Required Sync Before Review
+
+Before asking for review, confirm that the branch keeps the onboarding slice
+consistent across these sources:
+
+| Surface | What must stay aligned |
+| --- | --- |
+| `openspec/changes/agent-dispatch-platform/` | Scope, acceptance, and rollout notes for the onboarding runtime slice |
+| `src/api/openapi.yaml` | request/response and error-code vocabulary for bundle upload |
+| `src/api/contracts.ts` | TypeScript contract names, enums, and response shapes |
+| `docs/ONBOARDING_PIPELINE.md` | deterministic validation, replay, and conflict rules |
+| runtime/tests | executable handler plus local smoke/assertion coverage |
+
+## Minimum Validation Contract
+
+A PR that lands the onboarding runtime slice should publish literal output for
+all of these commands in the PR body or a signed follow-up comment:
+
+1. `openspec validate --all`
+2. `npm test`
+3. `npm run check:contract-drift`
+4. `npm run smoke:onboarding`
+5. `git diff --check`
+6. `bash scripts/agent_prepush_check.sh --github-user <github-user>`
+
+If one command is intentionally skipped, record `not run: <reason>` verbatim so
+reviewers know the omission is deliberate rather than missing evidence.
+
+## Minimum Smoke Evidence
+
+The onboarding smoke output should show one accepted upload and the two MVP
+negative/replay checkpoints that planning and QA care about most:
+
+| Scenario | Expected signal |
+| --- | --- |
+| First upload accepted | stable `agentId`, `version`, and indexed skill summary |
+| Same payload replayed | `RETURN_EXISTING_ON_HASH_MATCH` or equivalent replay marker |
+| Payload hash mismatch | `AGENT_BUNDLE_SIGNATURE_PAYLOAD_MISMATCH` or the published contract equivalent |
+
+If the branch changes conflict behavior, include the version-conflict path too,
+but do not drop the three baseline checkpoints above.
+
+## PR Body Handoff Shape
+
+Keep the onboarding slice reviewable with this structure:
+
+### Acceptance criteria mapping
+- epic #2 upload/runtime claim advanced by ...
+- onboarding deterministic rules preserved in `docs/ONBOARDING_PIPELINE.md`
+- OpenSpec/OpenAPI/contracts/runtime tests stay synchronized
+
+### QA steps
+- run the six validation commands in order
+- record the onboarding smoke happy path, replay path, and payload-hash mismatch
+- note the exact expected result/error code for each step
+
+### Risk / rollback
+- state whether persistence is still in-memory or durable
+- call out any signature-validation shortcuts that remain format-only
+- describe the single revert/disable step if the upload route must be backed out
+
+## GitHub Write-Back Rules
+
+Use GitHub as the live record after validation:
+
+- Link the implementation PR from epic [#2](https://github.com/jckhang/agent-indeed/issues/2) when the onboarding slice meaningfully changes the MVP cutline.
+- Post the literal validation block on the PR before asking QA or planning to reuse the command path.
+- If QA needs the onboarding smoke output for a broader beta-readiness pass, point them at the signed PR evidence first instead of copying partial transcripts into repo docs.
+- Keep signatures on PR comments and review replies in the form `--albatross-dev-agent` when planning posts the handoff note.
+
+## Review Questions
+
+Reviewers should be able to answer these without reconstructing the branch by
+hand:
+
+1. Does the branch keep the published upload contract and runtime behavior in sync?
+2. Can a reviewer rerun one local command path and observe create, replay, and mismatch behavior?
+3. Is the remaining gap clearly called out as runtime durability, cryptographic verification depth, or QA follow-through rather than vague "future work"?
+4. Is the evidence posted in the PR thread instead of buried only in local notes?

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,6 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
+- 新增 onboarding runtime handoff 契约，统一 agent bundle upload slice 的校验命令、最小 smoke 证据与 epic/PR 回写格式。
 
 ## Capabilities
 
@@ -39,6 +40,7 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
+- 新增 `docs/ONBOARDING_RUNTIME_HANDOFF.md`，作为 agent bundle upload runtime follow-through 的评审与证据交接基线。
 - 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -53,3 +53,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.14.a 输出 `docs/ONBOARDING_RUNTIME_HANDOFF.md`，统一 onboarding upload slice 的 review/validation/epic write-back 格式，避免证据散落在 PR 评论中。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: add one onboarding runtime handoff contract for epic #2 review and evidence write-back

## What Changed

- added `docs/ONBOARDING_RUNTIME_HANDOFF.md` to define the review, validation, smoke-evidence, and GitHub write-back contract for the executable onboarding upload slice
- linked `docs/ONBOARDING_PIPELINE.md` to the new handoff doc so onboarding behavior and PR evidence use one review path
- updated `openspec/changes/agent-dispatch-platform/proposal.md` and `openspec/changes/agent-dispatch-platform/tasks.md` so the active OpenSpec change records this planning/runtime handoff follow-up

## Why

- epic #2 is still the only open albatross-owned issue, and the onboarding upload slice needs one durable handoff contract so validation output and smoke evidence do not get scattered across PR comments
- this gives backend, QA, and planning one reusable checklist before the onboarding runtime implementation PR merges and starts feeding broader beta-readiness review

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| OpenSpec artifacts remain synchronized with planning/runtime follow-through | records the onboarding handoff scope in the active OpenSpec proposal/tasks alongside the repo docs | `openspec/changes/agent-dispatch-platform/proposal.md`, `openspec/changes/agent-dispatch-platform/tasks.md`, `openspec validate --all` |
| Agent onboarding/runtime claims stay reviewable and reproducible | defines one validation + smoke-evidence contract and links it from the onboarding pipeline doc | `docs/ONBOARDING_RUNTIME_HANDOFF.md`, `docs/ONBOARDING_PIPELINE.md` |

## QA Plan

### Preconditions

- work from a branch that introduces or updates the executable onboarding upload slice
- use the validation commands listed in `docs/ONBOARDING_RUNTIME_HANDOFF.md`

### Steps

1. Review `docs/ONBOARDING_RUNTIME_HANDOFF.md` for the required validation/evidence shape.
2. Confirm `docs/ONBOARDING_PIPELINE.md` points onboarding runtime reviews at that handoff contract.
3. Run the validation commands listed below.

### Expected Results

- the repo documents one reusable onboarding runtime review/evidence workflow
- OpenSpec validation passes after the new handoff artifact is added
- diff and pre-push hygiene checks pass on the focused docs branch

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
- `git diff --check`
- `bash scripts/agent_prepush_check.sh --github-user jckhang`
- `npm test`
- `npm run check:contract-drift`

```text
$ PATH=/opt/homebrew/bin:$PATH npx -y @fission-ai/openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

```text
$ git diff --check
```

```text
$ bash scripts/agent_prepush_check.sh --github-user jckhang
[ok] Branch 'codex/issue-2-onboarding-runtime-handoff' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (jckhang).
[ok] git user.email matches expected account (jckhang@users.noreply.github.com).

Pre-push guard passed.
```

```text
not run: npm test (docs/OpenSpec-only change; no runtime or contract code changed on this branch)
```

```text
not run: npm run check:contract-drift (docs/OpenSpec-only change; no API/runtime route surface changed on this branch)
```

## Risks and Rollback

- Risk:
  - the new handoff doc could drift from the eventual onboarding implementation if later branches skip updating it when command names or evidence shape change
- Rollback:
  - revert commit `cafa74f` to remove the onboarding handoff doc and its linked OpenSpec/doc references

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--albatross-dev-agent`
