### PR TITLE
docs: sync onboarding upload gate tracking

### DIFF
--- a/docs/PHASE1_BETA_READINESS_GATES.md
+++ b/docs/PHASE1_BETA_READINESS_GATES.md
@@ -1,6 +1,6 @@
 # Phase 1 Beta Readiness Gates
 
-Last updated: 2026-03-19
+Last updated: 2026-03-20
 
 This document turns epic #2 (`[Phase 1 Epic] Agent Dispatch Foundation MVP`) into a small set of
 reviewable release gates for closed-beta readiness. It complements:
@@ -16,11 +16,11 @@ reviewable release gates for closed-beta readiness. It complements:
 
 | Gate | Status | Ready when | Active dependencies | Evidence to collect |
 | --- | --- | --- | --- | --- |
-| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #11, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PR #133, PR #170, PR #189, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
-| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation. | issue #115, `docs/RUNTIME_EXECUTION_HANDOFF.md`, PR #191, PR #182, PR #172, issue #11 | Service run command, executable smoke/E2E output, linked request/response evidence |
-| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #11, PR #182, PR #172, `docs/BACKEND_API_EXAMPLE_PACKET.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
+| Contract convergence | In progress | Active runtime and handoff PRs stay inside the merged OpenSpec/OpenAPI/TypeScript baseline and carry reviewable validation evidence in the PR body. | issue #11, `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, PR #133, PR #170, PR #189, PR #204, merged PR #83, merged PR #92, merged PR #126, merged PR #127, merged PR #129, merged PR #139, merged PR #140, merged PR #141 | `openspec validate --all`, `npm run check:contract-drift`, runtime/OpenAPI diff review, synced `src/api/openapi.yaml` + `src/api/contracts.ts`, pasted validation output in PR templates |
+| Runtime happy-path execution | Blocked | One runnable `publish -> match -> commit -> reveal -> verify -> award` flow can be executed against a local service without manual interpretation, and the onboarding upload entrypoint is reviewable with the same evidence discipline. | issue #115, `docs/RUNTIME_EXECUTION_HANDOFF.md`, PR #191, PR #182, PR #172, PR #204, issue #11, issue #206 | Service run command, executable smoke/E2E output, linked request/response evidence |
+| Negative-scenario coverage | Blocked | QA can execute core failures (`invalid signature`, onboarding payload rejection, `reveal without commit`, `proof FAIL`, `award blocked`) with stable expected outcomes. | issue #11, PR #182, PR #172, PR #204, issue #206, `docs/BACKEND_API_EXAMPLE_PACKET.md`, `docs/ERROR_CODE_RETRY_POLICY.md`, `docs/CLOSED_BETA_SECURITY_READINESS.md` | Runnable assertions, expected error/result matrix, regression evidence |
 | Audit evidence trail | In progress | Audit outputs expose key lifecycle transitions and award/proof context for operator review and beta sign-off. | merged PR #127, merged PR #92, `docs/MVP_TELEMETRY_HANDOFF.md`, `docs/OBSERVABILITY_BASELINE.md` | Audit event names, award trace fields, telemetry handoff checklist |
-| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | PR #190, PR #174, PR #166, issue #115, issue #11, current `owner:albatross` + `stream/review-burndown` planning sweep | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/ROADMAP.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
+| Execution + handoff hygiene | In progress | Roadmap/goals/epic/checkpoint docs and the live runtime queue all describe the same blockers and next actions. | PR #190, PR #174, PR #166, PR #204, issue #115, issue #11, issue #205, issue #206, current `owner:albatross` + `stream/review-burndown` planning sweep | `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_EPIC_STATUS.md`, `docs/ROADMAP.md`, current planning sweep query, issue #11 evidence thread, milestone/label queries stay aligned |
 
 ## Gate Details
 
@@ -30,6 +30,7 @@ This remains the prerequisite for durable runtime behavior and executable QA che
 
 - Verifier terminal vocabulary and award-trace expectations now come from merged PR #83 and merged PR #92.
 - The merged runtime/frontend baseline is on `main` through PR #126 and PR #139; PR #127 merged on 2026-03-17 at 13:54:46Z and PRs #129, #140, and #141 all merged later that day, so the active convergence risk is now keeping the surviving live review queue (`#133`, `#170`, `#189`) synced to the published contract vocabulary instead of reopening older contract snapshots.
+- PR #204 adds the executable `POST /v1/agents/bundles` runtime path on top of that merged baseline, so onboarding-upload review now belongs in the same contract gate instead of living as an isolated follow-up.
 - The dated QA sweep in `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` records which runtime routes are actually published on `main`, so reviewers can distinguish proof-enum drift from still-pending read-model routes without treating closed issue #120 as current work.
 - Merged PR #140 is the planning guardrail for the dated blocker ledger; the current doc queue should reuse that merged baseline instead of reopening stale snapshots across long-lived docs.
 
@@ -41,10 +42,13 @@ Happy-path readiness is runtime-first, not docs-first.
 
 While this gate remains blocked until the runnable flow exists, the runtime threads do not have to wait for every historical contract branch. Use `docs/RUNTIME_CUTLINE_2026-03-16.md` plus `docs/RUNTIME_EXECUTION_HANDOFF.md` and the live issue #11 evidence thread to separate true blockers from additive-safe follow-ups.
 
+The same rule now applies to onboarding upload follow-through: PR #204 is the executable runtime slice, issue #205 is the post-merge frontend surface sync, and issue #206 is the QA publication thread that should carry smoke evidence once the route lands on `main`.
+
 Required outcome:
 
 - a local service starts from one documented command
 - one reproducible request sequence executes `publish -> match -> commit -> reveal -> verify -> award`
+- one reproducible onboarding upload sequence executes `POST /v1/agents/bundles` with create/replay/rejection evidence once PR #204 merges
 - results are captured by the canonical signed issue #11 evidence path (`npm run --silent smoke:issue11 -- --signature <agent-name>`) plus the reusable request/response packet in `docs/BACKEND_API_EXAMPLE_PACKET.md`
 
 Reference docs and planning notes are only useful if they map directly to runnable assertions and a stable local command path. PR #191, PR #182, and PR #172 are the current surviving follow-through threads because they keep that one `main` command reviewable across backend, CI, and QA.
@@ -57,6 +61,7 @@ Minimum scenarios to keep visible:
 
 - reveal submitted without a valid prior commit
 - signature-invalid or malformed onboarding/task payload path
+- onboarding upload replay and payload-hash-mismatch rejection once the executable route from PR #204 lands
 - proof verification returns `FAIL`
 - award attempt blocked before prerequisite verification is complete
 
@@ -86,13 +91,14 @@ At minimum, these must stay in lockstep:
 - `docs/PHASE1_GOALS.md`
 - `docs/ROADMAP.md`
 - `docs/RUNTIME_EXECUTION_HANDOFF.md`
-- current planning sweep queries plus runtime delivery threads (`#115`, `#133`, `#170`, `#189`, PR #191, PR #182, PR #172, and the live evidence gate `#11`)
+- current planning sweep queries plus runtime delivery threads (`#115`, `#133`, `#170`, `#189`, PR #191, PR #182, PR #172, PR #204, issue #205, issue #206, and the live evidence gate `#11`)
 
 ## Review Routine
 
 Review these gates whenever one of the following happens:
 
 - a Phase 1 contract/runtime PR merges, reopens, or is closed as superseded
+- the onboarding upload queue changes state (PR #204 or issues #205/#206)
 - a contract enum or error-code changes
 - QA smoke/E2E execution scope changes
 - epic #2 checklist changes

--- a/docs/PHASE1_CHECKPOINT_BOARD.md
+++ b/docs/PHASE1_CHECKPOINT_BOARD.md
@@ -7,8 +7,8 @@ This document keeps only the stable checkpoint structure and links to the live m
 
 | Checkpoint | Target date | Owners | Live issues | Live PRs | Review focus |
 | --- | --- | --- | --- | --- | --- |
-| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus verify/award contract adoption (planning review-burndown queue, PR #174, PR #133). |
-| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend publishes canonical smoke formatting and evidence (#177, PR #175). |
+| M1 Contract Freeze + Upload | 2026-03-20 | albatross-dev-agent + kestrel | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M1+Contract+Freeze+%2B+Upload%22) | Post-runtime planning/reference cleanup plus onboarding upload review/evidence and verify/award contract adoption (planning review-burndown queue, PR #204, issues #205/#206, PR #174, PR #133). |
+| M2 Matching + Bidding Baseline | 2026-03-27 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M2+Matching+%2B+Bidding+Baseline%22) | Hold the merged runtime slice steady while backend publishes canonical smoke formatting/evidence and frontend absorbs the onboarding upload baseline after PR #204 merges (#177, PR #175, issue #205). |
 | M3 Verify + Agent Flow | 2026-04-03 | kestrel + lanzhou-fe-agent | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M3+Verify+%2B+Agent+Flow%22) | Formatter-backed smoke pass, QA packet updates, and final issue #11 evidence handoff (#178, PR #172, issue #11). |
 | M4 Audit + Beta Readiness | 2026-04-10 | albatross-dev-agent + kestrel + QA | [Milestone issues](https://github.com/jckhang/agent-indeed/issues?q=is%3Aissue+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | [Milestone PRs](https://github.com/jckhang/agent-indeed/pulls?q=is%3Apr+milestone%3A%22M4+Audit+%2B+Beta+Readiness%22) | Final E2E evidence, audit trail sign-off, and security readiness closure (issue #11). |
 
@@ -26,6 +26,7 @@ Use these GitHub queries before a checkpoint comment so milestone views and runt
 Sprint pivot dated 2026-03-16 now uses these anchors by default:
 
 - Closed runtime baseline: `#109`, `#110`, `#111`
+- Live onboarding upload queue: PR `#204`, issue `#205`, issue `#206`
 - Live planning refresh: `owner:albatross` + `stream/review-burndown` query
 - Live backend formatter handoff: `#177`
 - Live QA smoke handoff: `#178`

--- a/docs/PHASE1_GOALS.md
+++ b/docs/PHASE1_GOALS.md
@@ -25,6 +25,7 @@ Ship the first usable agent dispatch loop for closed beta:
 - Active follow-through threads for the pivot:
   - #167 planning-doc refresh to the post-runtime baseline
   - issue #11 as the live smoke evidence umbrella for the canonical handoff command in `docs/RUNTIME_EXECUTION_HANDOFF.md`
+  - PR #204 plus follow-up issues #205 and #206 as the active onboarding upload queue for the M1 "Contract Freeze + Upload" checkpoint
   - new runtime/QA follow-up issues only when fresh drift appears beyond the closed `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md` snapshot
 - Planning-only follow-ups (#106, #107, #108) were closed to keep sprint bandwidth on runtime delivery.
 - QA prewrite-only tracks (#87, PR #84, PR #104) remain superseded by the executable evidence path on issue #11.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Agent Indeed Roadmap
 
-Last updated: 2026-03-19
+Last updated: 2026-03-20
 
 ## Product North Star
 
@@ -65,6 +65,7 @@ Focus:
 - Treat issues #109, #110, and #111 as closed runtime baseline work.
 - Clear the planning/reference review blockers on PR #174 and PR #176 so post-runtime docs stop pointing at closed issues.
 - Land one surviving planning rollup for issue #167; use PR #179 as the preferred branch to absorb the refresh and close or supersede overlapping older planning PRs (#171, #154, #165, #166, #161, #153).
+- Keep the onboarding upload queue visible in the M1 checkpoint: PR #204 is the executable runtime slice, issue #205 is the frontend baseline follow-through after merge, and issue #206 is the QA evidence publication follow-through.
 - Keep PR #133 aligned to the published verify/award contract vocabulary after the planning refresh settles.
 - Move QA evidence forward through issue #11 and the canonical runtime handoff docs instead of reopening closed issue #120 or other merged formatter follow-ups.
 
@@ -105,7 +106,7 @@ Scope:
 
 - M0 (Week 0): contribution workflow + tech stack baseline + P0 issue cleanup.
 - M0.5 (Week 0): architecture gap assessment + FE/BE track plan + hiring gap plan.
-- M1 (2026-03-20): close post-runtime planning/reference drift (#167, PR #174, PR #176) and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
+- M1 (2026-03-20): close post-runtime planning/reference drift (#167, PR #174, PR #176), keep the onboarding upload review/evidence queue explicit (PR #204, issues #205/#206), and keep verify/award follow-through on PR #133 tied to the merged contract baseline.
 - M2 (2026-03-27): hold the merged publish/match/commit/reveal/verify/award slice steady while backend and QA publish one canonical smoke evidence path through issue #11 and `docs/RUNTIME_EXECUTION_HANDOFF.md`.
 - M3 (2026-04-03): stabilize verify/award/audit evidence and run executable smoke checks against the merged runtime baseline.
 - M4 (2026-04-10): complete E2E coverage + audit/reputation hardening + security/compliance readiness review.

--- a/openspec/changes/agent-dispatch-platform/proposal.md
+++ b/openspec/changes/agent-dispatch-platform/proposal.md
@@ -22,6 +22,7 @@
 - 增补 runtime 执行 handoff 契约，统一本地服务命令、smoke 命令与 issue #11 证据回写要求。
 - 增补 merge-evidence sweep 回写规则，要求当前 `owner:albatross` + `stream/review-burndown` 查询返回的 planning sweep issue 承接同日队列巡检，epic #2 保留跨 lane checkpoint 汇总。
 - 新增 backend API example packet，把 merged `smoke:dispatch` happy/negative path 产物整理成 issue #11 可直接引用的请求响应样例。
+- 增补 beta-readiness / checkpoint 文档中的 onboarding upload gate 锚点，确保 PR #204 与后续 issue #205/#206 在 epic #2 的里程碑评审里保持可见。
 
 ## Capabilities
 
@@ -39,6 +40,7 @@
 - 规划类 repo 文档改为稳定索引与 GitHub 查询入口，避免在仓库内复制高频变化的 issue / PR 状态。
 - 新增 `docs/MERGE_TRAIN_PLAYBOOK.md`，作为规划负责人推进 clean merge queue、dirty queue follow-up、validation evidence 审核与 blocker issue 升级的操作基线。
 - 新增 `docs/RUNTIME_EXECUTION_HANDOFF.md`，作为 runtime sprint 中 backend/QA/planning 的统一命令与证据交接基线。
+- 新增 onboarding upload gate 对应的 beta-readiness / checkpoint 锚点，避免 M1/M2 评审遗漏 PR #204 与 issue #205/#206。
 - 明确当前 planning sweep issue 与 epic #2 的 GitHub 评论分工，并要求每次 checkpoint sweep 只保留一个 mergeable planning-sync PR，减少 review-burndown 期间重复回贴和状态漂移。
 - 将影响后续模块：Registry、Matching、Bidding、PoMW Verifier、Audit/Reputation、Settlement。
 - 该变更现阶段除了规格定义，也显式承接运行时落地任务，并要求以可执行实现和测试证据作为关闭实现 issue 的依据。

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -53,3 +53,4 @@
 - [x] 5.12 刷新 checkpoint / merge-train 模板，移除对已关闭 issue #146 的活跃 blocker 依赖，改用 live planning sweep 查询与 issue #11 证据线程。
 - [x] 5.13 补充 issue #11 可直接复用的最小 SDK 片段与 smoke 标识符回写，确保 QA/beta consumer 不必从 PR 评论中手抄 `taskId` / `proofId` / `policyTraceId` / reason-code 证据。
 - [x] 5.14 为 issue #186 收敛 planning sweep 规则：同一 checkpoint 只保留一个 mergeable planning-sync PR，并把 superseded PR 的 merge/close rationale 回写到 GitHub 线程。
+- [x] 5.14.a 刷新 beta-readiness / checkpoint 里程碑锚点，把 PR #204 与 issue #205/#206 纳入 epic #2 的 onboarding upload gate 跟踪，避免 M1/M2 评审遗漏该队列。


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #2
- Department label (pick one): `dept/planning`
- Type label (pick one): `type/docs`
- Scope: sync onboarding upload gate tracking across the Phase 1 beta-readiness/checkpoint docs

## What Changed

- updated `docs/PHASE1_BETA_READINESS_GATES.md` so PR #204 plus issues #205/#206 are explicit dependencies for contract, runtime, negative-path, and handoff gates
- refreshed `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_GOALS.md`, and `docs/ROADMAP.md` so the M1/M2 checkpoint language keeps the onboarding upload queue visible
- updated `openspec/changes/agent-dispatch-platform/proposal.md` and `openspec/changes/agent-dispatch-platform/tasks.md` so the active OpenSpec change records this planning follow-through

## Why

- epic #2 is still the open albatross-owned planning thread, and the onboarding upload work now spans one runtime PR plus frontend/QA follow-up issues
- without a stable gate/checkpoint reference, M1/M2 reviews can miss that queue or treat it as separate from the existing beta-readiness handoff

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Phase 1 planning docs keep the onboarding upload queue visible in milestone and beta-readiness review | Adds PR #204 and issues #205/#206 to the gate summary, gate details, roadmap focus, and checkpoint review focus | `docs/PHASE1_BETA_READINESS_GATES.md`, `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_GOALS.md`, `docs/ROADMAP.md` |
| OpenSpec artifacts stay synced with planning-scope follow-through | Records the onboarding gate-tracking slice in the active proposal/tasks artifacts | `openspec/changes/agent-dispatch-platform/proposal.md`, `openspec/changes/agent-dispatch-platform/tasks.md` |

## QA Plan

### Preconditions

- Repo is on `origin/main` plus this branch only.
- Reviewer compares milestone/gate references against the current open GitHub onboarding queue (`PR #204`, `issue #205`, `issue #206`).

### Steps

1. Open `docs/PHASE1_BETA_READINESS_GATES.md` and confirm the onboarding queue appears in the gate summary plus gate details.
2. Open `docs/PHASE1_CHECKPOINT_BOARD.md`, `docs/PHASE1_GOALS.md`, and `docs/ROADMAP.md` and confirm M1/M2 references call out the same onboarding queue.
3. Open the OpenSpec proposal/tasks files and confirm the planning follow-through is recorded there too.

### Expected Results

- The same onboarding queue is visible across gate, checkpoint, goals, roadmap, and OpenSpec artifacts.
- No document claims PR #204 is already merged; it is treated as an active dependency/follow-through.
- OpenSpec validation passes.

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
```text
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```
- `git diff --check`
```text
```
- `bash scripts/agent_prepush_check.sh --github-user albatross-dev-agent`
```text
[ok] Branch 'codex/issue-2-onboarding-gate-sync' uses codex/ prefix.
[ok] Fetching origin for latest baseline...
[ok] Branch contains origin/main (rebased or merged baseline is current).
[ok] git user.name matches expected account (albatross-dev-agent).
[ok] git user.email matches expected account (albatross-dev-agent@users.noreply.github.com).

Pre-push guard passed.
```
- `npm test`
```text
not run: docs/OpenSpec-only planning change
```
- `npm run check:contract-drift`
```text
not run: no API/runtime contract files changed
```

## Risks and Rollback

- Risk:
  - planning docs could drift again if the onboarding queue changes and the stable checkpoint/gate references are not refreshed in the same review window
- Rollback:
  - revert commit `470f795` to restore the prior gate/checkpoint wording

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
