### PR TITLE
[Week 2026-03-19] Guard onboarding route in contract drift

### DIFF
--- a/docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md
+++ b/docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md
@@ -23,7 +23,8 @@ Use `npm run check:contract-drift` when:
 
 - `src/api/openapi.yaml` and `src/api/contracts.ts` disagree on `ProofVerificationReasonCode`
 - `src/api/openapi.yaml` and `src/api/contracts.ts` disagree on `ProofVerifyErrorCode`
-- a required published runtime route disappears from OpenAPI
+- a required published runtime route disappears from OpenAPI, including the onboarding upload entry
+  point at `/v1/agents/bundles`
 
 The JSON output includes `src/api/openapi.yaml` line anchors for every required route plus
 OpenAPI/TypeScript anchors for both proof-verification enums, so review comments can cite the exact
@@ -41,6 +42,7 @@ Published runtime routes confirmed by the guard:
 - `/healthz` — `src/api/openapi.yaml:20`
 - `/readyz` — `src/api/openapi.yaml:33`
 - `/v1/runtime/summary` — `src/api/openapi.yaml:46`
+- `/v1/agents/bundles` — `src/api/openapi.yaml:59`
 - `/v1/tasks/{taskId}` — `src/api/openapi.yaml:307`
 - `/v1/tasks/{taskId}/audit-events` — `src/api/openapi.yaml:331`
 - `/v1/tasks/{taskId}/candidates` — `src/api/openapi.yaml:355`

--- a/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
+++ b/openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md
@@ -256,6 +256,7 @@
 - **THEN** 仓库提供唯一的签名命令 `npm run --silent smoke:issue11 -- --signature <agent-name>`
 - **AND** 该命令复用 merged dispatch smoke baseline，而不是引入第二条并行 smoke 路径
 - **AND** 输出包含可直接粘贴的 Markdown 证据块、底层 smoke 命令、稳定 task/bid/proof/policy/audit 标识，以及指向 `docs/BACKEND_API_EXAMPLE_PACKET.md` 与 `docs/RUNTIME_EXECUTION_HANDOFF.md` 的 handoff 锚点
+- **AND** `npm run check:contract-drift` 继续把 `/v1/agents/bundles` 视为必需的已发布路由，便于 QA 在同一轮 issue #11 / onboarding evidence 回贴中确认上传入口仍然存在
 
 #### Scenario: Runtime storage abstractions cover core lifecycle entities
 - **WHEN** 本地 control-plane 初始化存储层

--- a/openspec/changes/agent-dispatch-platform/tasks.md
+++ b/openspec/changes/agent-dispatch-platform/tasks.md
@@ -41,6 +41,7 @@
 - [x] 5.2 打通可执行的 MVP 垂直路径（issue #110）：`publish -> match -> commit -> reveal -> verify -> award`，并持久化关键状态转移。
 - [x] 5.3 将 smoke/E2E 文档矩阵转为可执行校验（issue #111），并把验证证据回写 issue #11。
 - [x] 5.3.a 增加 QA contract-drift 回归校验（issue #120），自动比对 OpenAPI / TypeScript proof reason-code 与当前 runtime 路由基线，减少 review 期间的手工枚举漂移。
+- [x] 5.3.b 将 `/v1/agents/bundles` 纳入 QA contract-drift 发布路由基线，确保 onboarding 入口的 `main` 可见性可以和 issue #11 证据线程一起回放。
 - [x] 5.4 输出前端 runtime 集成 tranche 与本地 runbook（issue #136），串联 manager publish / shortlist / award-readiness 与 agent commit / reveal / status-refresh 路径。
 - [x] 5.5 收敛前端 runtime 文档队列（issue #145），把 wiring target、fixture pack 与 demo payload pack 合并进单一 mainline handoff。
 - [x] 5.6 输出 `docs/RUNTIME_EXECUTION_HANDOFF.md`，统一 runtime sprint 的本地命令契约、证据包与 issue #11 回写规则。

--- a/scripts/check-runtime-contract-drift.js
+++ b/scripts/check-runtime-contract-drift.js
@@ -13,6 +13,7 @@ const REQUIRED_RUNTIME_ROUTES = [
   "/healthz",
   "/readyz",
   "/v1/runtime/summary",
+  "/v1/agents/bundles",
   "/v1/tasks/{taskId}",
   "/v1/tasks/{taskId}/audit-events",
   "/v1/tasks/{taskId}/candidates",

--- a/test/api/runtime-contract-drift.test.js
+++ b/test/api/runtime-contract-drift.test.js
@@ -13,6 +13,7 @@ test("runtime contract drift guard keeps OpenAPI and contracts aligned", () => {
   assert.doesNotThrow(() => assertNoDrift(snapshot));
   assert.deepEqual(snapshot.runtimeRoutes.published, REQUIRED_RUNTIME_ROUTES);
   assert.deepEqual(Object.keys(snapshot.runtimeRoutes.anchors), REQUIRED_RUNTIME_ROUTES);
+  assert.equal(snapshot.runtimeRoutes.anchors["/v1/agents/bundles"], "src/api/openapi.yaml:59");
   assert.match(
     snapshot.enums.proofVerificationReasonCode.openapiAnchor,
     /^src\/api\/openapi\.yaml:\d+$/


### PR DESCRIPTION
## PR Metadata

- Linked issue(s): refs #206
- Department label (pick one): `dept/qa`
- Type label (pick one): `type/test`
- Scope: keep the QA contract-drift guard aligned with the published onboarding upload route

## What Changed

- add `/v1/agents/bundles` to the required published runtime routes in `scripts/check-runtime-contract-drift.js`
- pin the onboarding upload route anchor in `test/api/runtime-contract-drift.test.js`
- refresh the QA drift sweep doc and OpenSpec artifacts so issue #11 / onboarding evidence checks reference the same route baseline

## Why

- issue #206 explicitly asks QA to confirm `/v1/agents/bundles` still appears in the published route set on `main`
- the drift guard previously skipped that onboarding route, so reviewers could not use the canonical JSON output as evidence for the upload entry point

## Acceptance Criteria Mapping

| Acceptance criterion | How this PR satisfies it | Evidence |
| --- | --- | --- |
| Confirm `npm run check:contract-drift` still reports `/v1/agents/bundles` present in the published route set. | Adds `/v1/agents/bundles` to the required route baseline and locks its OpenAPI anchor in test coverage. | `scripts/check-runtime-contract-drift.js`, `test/api/runtime-contract-drift.test.js`, `npm run check:contract-drift` output |
| Keep QA/onboarding evidence guidance synchronized with the published contract baseline. | Updates the dated QA sweep doc plus OpenSpec task/spec notes to call out the onboarding upload route in the same evidence lane. | `docs/QA_CONTRACT_DRIFT_SWEEP_2026-03-18.md`, `openspec/changes/agent-dispatch-platform/tasks.md`, `openspec/changes/agent-dispatch-platform/specs/task-marketplace-bidding-powm/spec.md` |

## QA Plan

### Preconditions

- Use current `main` as the branch base.
- Ensure `/opt/homebrew/bin` is on `PATH` so `node`, `npm`, and `openspec` resolve in this worktree.

### Steps

1. Run `npm test`.
2. Run `npm run check:contract-drift`.
3. Run `openspec validate --all`.

### Expected Results

- the Node test suite passes
- contract-drift output lists `/v1/agents/bundles` in `runtimeRoutes.published`
- OpenSpec validation passes with no failures

### Validation Output

- Paste the exact command output for every validation step you ran. If a step was not run, replace it with `not run: <reason>`.
- `openspec validate --all`
- `npm test`
- `npm run check:contract-drift`

```text
$ openspec validate --all
- Validating...
✓ change/agent-dispatch-platform
Totals: 1 passed, 0 failed (1 items)
```

```text
$ npm test
> test
> node --test
...
✔ formatIssue11Evidence includes the smoke summary, logs, and signature
✔ runIssue11Evidence returns the smoke markdown packet
ℹ pass 22
ℹ fail 0
```

```text
$ npm run check:contract-drift
> check:contract-drift
> node scripts/check-runtime-contract-drift.js --assert

runtimeRoutes.published includes `/v1/agents/bundles`
runtimeRoutes.anchors["/v1/agents/bundles"] = "src/api/openapi.yaml:59"
missingRequired = []
```

## Risks and Rollback

- Risk:
  - QA guard now fails if `/v1/agents/bundles` disappears from the published OpenAPI route set; follow-on PRs that intentionally reshape onboarding routes must update the draft and this guard together.
- Rollback:
  - Revert commit `462663e` or remove `/v1/agents/bundles` from `REQUIRED_RUNTIME_ROUTES` and revert the matching doc/test updates.

## Checklist

- [x] Exactly one department label is set (`dept/*`)
- [x] Exactly one type label is set (`type/*`)
- [x] OpenSpec/API/contracts/docs are synced if scope requires
- [x] Acceptance criteria mapping is complete
- [x] QA steps are reproducible and include expected results
- [x] PR comments/review replies are signed with `--<agent-name>`
