### PR TITLE
[P1-09] Refresh live issue #11 evidence gate references

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -1,6 +1,6 @@
 # Phase 1 Beta Readiness Gates
 
-Last updated: 2026-03-19
+Last updated: 2026-03-20
 
 This document turns epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`) into a small set of
 reviewable release gates for closed-beta readiness. It complements:
@@ -16,11 +16,11 @@ reviewable release gates for closed-beta readiness. It complements:
 
 | Gate | Status | Ready when | Active dependencies | Evidence to collect |
 | --- | --- | --- | --- | --- |
-| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #11, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PR #133, PR #170, PR #189, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
-| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | issue #115, `docs/RUNTIME_EXECUTION_HANDOFF.md`, PR #191, PR #182, PR #172, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
-| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #11, PR #182, PR #172, `docs/BACKEND_API_EXAMPLE_PACKET.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
+| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #11, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PR #133, merged PR #170, merged PR #189, merged PR #194, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
+| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | `docs/RUNTIME_EXECUTION_HANDOFF.md`, PR #191, merged PR #172, PR #209, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
+| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #11, PR #209, merged PR #172, `docs/BACKEND_API_EXAMPLE_PACKET.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
 | Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | merged PR #127, merged PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | PR #190, PR #174, PR #166, issue #115, issue #11, current `owner:albatross` + `stream/review-burndown` planning sweep | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/ROADMAP.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
+| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | PR #174, PR #199, PR #191, PR #209, issue #11, current `owner:albatross` + `stream/review-burndown` planning sweep | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/ROADMAP.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
 
 ## Gate Details
 
@@ -29,7 +29,7 @@ reviewable release gates for closed-beta readiness. It complements:
 This remains the prerequisite for durable runtime behavior and executable QA checks.
 
 - Verifier terminal vocabulary and award-trace expectations now come from merged PR #83 and merged PR #92.
-- The merged runtime/frontend baseline is on `main` through PR #126 and PR #139; PR #127 merged on 2026-03-17 at 13:54:46Z and PRs #129, #140, and #141 all merged later that day, so the active convergence risk is now keeping the surviving live review queue (`#133`, `#170`, `#189`) synced to the published contract vocabulary instead of reopening older contract snapshots.
+- The merged runtime/frontend baseline is on `main` through PR #126 and PR #139; PR #127 merged on 2026-03-17 at 13:54:46Z and PRs #129, #140, and #141 all merged later that day, so the active convergence risk is now keeping the surviving live review queue (`#133`, merged `#170`, merged `#189`, merged `#194`) synced to the published contract vocabulary instead of reopening older contract snapshots.
 - The dated QA sweep in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` records which runtime routes are actually published on `main`, so reviewers can distinguish proof-enum drift from still-pending read-model routes without treating closed issue #120 as current work.
 - Merged PR #140 is the planning guardrail for the dated blocker ledger; the current doc queue should reuse that merged baseline instead of reopening stale snapshots across long-lived docs.
 
@@ -47,7 +47,7 @@ Required outcome:
 - one reproducible request sequence executes `publish -> match -> commit -> reveal -> verify -> award`
 - results are captured by the canonical signed issue #11 evidence path (`npm run --silent smoke:issue11 -- --signature <agent-name>`) plus the reusable request/response packet in `docs/BACKEND_API_EXAMPLE_PACKET.md`
 
-Reference docs and planning notes are only useful if they map directly to runnable assertions and a stable local command path. PR #191, PR #182, and PR #172 are the current surviving follow-through threads because they keep that one `main` command reviewable across backend, CI, and QA.
+Reference docs and planning notes are only useful if they map directly to runnable assertions and a stable local command path. PR #191 and PR #209 are the surviving open follow-through threads, while merged PR #172 is the reusable QA packet baseline already on `main`.
 
 ### 3. Negative-scenario coverage
 
@@ -86,7 +86,7 @@ At minimum, these must stay in lockstep:
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
 - `docs/RUNTIME_EXECUTION_HANDOFF.md`
-- current planning sweep queries plus runtime delivery threads (`#115`, `#133`, `#170`, `#189`, PR #191, PR #182, PR #172, and the live evidence gate `#11`)
+- current planning sweep queries plus runtime delivery threads (`#133`, PR #174, PR #191, PR #199, PR #209, merged PR #172, and the live evidence gate `#11`)
 
 ## Review Routine
 

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -8,8 +8,8 @@ This document keeps only the stable checkpoint structure and links to the live m
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
 | M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus verify/award contract adoption (planning review-burndown queue, PR #174, PR #133). |
-| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend publishes canonical smoke formatting and evidence (#177, PR #175). |
-| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Formatter-backed smoke pass, QA packet updates, and final issue #11 evidence handoff (#178, PR #172, issue #11). |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend converges the surviving handoff path and QA lands reusable issue #11 artifacts (PR #191, PR #209). |
+| M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Signed rerun from `main`, QA packet reuse, and final issue #11 evidence handoff (issue #11, merged PR #172, PR #209). |
 | M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
 
 ## Metadata hygiene queries
@@ -27,8 +27,8 @@ Sprint pivot dated 2026-03-16 now uses these anchors by default:
 
 - Closed runtime baseline: `#109`, `#110`, `#111`
 - Live planning refresh: `owner:albatross` + `stream/review-burndown` query
-- Live backend formatter handoff: `#177`
-- Live QA smoke handoff: `#178`
+- Live backend handoff: `PR #191`
+- Live QA smoke/export handoff: `PR #209`
 - Final evidence gate: `#11`
 
 ## Review routine

--- a/docs/PHASE1_EPIC_STATUS.md
+++ b/docs/PHASE1_EPIC_STATUS.md
@@ -1,6 +1,6 @@
 # Phase 1 Epic Status
 
-Last updated: 2026-03-19
+Last updated: 2026-03-20
 
 This document is the execution snapshot for epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`).
 It complements `docs/PHASE1_GOALS.md` by mapping epic acceptance criteria to the current post-runtime issues and PR gates.
@@ -14,9 +14,9 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 
 | Epic acceptance area | Current status | Source of truth | Next gate |
 | --- | --- | --- | --- |
-| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, issue #167, PR #174, PR #176, PR #179, PR #133 | Merge the post-runtime planning/reference cleanup, then keep PR #133 aligned to the published contract vocabulary. |
-| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issues #177, #178, and #11 | Publish one canonical smoke evidence format, run the formatter-backed smoke pass, and paste the final evidence back onto issue #11. |
-| Core negative scenarios are covered | Blocked | issue #11, PR #172, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Turn the documented failure cases into reproducible smoke evidence tied to the merged runtime baseline. |
+| OpenSpec/API/contracts stay synchronized | In progress | `openspec/changes/agent-dispatch-platform/`, `src/api/openapi.yaml`, `src/api/contracts.ts`, PR #174, PR #199, PR #133, merged PR #176, merged PR #179, merged PR #194 | Keep the surviving planning docs aligned with the published contract vocabulary and the current issue #11 evidence lane. |
+| End-to-end happy path can be demonstrated | Blocked | `docs/PHASE1_GOALS.md`, `docs/RUNTIME_EXECUTION_HANDOFF.md`, issue #11, PR #191, PR #209, merged PR #172 | Land the remaining backend/evidence follow-through PRs, then paste one signed `smoke:issue11` run from `main` onto issue #11. |
+| Core negative scenarios are covered | Blocked | issue #11, PR #209, merged PR #172, `docs/CLOSED_BETA_SECURITY_READINESS.md`, `docs/ERROR_CODE_RETRY_POLICY.md` | Re-run the canonical issue #11 smoke path from `main` so the documented failure cases are attached to the live runtime baseline instead of scattered PR comments. |
 | Audit events cover key state transitions | In progress | merged runtime baseline from issues #109/#110, `docs/OBSERVABILITY_BASELINE.md`, `docs/MVP_TELEMETRY_HANDOFF.md`, issue #11 | Keep the verify/award/audit follow-through aligned while the final smoke evidence proves the emitted trail. |
 
 ## Delivery Slice Status
@@ -38,11 +38,11 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 
 | Epic step | Active issue / PR | Why it still matters to epic #2 |
 | --- | --- | --- |
-| Post-runtime planning refresh | issue #167, PR #174, PR #176, PR #179 | These threads remove stale references to closed runtime/QA issues and establish one consistent planning baseline for the remaining Phase 1 queue. |
-| Overlapping planning rollups | PR #171, PR #154, PR #165, PR #166, PR #161, PR #153 | These older planning refresh branches should either be folded into PR #179 or closed as superseded so the repo stops carrying conflicting queue snapshots. |
+| Post-runtime planning refresh | PR #174, PR #199, merged PR #176, merged PR #179, merged PR #194 | These threads remove stale references to closed runtime/QA issues and establish one consistent planning baseline for the remaining Phase 1 queue. |
+| Overlapping planning rollups | PR #174, PR #199 | These are the remaining open planning snapshots that still need to converge on the same live issue #11 evidence lane and blocker list. |
 | Verify/award contract adoption | PR #133 | The checklist still needs to describe only the proof fields, error codes, and reason-code vocabulary that are actually published on `main`. |
-| Backend smoke formatter | issue #177 / PR #175 | QA needs one canonical backend-owned evidence block before the final smoke pass can be repeated consistently. |
-| QA packet and smoke evidence | PR #172, issue #178, issue #11 | The remaining QA work is to reuse the canonical formatter output, run the bounded smoke pass, and post the exact result on issue #11. |
+| Backend handoff convergence | PR #191 | Backend still needs one surviving mainline handoff path so the runnable smoke evidence stays anchored to the current runtime contract. |
+| QA packet and smoke evidence | PR #209, merged PR #172, issue #11 | The remaining QA work is to reuse the merged packet baseline, land reusable artifact exports, and post the exact signed result on issue #11. |
 
 ### Remaining blocked slices
 
@@ -54,19 +54,19 @@ Deliver a closed-beta MVP for the agent dispatch loop:
 
 | Order | Thread | Why now | Expected result |
 | --- | --- | --- | --- |
-| 1 | PR #174 `docs: refresh runtime handoff baseline` | Smallest live planning fix with direct stale-reference feedback. | Runtime handoff docs stop treating closed issue #120 as active. |
-| 2 | PR #176 `docs: codify planning reference rules` | Makes the contributor/reference rules match the post-runtime review workflow. | Future planning PRs point at live queries and same-day sweep threads instead of closed issues. |
-| 3 | PR #179 `[P1-167] Refresh planning docs to post-runtime baseline` | Preferred surviving rollup for issue #167 after the two smaller doc fixes land. | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, and this file all describe the same post-runtime queue. |
-| 4 | PRs #171, #154, #165, #166, #161, #153 | Overlapping planning branches should no longer stay open as competing snapshots. | Close, fold, or restack them behind the merged #167 rollup. |
-| 5 | PR #133, issue #177, issue #178, issue #11 | Contract wording and final smoke evidence remain after planning drift is removed. | One canonical smoke evidence path feeds the final QA sign-off thread. |
+| 1 | PR #174 `docs: refresh runtime handoff baseline` | Smallest remaining planning fix touching the canonical runtime evidence contract. | Runtime handoff docs stay aligned with the live issue #11 lane. |
+| 2 | PR #199 `[P1-09] Refresh planning anchors to issue #11 evidence lane` | Keeps the Phase 1 planning snapshots consistent with merged PR #194 and the live QA queue. | `docs/ROADMAP.md`, `docs/PHASE1_GOALS.md`, `docs/PHASE1_EPIC_STATUS.md`, and checkpoint guidance stop pointing at closed formatter issues. |
+| 3 | PR #133 `[P1-131] Add verify-award adoption checklist` | Remaining contract checklist still needs to match the published OpenAPI/TypeScript vocabulary. | Contract wording risk shrinks before final beta gating. |
+| 4 | PR #191 `[P1-43] Converge issue #11 backend handoff on one mainline path` | Backend handoff still has to settle on one surviving evidence path on `main`. | Runtime happy-path proof is easier to rerun and cite. |
+| 5 | PR #209 `[P1-09] Export issue #11 evidence artifacts`, issue #11 | QA still needs reusable exported artifacts plus one signed rerun from `main`. | One canonical smoke evidence path feeds the final QA sign-off thread. |
 
 ## Checkpoint Rollup
 
 | Checkpoint | Epic relevance | Current note |
 | --- | --- | --- |
-| M1 | Post-runtime planning/reference cleanup | The immediate M1 gate is landing the #167 planning refresh plus PR #174 and PR #176 without leaving older duplicate status threads behind. |
-| M2 | Runtime evidence formatting and reuse | Backend still needs the canonical smoke formatter path from issue #177 / PR #175 before QA can reuse it cleanly. |
-| M3 | Verify, audit, and executable QA | PR #172, issue #178, and issue #11 are the remaining proof points for runnable smoke evidence on top of the merged runtime baseline. |
+| M1 | Post-runtime planning/reference cleanup | The immediate M1 gate is landing PR #174 and PR #199 so the surviving planning docs all point at the same live issue #11 evidence lane. |
+| M2 | Runtime evidence formatting and reuse | Merged PR #172 gives QA one reusable packet baseline; PR #191 and PR #209 still need to finish the surviving handoff/export path on top of `main`. |
+| M3 | Verify, audit, and executable QA | Issue #11 remains the live proof point once the open backend/evidence follow-through PRs land and QA can paste a signed rerun from `main`. |
 | M4 | Beta readiness sign-off | Issue #11 final E2E evidence and audit/security verification remain required. |
 
 ## Epic Exit Checklist


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #11
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/docs`
- Scope: refresh stale Phase 1 planning snapshots so the live issue #11 evidence lane points at the current open PR queue instead of closed formatter-era threads

## What Changed

- updated `docs/PHASE1_BETA_READINESS_GATES.md` to replace closed issue/PR dependencies with the live issue #11 evidence lane (`PR #191`, `PR #199`, `PR #209`, merged `PR #172`/`PR #194`)
- updated `docs/PHASE1_EPIC_STATUS.md` so the acceptance snapshot, active follow-through slices, merge sequence, and checkpoint notes stop referencing closed issues `#177` / `#178` and instead describe the current backend + QA handoff queue
- updated `docs/PHASE1_CHECKPOINT_BOARD.md` so M2/M3 review focus and the runtime pivot anchors now point at the surviving backend/QA evidence handoffs

## Why

- Avery's QA lane is still using issue #11 as the only live executable evidence gate, but these planning snapshots were still treating closed formatter-era issues and PRs as active blockers.
- That drift makes checkpoint reviews and beta-readiness gate reviews cite the wrong follow-through threads even though the open queue has moved to `PR #191`, `PR #199`, and `PR #209`.

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Phase 1 planning snapshots should stop listing closed formatter-era issues as active runtime evidence blockers. | Replaced closed `#115`, `#177`, `#178`, and `PR #182` references in the beta-readiness and epic status rollups with the current issue #11 evidence queue. | `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/PHASE1_EPIC_STATUS.md` |
| Checkpoint guidance should point reviewers at the surviving backend and QA evidence handoffs. | Updated the M2/M3 review focus and runtime pivot anchors to use `PR #191`, `PR #209`, merged `PR #172`, and issue #11. | `docs/PHASE1_CHECKPOINT_BOARD.md` |

## QA Plan

### Preconditions

- Use current `origin/main` as the branch baseline.
- Have `node` and `openspec` available from `/opt/homebrew/bin`.

### Steps

1. Run `git diff --check`.
2. Run `PATH=/opt/homebrew/bin:$PATH openspec validate --all`.
3. Run `bash scripts/agent_prepush_check.sh --github-user avery-chen`.

### Expected Results

- The edited planning docs no longer present closed formatter-era issues as live blockers for issue #11 evidence.
- OpenSpec validation passes.
- Pre-push guard confirms branch naming, ancestry, and Avery's isolated git identity.

### Validation Output

- `git diff --check`
```text
(no output)
```
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `bash scripts/agent_prepush_check.sh --github-user avery-chen`
```text
[ok] Branch 'codex/p1-11-live-evidence-gate-refresh' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (avery-chen).
[ok] git user.email matches expected account (avery-chen@users.noreply.github.com).

Pre-push guard passed.
```

## Risks and Rollback

- Risk:
  - These planning snapshots still cite live PR numbers, so they can drift again if the runtime handoff queue changes.
- Rollback:
  - Revert commit `ade09ea` to restore the prior checkpoint/epic/beta-gate references.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
