### PR TITLE
[P1-09] Export issue #11 evidence artifacts

### DIFF
--- a/docs/BACKEND_API_EXAMPLE_PACKET.md
+++ b/docs/BACKEND_API_EXAMPLE_PACKET.md
@@ -18,8 +18,9 @@ runtime smoke flow. They are meant to be copied as canonical examples, not treat
 new contract definitions. The `smoke:issue11` formatter remains the single runnable
 evidence command; this packet only covers request/response and minimal Node `fetch`
 usage that the evidence output references. When a PR or local archive also needs files,
-the same command can emit `issue11-evidence.md` and `issue11-summary.json` via
-`--output-dir <dir>` without changing the stdout packet that gets pasted into issue
+the same command can emit `issue11-evidence.md`, `issue11-summary.json`, and a
+self-describing `issue11-artifacts-manifest.json` via `--output-dir <dir>` without
+changing the stdout packet that gets pasted into issue
 [#11](https://github.com/jckhang/agent-indeed/issues/11).
 
 ## Happy path packet

--- a/docs/BACKEND_API_EXAMPLE_PACKET.md
+++ b/docs/BACKEND_API_EXAMPLE_PACKET.md
@@ -21,7 +21,9 @@ usage that the evidence output references. When a PR or local archive also needs
 the same command can emit `issue11-evidence.md`, `issue11-summary.json`, and a
 self-describing `issue11-artifacts-manifest.json` via `--output-dir <dir>` without
 changing the stdout packet that gets pasted into issue
-[#11](https://github.com/jckhang/agent-indeed/issues/11).
+[#11](https://github.com/jckhang/agent-indeed/issues/11). That manifest also records the
+generation timestamp, git branch/commit, and exported file paths so PR comments and local
+archives can point back to one exact smoke run.
 
 ## Happy path packet
 

--- a/docs/BACKEND_API_EXAMPLE_PACKET.md
+++ b/docs/BACKEND_API_EXAMPLE_PACKET.md
@@ -10,13 +10,17 @@ backend-owned request/response reference for QA, beta consumers, and issue
 - Runtime implementation: `src/runtime/dispatch-smoke.js`
 - API contracts: `src/api/openapi.yaml`, `src/api/contracts.ts`
 - Final issue-evidence handoff: `npm run --silent smoke:issue11 -- --signature <agent-name>`
+- Optional issue-evidence artifact export: `npm run --silent smoke:issue11 -- --signature <agent-name> --output-dir <dir>`
 - Final E2E aggregation thread: issue [#11](https://github.com/jckhang/agent-indeed/issues/11)
 
 The examples below use the deterministic IDs and payload shapes exercised by the local
 runtime smoke flow. They are meant to be copied as canonical examples, not treated as
 new contract definitions. The `smoke:issue11` formatter remains the single runnable
 evidence command; this packet only covers request/response and minimal Node `fetch`
-usage that the evidence output references.
+usage that the evidence output references. When a PR or local archive also needs files,
+the same command can emit `issue11-evidence.md` and `issue11-summary.json` via
+`--output-dir <dir>` without changing the stdout packet that gets pasted into issue
+[#11](https://github.com/jckhang/agent-indeed/issues/11).
 
 ## Happy path packet
 

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -45,8 +45,9 @@ For the current `main` runtime baseline, QA can use `npm run --silent smoke:issu
 as the canonical backend-owned issue `#11` evidence command. It turns the merged smoke suite
 into one ready-to-paste packet without manually rewriting the task/bid/proof ids, error
 codes, PASS-line transcript, or decision-trace fields. When a PR or local rerun also needs
-artifact files, add `--output-dir <dir>` to emit `issue11-evidence.md` plus
-`issue11-summary.json` without changing the pasted stdout packet.
+artifact files, add `--output-dir <dir>` to emit `issue11-evidence.md`,
+`issue11-summary.json`, and `issue11-artifacts-manifest.json` without changing the pasted
+stdout packet.
 
 ## Evidence package
 

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -44,7 +44,9 @@ their PR body and linked issue comments.
 For the current `main` runtime baseline, QA can use `npm run --silent smoke:issue11 -- --signature <agent-name>`
 as the canonical backend-owned issue `#11` evidence command. It turns the merged smoke suite
 into one ready-to-paste packet without manually rewriting the task/bid/proof ids, error
-codes, PASS-line transcript, or decision-trace fields.
+codes, PASS-line transcript, or decision-trace fields. When a PR or local rerun also needs
+artifact files, add `--output-dir <dir>` to emit `issue11-evidence.md` plus
+`issue11-summary.json` without changing the pasted stdout packet.
 
 ## Evidence package
 

--- a/docs/RUNTIME_EXECUTION_HANDOFF.md
+++ b/docs/RUNTIME_EXECUTION_HANDOFF.md
@@ -47,7 +47,8 @@ into one ready-to-paste packet without manually rewriting the task/bid/proof ids
 codes, PASS-line transcript, or decision-trace fields. When a PR or local rerun also needs
 artifact files, add `--output-dir <dir>` to emit `issue11-evidence.md`,
 `issue11-summary.json`, and `issue11-artifacts-manifest.json` without changing the pasted
-stdout packet.
+stdout packet. The manifest must carry enough provenance to map exported files back to the
+exact smoke run, including generated time, git branch/commit, and the resolved artifact paths.
 
 ## Evidence package
 

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -90,7 +90,7 @@
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
    - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
-   - issue #11 evidence exporter 继续保持单一 stdout Markdown 契约，但允许附加输出本地 Markdown/JSON 工件，避免 PR 评论、issue 回贴与本地归档之间出现二次手工整理。
+   - issue #11 evidence exporter 继续保持单一 stdout Markdown 契约，但允许附加输出本地 Markdown/JSON 工件与自描述 manifest，避免 PR 评论、issue 回贴与本地归档之间出现二次手工整理或重复猜测导出路径。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -90,6 +90,7 @@
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
    - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
+   - issue #11 evidence exporter 继续保持单一 stdout Markdown 契约，但允许附加输出本地 Markdown/JSON 工件，避免 PR 评论、issue 回贴与本地归档之间出现二次手工整理。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/design.md
+++ b/openspec/changes/agent-dispatch-platform/design.md
@@ -90,7 +90,7 @@
    - `Implement` 类 issue 的关闭标准必须包含运行时代码或可执行测试证据，spec/docs-only PR 不再作为单独关闭依据。
    - runtime 线程共享同一份 `docs/RUNTIME_EXECUTION_HANDOFF.md` 命令/证据契约：至少发布 service、reset/seed、smoke 三类命令，并将最终 happy/negative 证据回写到 issue #11。
    - backend 侧补充 `docs/BACKEND_API_EXAMPLE_PACKET.md`，把 merged smoke flow 的 publish/match/commit/reveal/verify/award 请求响应和核心负面场景固定成一个 QA / beta consumer 可复用的数据包。
-   - issue #11 evidence exporter 继续保持单一 stdout Markdown 契约，但允许附加输出本地 Markdown/JSON 工件与自描述 manifest，避免 PR 评论、issue 回贴与本地归档之间出现二次手工整理或重复猜测导出路径。
+   - issue #11 evidence exporter 继续保持单一 stdout Markdown 契约，但允许附加输出本地 Markdown/JSON 工件与自描述 manifest，避免 PR 评论、issue 回贴与本地归档之间出现二次手工整理或重复猜测导出路径；manifest 还必须记录生成时间、git branch/commit 与导出文件路径，确保跨 lane 复用时能追溯到同一 smoke run。
 12. Bid / proof 异步状态读取在 MVP 阶段统一采用轮询
    - 写接口（commit、reveal、verify）只保证接收或返回当前决策快照，不承诺前端可以仅靠写响应完成后续时间线渲染。
    - 读接口补充 `GET /v1/tasks/{taskId}/bids/{bidId}` 与 `GET /v1/tasks/{taskId}/proofs/{proofId}`，提供 commit/reveal/proof/award 的当前状态投影。

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,6 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
+- 让 issue #11 证据命令支持额外导出 Markdown/JSON 工件，便于 QA 在 PR、本地归档与 issue 回贴之间复用同一份 smoke 结果。
 
 ## Capabilities
 

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,7 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
-- 让 issue #11 证据命令支持额外导出 Markdown/JSON 工件，便于 QA 在 PR、本地归档与 issue 回贴之间复用同一份 smoke 结果。
+- 让 issue #11 证据命令支持额外导出 Markdown/JSON 工件与自描述 manifest，便于 QA 在 PR、本地归档与 issue 回贴之间复用同一份 smoke 结果。
 
 ## Capabilities
 

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,7 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
-- 让 issue #11 证据命令支持额外导出 Markdown/JSON 工件与自描述 manifest，便于 QA 在 PR、本地归档与 issue 回贴之间复用同一份 smoke 结果。
+- 让 issue #11 证据命令支持额外导出 Markdown/JSON 工件与自描述 manifest，便于 QA 在 PR、本地归档与 issue 回贴之间复用同一份 smoke 结果，并能追溯到生成时间与对应 git revision。
 
 ## Capabilities
 

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -257,6 +257,7 @@
 - **AND** 该命令复用 merged dispatch smoke baseline，而不是引入第二条并行 smoke 路径
 - **AND** 输出包含可直接粘贴的 Markdown 证据块、底层 smoke 命令、稳定 task/bid/proof/policy/audit 标识，以及指向 `docs/BACKEND_API_EXAMPLE_PACKET.md` 与 `docs/RUNTIME_EXECUTION_HANDOFF.md` 的 handoff 锚点
 - **AND** 在需要把证据同时附到 PR/本地工件目录时，命令支持额外导出 `issue11-evidence.md`、`issue11-summary.json` 与自描述 `issue11-artifacts-manifest.json`，避免手工复制 stdout 再次改写或猜测工件路径
+- **AND** 该 manifest 至少记录生成时间、git branch/commit、证据命令与导出文件路径，确保 QA/automation 可以把外部保存的工件追溯回同一条 smoke run
 
 #### Scenario: Runtime storage abstractions cover core lifecycle entities
 - **WHEN** 本地 control-plane 初始化存储层

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -257,7 +257,7 @@
 - **AND** 该命令复用 merged dispatch smoke baseline，而不是引入第二条并行 smoke 路径
 - **AND** 输出包含可直接粘贴的 Markdown 证据块、底层 smoke 命令、稳定 task/bid/proof/policy/audit 标识，以及指向 `docs/BACKEND_API_EXAMPLE_PACKET.md` 与 `docs/RUNTIME_EXECUTION_HANDOFF.md` 的 handoff 锚点
 - **AND** 在需要把证据同时附到 PR/本地工件目录时，命令支持额外导出 `issue11-evidence.md`、`issue11-summary.json` 与自描述 `issue11-artifacts-manifest.json`，避免手工复制 stdout 再次改写或猜测工件路径
-- **AND** 该 manifest 至少记录生成时间、git branch/commit、证据命令与导出文件路径，确保 QA/automation 可以把外部保存的工件追溯回同一条 smoke run
+- **AND** 该 manifest 至少记录生成时间、git branch/commit、可直接重放的证据命令与导出文件路径，即使工件目录包含空格也能让 QA/automation 把外部保存的工件追溯回同一条 smoke run
 
 #### Scenario: Runtime storage abstractions cover core lifecycle entities
 - **WHEN** 本地 control-plane 初始化存储层

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -256,7 +256,7 @@
 - **THEN** 仓库提供唯一的签名命令 `npm run --silent smoke:issue11 -- --signature <agent-name>`
 - **AND** 该命令复用 merged dispatch smoke baseline，而不是引入第二条并行 smoke 路径
 - **AND** 输出包含可直接粘贴的 Markdown 证据块、底层 smoke 命令、稳定 task/bid/proof/policy/audit 标识，以及指向 `docs/BACKEND_API_EXAMPLE_PACKET.md` 与 `docs/RUNTIME_EXECUTION_HANDOFF.md` 的 handoff 锚点
-- **AND** 在需要把证据同时附到 PR/本地工件目录时，命令支持额外导出 `issue11-evidence.md` 与 `issue11-summary.json`，避免手工复制 stdout 再次改写
+- **AND** 在需要把证据同时附到 PR/本地工件目录时，命令支持额外导出 `issue11-evidence.md`、`issue11-summary.json` 与自描述 `issue11-artifacts-manifest.json`，避免手工复制 stdout 再次改写或猜测工件路径
 
 #### Scenario: Runtime storage abstractions cover core lifecycle entities
 - **WHEN** 本地 control-plane 初始化存储层

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -256,6 +256,7 @@
 - **THEN** 仓库提供唯一的签名命令 `npm run --silent smoke:issue11 -- --signature <agent-name>`
 - **AND** 该命令复用 merged dispatch smoke baseline，而不是引入第二条并行 smoke 路径
 - **AND** 输出包含可直接粘贴的 Markdown 证据块、底层 smoke 命令、稳定 task/bid/proof/policy/audit 标识，以及指向 `docs/BACKEND_API_EXAMPLE_PACKET.md` 与 `docs/RUNTIME_EXECUTION_HANDOFF.md` 的 handoff 锚点
+- **AND** 在需要把证据同时附到 PR/本地工件目录时，命令支持额外导出 `issue11-evidence.md` 与 `issue11-summary.json`，避免手工复制 stdout 再次改写
 
 #### Scenario: Runtime storage abstractions cover core lifecycle entities
 - **WHEN** 本地 control-plane 初始化存储层

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -54,3 +54,4 @@
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
 - [x] 5.15 为 issue #11 证据命令增加可选工件导出（Markdown + JSON），让 QA/automation 可复用同一份 smoke 结果回贴 issue、附到 PR、并保留本地归档。
+- [x] 5.15.a 为 issue #11 导出工件增加自描述 manifest，固定证据命令与产物路径，避免 PR/自动化侧重复猜测文件名。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -56,3 +56,4 @@
 - [x] 5.15 为 issue #11 证据命令增加可选工件导出（Markdown + JSON），让 QA/automation 可复用同一份 smoke 结果回贴 issue、附到 PR、并保留本地归档。
 - [x] 5.15.a 为 issue #11 导出工件增加自描述 manifest，固定证据命令与产物路径，避免 PR/自动化侧重复猜测文件名。
 - [x] 5.15.b 为 issue #11 导出 manifest 增加生成时间、git branch/commit 与全量工件路径，确保跨 PR/本地归档的证据可以追溯到同一 smoke run。
+- [x] 5.15.c 为 issue #11 CLI 导出路径补充成功回归覆盖，并把 manifest 中的证据命令固化为可重放的 shell-safe 绝对路径，避免包含空格的工件目录破坏自动化复跑。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -55,3 +55,4 @@
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
 - [x] 5.15 为 issue #11 证据命令增加可选工件导出（Markdown + JSON），让 QA/automation 可复用同一份 smoke 结果回贴 issue、附到 PR、并保留本地归档。
 - [x] 5.15.a 为 issue #11 导出工件增加自描述 manifest，固定证据命令与产物路径，避免 PR/自动化侧重复猜测文件名。
+- [x] 5.15.b 为 issue #11 导出 manifest 增加生成时间、git branch/commit 与全量工件路径，确保跨 PR/本地归档的证据可以追溯到同一 smoke run。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -53,3 +53,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.15 为 issue #11 证据命令增加可选工件导出（Markdown + JSON），让 QA/automation 可复用同一份 smoke 结果回贴 issue、附到 PR、并保留本地归档。

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -69,8 +69,9 @@ To keep the pasted stdout packet and save the same run into a local archive dire
 npm run --silent smoke:issue11 -- --signature avery --output-dir ./artifacts/issue11
 ```
 
-That variant still prints the markdown packet to stdout and also writes `issue11-evidence.md`
-plus `issue11-summary.json` into the requested directory for PR attachments or local reruns.
+That variant still prints the markdown packet to stdout and also writes `issue11-evidence.md`,
+`issue11-summary.json`, and `issue11-artifacts-manifest.json` into the requested directory
+for PR attachments, automation handoff, or local reruns.
 
 `npm test` also shells this command end-to-end and asserts the PASS-line plus JSON-summary contract, so CI covers the exact smoke output shape that QA copies into issue evidence.
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -8,6 +8,7 @@ This directory holds the first runnable backend control-plane scaffold for Agent
 - Start with file watching: `npm run dev`
 - Run the end-to-end dispatch smoke suite: `npm run smoke:dispatch`
 - Print an issue-ready issue `#11` evidence packet: `npm run --silent smoke:issue11 -- --signature avery`
+- Export the same issue `#11` packet to local artifacts: `npm run --silent smoke:issue11 -- --signature avery --output-dir ./artifacts/issue11`
 - Run the built-in runtime tests: `npm test`
 - Run the bootstrap smoke flow: `npm run smoke:bootstrap`
 
@@ -61,6 +62,15 @@ npm run --silent smoke:issue11 -- --signature avery
 ```
 
 That command reuses the dispatch smoke suite, captures the PASS lines and JSON summary, and formats one markdown packet with the happy-path ids, negative-path reason codes, and links to the reusable handoff docs.
+
+To keep the pasted stdout packet and save the same run into a local archive directory:
+
+```bash
+npm run --silent smoke:issue11 -- --signature avery --output-dir ./artifacts/issue11
+```
+
+That variant still prints the markdown packet to stdout and also writes `issue11-evidence.md`
+plus `issue11-summary.json` into the requested directory for PR attachments or local reruns.
 
 `npm test` also shells this command end-to-end and asserts the PASS-line plus JSON-summary contract, so CI covers the exact smoke output shape that QA copies into issue evidence.
 

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -71,7 +71,9 @@ npm run --silent smoke:issue11 -- --signature avery --output-dir ./artifacts/iss
 
 That variant still prints the markdown packet to stdout and also writes `issue11-evidence.md`,
 `issue11-summary.json`, and `issue11-artifacts-manifest.json` into the requested directory
-for PR attachments, automation handoff, or local reruns.
+for PR attachments, automation handoff, or local reruns. The manifest records the generated
+timestamp, current git branch/commit, and all exported artifact paths so downstream lanes can
+trace a copied artifact set back to the exact smoke run that produced it.
 
 `npm test` also shells this command end-to-end and asserts the PASS-line plus JSON-summary contract, so CI covers the exact smoke output shape that QA copies into issue evidence.
 

--- a/src/runtime/issue11-evidence.js
+++ b/src/runtime/issue11-evidence.js
@@ -112,27 +112,36 @@ async function writeIssue11Artifacts({ markdown, outputDir, summary }) {
   };
 }
 
-function parseArgs(argv) {
+export function parseIssue11EvidenceArgs(argv) {
   const options = {};
 
   for (let index = 0; index < argv.length; index += 1) {
-    if (argv[index] === "--signature") {
-      options.signature = argv[index + 1];
+    const arg = argv[index];
+
+    if (arg === "--signature" || arg === "--output-dir") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`missing value for ${arg}`);
+      }
+
+      if (arg === "--signature") {
+        options.signature = value;
+      } else {
+        options.outputDir = value;
+      }
+
       index += 1;
       continue;
     }
 
-    if (argv[index] === "--output-dir") {
-      options.outputDir = argv[index + 1];
-      index += 1;
-    }
+    throw new Error(`unknown argument: ${arg}`);
   }
 
   return options;
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const options = parseArgs(process.argv.slice(2));
+  const options = parseIssue11EvidenceArgs(process.argv.slice(2));
 
   runIssue11Evidence(options).catch((error) => {
     console.error(error);

--- a/src/runtime/issue11-evidence.js
+++ b/src/runtime/issue11-evidence.js
@@ -78,6 +78,7 @@ export async function runIssue11Evidence({
   const artifactPaths = await writeIssue11Artifacts({
     markdown,
     outputDir,
+    signature,
     summary
   });
 
@@ -91,7 +92,12 @@ export async function runIssue11Evidence({
   };
 }
 
-async function writeIssue11Artifacts({ markdown, outputDir, summary }) {
+export async function writeIssue11Artifacts({
+  markdown,
+  outputDir,
+  signature,
+  summary
+}) {
   if (!outputDir) {
     return null;
   }
@@ -99,14 +105,31 @@ async function writeIssue11Artifacts({ markdown, outputDir, summary }) {
   const resolvedOutputDir = path.resolve(outputDir);
   const markdownPath = path.join(resolvedOutputDir, "issue11-evidence.md");
   const summaryPath = path.join(resolvedOutputDir, "issue11-summary.json");
+  const manifestPath = path.join(resolvedOutputDir, "issue11-artifacts-manifest.json");
+  const evidenceCommand = signature
+    ? `npm run --silent smoke:issue11 -- --signature ${signature} --output-dir ${outputDir}`
+    : `npm run --silent smoke:issue11 -- --output-dir ${outputDir}`;
+  const manifest = {
+    artifactVersion: 1,
+    evidenceIssue: 11,
+    evidenceCommand,
+    smokeCommand: summary.command,
+    signature: signature ?? null,
+    generatedArtifacts: {
+      markdownPath,
+      summaryPath
+    }
+  };
 
   await mkdir(resolvedOutputDir, { recursive: true });
   await Promise.all([
     writeFile(markdownPath, `${markdown}\n`, "utf8"),
-    writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8")
+    writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8"),
+    writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8")
   ]);
 
   return {
+    manifestPath,
     markdownPath,
     summaryPath
   };

--- a/src/runtime/issue11-evidence.js
+++ b/src/runtime/issue11-evidence.js
@@ -8,15 +8,39 @@ function findScenario(summary, name) {
   return summary.scenarios.find((scenario) => scenario.name === name);
 }
 
+function formatShellArg(value) {
+  if (value === "") {
+    return "''";
+  }
+
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) {
+    return value;
+  }
+
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
+}
+
+export function formatIssue11EvidenceCommand({ outputDir, signature } = {}) {
+  const commandParts = ["npm", "run", "--silent", "smoke:issue11", "--"];
+
+  if (signature) {
+    commandParts.push("--signature", signature);
+  }
+
+  if (outputDir) {
+    commandParts.push("--output-dir", path.resolve(outputDir));
+  }
+
+  return commandParts.map(formatShellArg).join(" ");
+}
+
 export function formatIssue11Evidence({ summary, logLines, signature } = {}) {
   const happyPath = findScenario(summary, "happy-path");
   const invalidSignature = findScenario(summary, "invalid-signature");
   const negativePaths = findScenario(summary, "negative-paths");
   const evidenceLog = logLines.join("\n");
   const signedNote = signature ? `\n--${signature}` : "";
-  const evidenceCommand = signature
-    ? `npm run --silent smoke:issue11 -- --signature ${signature}`
-    : "npm run --silent smoke:issue11";
+  const evidenceCommand = formatIssue11EvidenceCommand({ signature });
 
   return [
     "## Issue #11 executable smoke evidence",
@@ -107,9 +131,10 @@ export async function writeIssue11Artifacts({
   const markdownPath = path.join(resolvedOutputDir, "issue11-evidence.md");
   const summaryPath = path.join(resolvedOutputDir, "issue11-summary.json");
   const manifestPath = path.join(resolvedOutputDir, "issue11-artifacts-manifest.json");
-  const evidenceCommand = signature
-    ? `npm run --silent smoke:issue11 -- --signature ${signature} --output-dir ${outputDir}`
-    : `npm run --silent smoke:issue11 -- --output-dir ${outputDir}`;
+  const evidenceCommand = formatIssue11EvidenceCommand({
+    outputDir: resolvedOutputDir,
+    signature
+  });
   const generatedAt = new Date().toISOString();
   const gitMetadata = readGitMetadata();
   const manifest = {

--- a/src/runtime/issue11-evidence.js
+++ b/src/runtime/issue11-evidence.js
@@ -1,3 +1,5 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { runDispatchSmokeSuite } from "./dispatch-smoke.js";
 
@@ -56,7 +58,11 @@ export function formatIssue11Evidence({ summary, logLines, signature } = {}) {
   ].join("\n");
 }
 
-export async function runIssue11Evidence({ log = console.log, signature } = {}) {
+export async function runIssue11Evidence({
+  log = console.log,
+  outputDir,
+  signature
+} = {}) {
   const logLines = [];
   const summary = await runDispatchSmokeSuite({
     command: "npm run smoke:dispatch",
@@ -69,13 +75,40 @@ export async function runIssue11Evidence({ log = console.log, signature } = {}) 
     logLines,
     signature
   });
+  const artifactPaths = await writeIssue11Artifacts({
+    markdown,
+    outputDir,
+    summary
+  });
 
   log(markdown);
 
   return {
+    artifactPaths,
     summary,
     logLines,
     markdown
+  };
+}
+
+async function writeIssue11Artifacts({ markdown, outputDir, summary }) {
+  if (!outputDir) {
+    return null;
+  }
+
+  const resolvedOutputDir = path.resolve(outputDir);
+  const markdownPath = path.join(resolvedOutputDir, "issue11-evidence.md");
+  const summaryPath = path.join(resolvedOutputDir, "issue11-summary.json");
+
+  await mkdir(resolvedOutputDir, { recursive: true });
+  await Promise.all([
+    writeFile(markdownPath, `${markdown}\n`, "utf8"),
+    writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`, "utf8")
+  ]);
+
+  return {
+    markdownPath,
+    summaryPath
   };
 }
 
@@ -85,6 +118,12 @@ function parseArgs(argv) {
   for (let index = 0; index < argv.length; index += 1) {
     if (argv[index] === "--signature") {
       options.signature = argv[index + 1];
+      index += 1;
+      continue;
+    }
+
+    if (argv[index] === "--output-dir") {
+      options.outputDir = argv[index + 1];
       index += 1;
     }
   }

--- a/src/runtime/issue11-evidence.js
+++ b/src/runtime/issue11-evidence.js
@@ -1,4 +1,5 @@
 import { mkdir, writeFile } from "node:fs/promises";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { runDispatchSmokeSuite } from "./dispatch-smoke.js";
@@ -109,13 +110,22 @@ export async function writeIssue11Artifacts({
   const evidenceCommand = signature
     ? `npm run --silent smoke:issue11 -- --signature ${signature} --output-dir ${outputDir}`
     : `npm run --silent smoke:issue11 -- --output-dir ${outputDir}`;
+  const generatedAt = new Date().toISOString();
+  const gitMetadata = readGitMetadata();
   const manifest = {
-    artifactVersion: 1,
+    artifactVersion: 2,
     evidenceIssue: 11,
+    generatedAt,
+    repo: {
+      branch: gitMetadata.branch,
+      commit: gitMetadata.commit,
+      cwd: process.cwd()
+    },
     evidenceCommand,
     smokeCommand: summary.command,
     signature: signature ?? null,
     generatedArtifacts: {
+      manifestPath,
       markdownPath,
       summaryPath
     }
@@ -133,6 +143,28 @@ export async function writeIssue11Artifacts({
     markdownPath,
     summaryPath
   };
+}
+
+export function readGitMetadata() {
+  const fallback = {
+    branch: null,
+    commit: null
+  };
+
+  try {
+    return {
+      branch: execFileSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], {
+        cwd: process.cwd(),
+        encoding: "utf8"
+      }).trim(),
+      commit: execFileSync("git", ["rev-parse", "HEAD"], {
+        cwd: process.cwd(),
+        encoding: "utf8"
+      }).trim()
+    };
+  } catch {
+    return fallback;
+  }
 }
 
 export function parseIssue11EvidenceArgs(argv) {

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -9,6 +9,7 @@ import { fileURLToPath } from "node:url";
 import {
   formatIssue11Evidence,
   parseIssue11EvidenceArgs,
+  readGitMetadata,
   runIssue11Evidence,
   writeIssue11Artifacts
 } from "../../src/runtime/issue11-evidence.js";
@@ -108,6 +109,9 @@ test("runIssue11Evidence writes markdown and summary artifacts when requested", 
   assert.match(markdown, /--avery/);
   assert.equal(summary.status, "ok");
   assert.equal(summary.scenarios[0].name, "happy-path");
+  assert.match(manifest.generatedAt, /^\d{4}-\d{2}-\d{2}T/);
+  assert.equal(manifest.generatedArtifacts.manifestPath, result.artifactPaths.manifestPath);
+  assert.equal(manifest.repo.cwd, process.cwd());
   assert.equal(manifest.evidenceIssue, 11);
   assert.equal(
     manifest.evidenceCommand,
@@ -132,11 +136,20 @@ test("writeIssue11Artifacts persists a self-describing manifest alongside export
 
   const manifest = JSON.parse(await readFile(artifactPaths.manifestPath, "utf8"));
 
-  assert.equal(manifest.artifactVersion, 1);
+  assert.equal(manifest.artifactVersion, 2);
   assert.equal(manifest.signature, "avery");
   assert.equal(manifest.smokeCommand, "npm run smoke:dispatch");
+  assert.equal(manifest.repo.cwd, process.cwd());
   assert.equal(manifest.generatedArtifacts.markdownPath, artifactPaths.markdownPath);
+  assert.equal(manifest.generatedArtifacts.manifestPath, artifactPaths.manifestPath);
   assert.equal(manifest.generatedArtifacts.summaryPath, artifactPaths.summaryPath);
+});
+
+test("readGitMetadata returns the current branch and commit when available", () => {
+  const metadata = readGitMetadata();
+
+  assert.match(metadata.commit, /^[0-9a-f]{40}$/);
+  assert.ok(metadata.branch);
 });
 
 test("parseIssue11EvidenceArgs accepts signature and output directory flags", () => {

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -7,6 +7,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 
 import {
+  formatIssue11EvidenceCommand,
   formatIssue11Evidence,
   parseIssue11EvidenceArgs,
   readGitMetadata,
@@ -65,6 +66,18 @@ test("formatIssue11Evidence includes the smoke summary, logs, and signature", ()
   assert.match(markdown, /QUALITY_SCORE_BELOW_MINIMUM, HASHCASH_BITS_BELOW_MINIMUM/);
   assert.match(markdown, /TASK_AWARD_PRECONDITION_FAILED/);
   assert.match(markdown, /--avery/);
+});
+
+test("formatIssue11EvidenceCommand shell-quotes resolved artifact paths", () => {
+  const command = formatIssue11EvidenceCommand({
+    signature: "avery reviewer",
+    outputDir: "./artifacts/issue 11 bundle"
+  });
+
+  assert.equal(
+    command,
+    `npm run --silent smoke:issue11 -- --signature 'avery reviewer' --output-dir '${path.resolve("./artifacts/issue 11 bundle")}'`
+  );
 });
 
 test("runIssue11Evidence returns the smoke markdown packet", async () => {
@@ -177,6 +190,32 @@ test("parseIssue11EvidenceArgs rejects missing flag values and unknown arguments
     () => parseIssue11EvidenceArgs(["--bogus"]),
     /unknown argument: --bogus/
   );
+});
+
+test("issue11 evidence CLI writes artifacts for output directories with spaces", async () => {
+  const parentDir = await mkdtemp(path.join(os.tmpdir(), "issue11-evidence cli-"));
+  const outputDir = path.join(parentDir, "issue 11 bundle");
+  const cliPath = fileURLToPath(
+    new URL("../../src/runtime/issue11-evidence.js", import.meta.url)
+  );
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "--signature", "avery reviewer", "--output-dir", outputDir],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /## Issue #11 executable smoke evidence/);
+
+  const manifest = JSON.parse(
+    await readFile(path.join(outputDir, "issue11-artifacts-manifest.json"), "utf8")
+  );
+  assert.equal(
+    manifest.evidenceCommand,
+    `npm run --silent smoke:issue11 -- --signature 'avery reviewer' --output-dir '${outputDir}'`
+  );
+  assert.equal(manifest.generatedArtifacts.markdownPath, path.join(outputDir, "issue11-evidence.md"));
+  assert.equal(manifest.generatedArtifacts.summaryPath, path.join(outputDir, "issue11-summary.json"));
 });
 
 test("issue11 evidence CLI exits non-zero for invalid flags", () => {

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -9,7 +9,8 @@ import { fileURLToPath } from "node:url";
 import {
   formatIssue11Evidence,
   parseIssue11EvidenceArgs,
-  runIssue11Evidence
+  runIssue11Evidence,
+  writeIssue11Artifacts
 } from "../../src/runtime/issue11-evidence.js";
 
 test("formatIssue11Evidence includes the smoke summary, logs, and signature", () => {
@@ -94,14 +95,48 @@ test("runIssue11Evidence writes markdown and summary artifacts when requested", 
 
   assert.equal(result.artifactPaths.markdownPath, path.join(outputDir, "issue11-evidence.md"));
   assert.equal(result.artifactPaths.summaryPath, path.join(outputDir, "issue11-summary.json"));
+  assert.equal(
+    result.artifactPaths.manifestPath,
+    path.join(outputDir, "issue11-artifacts-manifest.json")
+  );
 
   const markdown = await readFile(result.artifactPaths.markdownPath, "utf8");
   const summary = JSON.parse(await readFile(result.artifactPaths.summaryPath, "utf8"));
+  const manifest = JSON.parse(await readFile(result.artifactPaths.manifestPath, "utf8"));
 
   assert.match(markdown, /## Issue #11 executable smoke evidence/);
   assert.match(markdown, /--avery/);
   assert.equal(summary.status, "ok");
   assert.equal(summary.scenarios[0].name, "happy-path");
+  assert.equal(manifest.evidenceIssue, 11);
+  assert.equal(
+    manifest.evidenceCommand,
+    `npm run --silent smoke:issue11 -- --signature avery --output-dir ${outputDir}`
+  );
+  assert.equal(manifest.generatedArtifacts.markdownPath, result.artifactPaths.markdownPath);
+  assert.equal(manifest.generatedArtifacts.summaryPath, result.artifactPaths.summaryPath);
+});
+
+test("writeIssue11Artifacts persists a self-describing manifest alongside exported files", async () => {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "issue11-manifest-"));
+  const artifactPaths = await writeIssue11Artifacts({
+    markdown: "## Issue #11 executable smoke evidence\n--avery",
+    outputDir,
+    signature: "avery",
+    summary: {
+      command: "npm run smoke:dispatch",
+      status: "ok",
+      scenarios: []
+    }
+  });
+
+  const manifest = JSON.parse(await readFile(artifactPaths.manifestPath, "utf8"));
+
+  assert.equal(manifest.artifactVersion, 1);
+  assert.equal(manifest.signature, "avery");
+  assert.equal(manifest.smokeCommand, "npm run smoke:dispatch");
+  assert.equal(manifest.generatedArtifacts.markdownPath, artifactPaths.markdownPath);
+  assert.equal(manifest.generatedArtifacts.summaryPath, artifactPaths.summaryPath);
 });
 
 test("parseIssue11EvidenceArgs accepts signature and output directory flags", () => {

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -1,5 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile } from "node:fs/promises";
 
 import {
   formatIssue11Evidence,
@@ -76,4 +79,24 @@ test("runIssue11Evidence returns the smoke markdown packet", async () => {
   assert.match(result.markdown, /`policytrace_00000001`/);
   assert.match(result.markdown, /```json/);
   assert.match(outputs[0], /## Issue #11 executable smoke evidence/);
+});
+
+test("runIssue11Evidence writes markdown and summary artifacts when requested", async () => {
+  const outputDir = await mkdtemp(path.join(os.tmpdir(), "issue11-evidence-"));
+  const result = await runIssue11Evidence({
+    signature: "avery",
+    outputDir,
+    log: () => {}
+  });
+
+  assert.equal(result.artifactPaths.markdownPath, path.join(outputDir, "issue11-evidence.md"));
+  assert.equal(result.artifactPaths.summaryPath, path.join(outputDir, "issue11-summary.json"));
+
+  const markdown = await readFile(result.artifactPaths.markdownPath, "utf8");
+  const summary = JSON.parse(await readFile(result.artifactPaths.summaryPath, "utf8"));
+
+  assert.match(markdown, /## Issue #11 executable smoke evidence/);
+  assert.match(markdown, /--avery/);
+  assert.equal(summary.status, "ok");
+  assert.equal(summary.scenarios[0].name, "happy-path");
 });

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -6,6 +6,7 @@ import { mkdtemp, readFile } from "node:fs/promises";
 
 import {
   formatIssue11Evidence,
+  parseIssue11EvidenceArgs,
   runIssue11Evidence
 } from "../../src/runtime/issue11-evidence.js";
 
@@ -99,4 +100,31 @@ test("runIssue11Evidence writes markdown and summary artifacts when requested", 
   assert.match(markdown, /--avery/);
   assert.equal(summary.status, "ok");
   assert.equal(summary.scenarios[0].name, "happy-path");
+});
+
+test("parseIssue11EvidenceArgs accepts signature and output directory flags", () => {
+  assert.deepEqual(parseIssue11EvidenceArgs([
+    "--signature",
+    "avery",
+    "--output-dir",
+    "./artifacts/issue11"
+  ]), {
+    signature: "avery",
+    outputDir: "./artifacts/issue11"
+  });
+});
+
+test("parseIssue11EvidenceArgs rejects missing flag values and unknown arguments", () => {
+  assert.throws(
+    () => parseIssue11EvidenceArgs(["--signature"]),
+    /missing value for --signature/
+  );
+  assert.throws(
+    () => parseIssue11EvidenceArgs(["--output-dir", "--signature"]),
+    /missing value for --output-dir/
+  );
+  assert.throws(
+    () => parseIssue11EvidenceArgs(["--bogus"]),
+    /unknown argument: --bogus/
+  );
 });

--- a/test/runtime/issue11-evidence.test.js
+++ b/test/runtime/issue11-evidence.test.js
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 
 import {
   formatIssue11Evidence,
@@ -127,4 +129,18 @@ test("parseIssue11EvidenceArgs rejects missing flag values and unknown arguments
     () => parseIssue11EvidenceArgs(["--bogus"]),
     /unknown argument: --bogus/
   );
+});
+
+test("issue11 evidence CLI exits non-zero for invalid flags", () => {
+  const cliPath = fileURLToPath(
+    new URL("../../src/runtime/issue11-evidence.js", import.meta.url)
+  );
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, "--output-dir", "--signature", "avery"],
+    { encoding: "utf8" }
+  );
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /missing value for --output-dir/);
 });


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: add optional artifact exports to the canonical issue #11 smoke evidence command

## What Changed

- added `--output-dir <dir>` support to `npm run --silent smoke:issue11` so one run can emit `issue11-evidence.md` and `issue11-summary.json`
- kept stdout stable as the paste-ready Markdown packet for issue #11 while returning generated artifact paths to callers
- documented the artifact export flow in `docs/RUNTIME_EXECUTION_HANDOFF.md` and synced the OpenSpec proposal/design/tasks/spec requirement
- added runtime coverage for artifact writing in `test/runtime/issue11-evidence.test.js`

## Why

- QA and automation can already generate one canonical issue #11 evidence packet, but attaching the same run to a PR or local archive still required manual copy/paste from stdout
- optional file exports keep the single smoke path intact while making handoff artifacts reusable across issue comments, PR evidence, and local reruns

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Canonical issue #11 evidence stays on one smoke command | `src/runtime/issue11-evidence.js` still builds the packet from `runDispatchSmokeSuite()` and only adds optional file exports | `src/runtime/issue11-evidence.js`, `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md` |
| QA can reuse one smoke run across issue comments, PRs, and local archives | `--output-dir` emits `issue11-evidence.md` and `issue11-summary.json` without changing stdout | `src/runtime/issue11-evidence.js`, `test/runtime/issue11-evidence.test.js`, `docs/RUNTIME_EXECUTION_HANDOFF.md` |

## QA Plan

### Preconditions

- PATH includes `/opt/homebrew/bin` so `node`, `npm`, and `openspec` resolve
- clean checkout on `codex/p1-11-issue11-evidence-artifacts`

### Steps

1. Run `npm test`.
2. Run `openspec validate --all`.
3. Run `bash scripts/agent_prepush_check.sh --github-user avery-chen`.
4. Run `npm run --silent smoke:issue11 -- --signature agent-indeed --output-dir <tmpdir>` and inspect the generated files.

### Expected Results

- all node tests pass, including the new artifact-export coverage
- OpenSpec validation passes for `agent-dispatch-platform`
- pre-push guard confirms branch prefix, mainline ancestry, and git identity
- the issue #11 smoke command still prints the same Markdown packet to stdout and also writes `issue11-evidence.md` plus `issue11-summary.json`

### Validation Output

- `openspec validate --all`
```text
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `npm test`
```text
> test
> node --test

✔ runtime contract drift guard keeps OpenAPI and contracts aligned (10.152625ms)
✔ healthz and readyz return runtime status (24.058333ms)
✔ POST /v1/tasks persists a task and updates runtime summary (15.279583ms)
✔ POST /v1/tasks rejects requests without a workspace header (2.614125ms)
✔ GET /v1/tasks/:taskId returns the persisted task payload (6.870041ms)
✔ GET /v1/tasks/:taskId returns 404 for unknown ids (3.468583ms)
✔ dispatch vertical slice publishes, matches, bids, verifies, awards, and exposes audit trails (36.366834ms)
✔ candidate shortlist query flags project a canonical snapshot without mutating it (2.950833ms)
✔ invalid signature, reveal without a commit, and failed verification return stable errors (11.381792ms)
✔ unknown routes are logged as 404s (0.846334ms)
✔ GET /v1/bids/:bidId/events rejects bid ids shorter than the published contract (0.812208ms)
✔ bid/proof status routes return 404 when the task-scoped projection does not exist (1.445625ms)
✔ bootstrap smoke command exercises the local runtime bootstrap path (44.48525ms)
✔ loadRuntimeConfig applies defaults for local runtime bootstrap (2.033917ms)
✔ loadRuntimeConfig rejects invalid ports (0.244084ms)
✔ loadRuntimeConfig rejects blank host and service names (0.083167ms)
✔ dispatch smoke CLI emits PASS lines and a machine-readable summary (181.3215ms)
✔ runDispatchSmoke executes the publish to award flow (56.519ms)
✔ runDispatchSmokeSuite executes happy-path and negative smoke scenarios (41.603167ms)
✔ store assigns deterministic ids across the dispatch lifecycle (2.955833ms)
✔ formatIssue11Evidence includes the smoke summary, logs, and signature (0.861584ms)
✔ runIssue11Evidence returns the smoke markdown packet (53.763166ms)
✔ runIssue11Evidence writes markdown and summary artifacts when requested (16.233666ms)
ℹ tests 23
ℹ suites 0
ℹ pass 23
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 334.175334
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/p1-11-issue11-evidence-artifacts' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```
- `npm run --silent smoke:issue11 -- --signature agent-indeed --output-dir <tmpdir>`
```text
stdout begins with:
## Issue #11 executable smoke evidence

- Evidence command: `npm run --silent smoke:issue11 -- --signature agent-indeed`
- Underlying smoke suite: `npm run smoke:dispatch`
- API examples: `docs/BACKEND_API_EXAMPLE_PACKET.md`
- Handoff contract: `docs/RUNTIME_EXECUTION_HANDOFF.md`

generated files:
issue11-evidence.md
issue11-summary.json
```

## Risks and Rollback

- Risk:
  - downstream automation may assume the result object has no `artifactPaths`; the stdout contract is unchanged, but callers reading the JS return shape should tolerate the additive field
- Rollback:
  - revert commit `3eb8a29` or remove the `--output-dir` code path from `src/runtime/issue11-evidence.js` and re-run the listed validations

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
